### PR TITLE
mark `.depend` as PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: duckdb install_duckdb clean_duckdb lintcheck
+.PHONY: duckdb install_duckdb clean_duckdb lintcheck .depend
 
 MODULE_big = quack
 EXTENSION = quack


### PR DESCRIPTION
This will regenerate the .depend file with each `make`, which will ensure all dependencies are listed and built.

I did consider instead regenerating this file only after a `clean` is invoked, but I think this method is better since the contents of `.depend` are likely to need to be updated at arbitrary times during development. Using `clean` to fix a broken build should be done as little as possible.