### PR TITLE
Simple GUC variable for duckdb cloud secret

### DIFF
--- a/include/quack/quack.h
+++ b/include/quack/quack.h
@@ -2,6 +2,7 @@
 
 // quack.c
 extern int quack_max_threads_per_query;
+extern char *quack_secret;
 extern "C" void _PG_init(void);
 
 // quack_hooks.c

--- a/include/quack/quack_utils.hpp
+++ b/include/quack/quack_utils.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <sstream>
+
+#include <cstdio>
+#include <cstdarg>
+#include <cstring>
+
+namespace quack {
+
+inline std::vector<std::string>
+tokenizeString(char *str, const char delimiter) {
+	std::vector<std::string> v;
+	std::stringstream ss(str); // Turn the string into a stream.
+	std::string tok;
+	while (getline(ss, tok, delimiter)) {
+		v.push_back(tok);
+	}
+	return v;
+};
+
+} // namespace quack

--- a/src/quack.cpp
+++ b/src/quack.cpp
@@ -5,10 +5,12 @@ extern "C" {
 
 #include "quack/quack.h"
 #include "quack/quack_node.hpp"
+#include "quack/quack_utils.hpp"
 
 static void quack_init_guc(void);
 
 int quack_max_threads_per_query = 1;
+char *quack_secret = nullptr;
 
 extern "C" {
 PG_MODULE_MAGIC;
@@ -19,12 +21,36 @@ _PG_init(void) {
 	quack_init_hooks();
 	quack_init_node();
 }
+
+}
+
+static bool
+quack_cloud_secret_check_hooks(char **newval, void **extra, GucSource source) {
+
+	std::vector<std::string> tokens = quack::tokenizeString(*newval, '#');
+
+	if (tokens.size() == 0) {
+		return true;
+	}
+
+	if (tokens.size() != 4) {
+		elog(WARNING, "Incorrect quack.cloud_secret format.");
+		return false;
+	}
+
+	if (tokens[0].compare("S3")) {
+		elog(WARNING, "quack.cloud_secret supports only S3.");
+		return false;
+	}
+
+	return true;
 }
 
 /* clang-format off */
 static void
 quack_init_guc(void) {
-	DefineCustomIntVariable("quack.max_threads_per_query",
+
+    DefineCustomIntVariable("quack.max_threads_per_query",
                             gettext_noop("DuckDB max no. threads per query."),
                             NULL,
                             &quack_max_threads_per_query,
@@ -36,4 +62,15 @@ quack_init_guc(void) {
                             NULL,
                             NULL,
                             NULL);
+
+    DefineCustomStringVariable("quack.cloud_secret",
+                               "Quack (duckdb) cloud secret GUC. Format is TYPE#ID#SECRET#REGION",
+                               NULL,
+                               &quack_secret,
+                               "",
+                               PGC_USERSET,
+                               0,
+                               &quack_cloud_secret_check_hooks,
+                               NULL,
+                               NULL);
 }


### PR DESCRIPTION
* `quack.cloud_secret` provides way to store information about remote cloud service secret. Format of GUC should be <TYPE>#<KEY>#<SECRET>#<REGION> and variable is stored only in current session.