### PR TITLE
GUC to enable/disable DuckDB query execution

### DIFF
--- a/include/quack/quack.h
+++ b/include/quack/quack.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // quack.c
+extern bool quack_execution;
 extern int quack_max_threads_per_query;
 extern char *quack_secret;
 extern "C" void _PG_init(void);

--- a/src/quack.cpp
+++ b/src/quack.cpp
@@ -9,6 +9,7 @@ extern "C" {
 
 static void quack_init_guc(void);
 
+bool quack_execution = true;
 int quack_max_threads_per_query = 1;
 char *quack_secret = nullptr;
 
@@ -50,6 +51,16 @@ quack_cloud_secret_check_hooks(char **newval, void **extra, GucSource source) {
 static void
 quack_init_guc(void) {
 
+    DefineCustomBoolVariable("quack.execution",
+                             gettext_noop("Is DuckDB query execution enabled."),
+                             NULL,
+                             &quack_execution,
+                             true,
+                             PGC_USERSET,
+                             0,
+                             NULL, 
+                             NULL, 
+                             NULL);
     DefineCustomIntVariable("quack.max_threads_per_query",
                             gettext_noop("DuckDB max no. threads per query."),
                             NULL,

--- a/src/quack_hooks.cpp
+++ b/src/quack_hooks.cpp
@@ -41,8 +41,9 @@ is_catalog_table(List *tables) {
 
 static PlannedStmt *
 quack_planner(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams) {
-	if (is_quack_extension_registered() && !is_catalog_table(parse->rtable) && parse->commandType == CMD_SELECT) {
-		PlannedStmt * quackPlan = quack_plan_node(parse, query_string, cursorOptions, boundParams);
+	if (quack_execution && is_quack_extension_registered() && !is_catalog_table(parse->rtable) &&
+	    parse->commandType == CMD_SELECT) {
+		PlannedStmt *quackPlan = quack_plan_node(parse, query_string, cursorOptions, boundParams);
 		if (quackPlan) {
 			return quackPlan;
 		}


### PR DESCRIPTION
* `quack.execution` is used to enable/disable DuckDB query execution engine. By default it is set to true.