### PR TITLE
COPY .. TO functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ MODULE_big = quack
 EXTENSION = quack
 DATA = quack.control $(wildcard quack--*.sql)
 
-SRCS = src/quack_detoast.cpp \
+SRCS = src/utility/copy.cpp \
+	   src/quack_detoast.cpp \
+	   src/quack_duckdb_connection.cpp \
 	   src/quack_filter.cpp \
 	   src/quack_heap_scan.cpp \
 	   src/quack_heap_seq_scan.cpp \

--- a/include/quack/quack_duckdb_connection.hpp
+++ b/include/quack/quack_duckdb_connection.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "nodes/pg_list.h"
+}
+
+#include "quack/quack_heap_scan.hpp"
+
+namespace quack {
+
+extern duckdb::unique_ptr<duckdb::Connection> quack_create_duckdb_connection(List *tables, List *neededColumns,
+                                                                             const char *query);
+
+} // namespace quack

--- a/include/quack/quack_heap_scan.hpp
+++ b/include/quack/quack_heap_scan.hpp
@@ -78,12 +78,14 @@ public:
 
 struct PostgresHeapReplacementScanData : public duckdb::ReplacementScanData {
 public:
-	PostgresHeapReplacementScanData(Query *parse, const char *query) : m_parse(parse), m_query(query) {
+	PostgresHeapReplacementScanData(List *tables, List *neededColumns, const char *query)
+	    : m_tables(tables), m_needed_columns(neededColumns), m_query(query) {
 	}
 	~PostgresHeapReplacementScanData() override {};
 
 public:
-	Query *m_parse;
+	List *m_tables;
+	List *m_needed_columns;
 	std::string m_query;
 };
 

--- a/include/quack/quack_heap_seq_scan.hpp
+++ b/include/quack/quack_heap_seq_scan.hpp
@@ -14,6 +14,8 @@ extern "C" {
 
 namespace quack {
 
+struct PostgresTableInformation;
+
 class PostgresHeapSeqScanThreadInfo {
 public:
 	PostgresHeapSeqScanThreadInfo();
@@ -88,7 +90,7 @@ private:
 	Page PreparePageRead(PostgresHeapSeqScanThreadInfo &threadScanInfo);
 
 private:
-	RangeTblEntry * m_tableEntry = nullptr;
+	RangeTblEntry * m_table = nullptr;
 	Relation m_rel = nullptr;
 	Snapshot m_snapshot = nullptr;
 	PostgresHeapSeqParallelScanState m_parallel_scan_state;

--- a/include/quack/quack_utils.hpp
+++ b/include/quack/quack_utils.hpp
@@ -5,8 +5,6 @@
 #include <sstream>
 
 #include <cstdio>
-#include <cstdarg>
-#include <cstring>
 
 namespace quack {
 

--- a/include/quack/utility/copy.hpp
+++ b/include/quack/utility/copy.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+extern "C" {
+#include "postgres.h"
+#include "nodes/plannodes.h"
+}
+
+extern bool quack_copy(PlannedStmt *pstmt, const char *queryString, struct QueryEnvironment *queryEnv,
+                       uint64 *processed);

--- a/src/quack_duckdb_connection.cpp
+++ b/src/quack_duckdb_connection.cpp
@@ -1,0 +1,54 @@
+#include "duckdb.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+#include "quack/quack_duckdb_connection.hpp"
+#include "quack/quack_heap_scan.hpp"
+#include "quack/quack_utils.hpp"
+
+namespace quack {
+
+static duckdb::unique_ptr<duckdb::DuckDB>
+quack_open_database() {
+	duckdb::DBConfig config;
+	// config.SetOption("memory_limit", "2GB");
+	// config.SetOption("threads", "8");
+	// config.allocator = duckdb::make_uniq<duckdb::Allocator>(QuackAllocate, QuackFree, QuackReallocate, nullptr);
+	return duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+}
+
+duckdb::unique_ptr<duckdb::Connection>
+quack_create_duckdb_connection(List *tables, List *neededColumns, const char *query) {
+	auto db = quack::quack_open_database();
+
+	/* Add tables */
+	db->instance->config.replacement_scans.emplace_back(
+	    quack::PostgresHeapReplacementScan,
+	    duckdb::make_uniq_base<duckdb::ReplacementScanData, quack::PostgresHeapReplacementScanData>(
+	        tables, neededColumns, query));
+
+	auto connection = duckdb::make_uniq<duckdb::Connection>(*db);
+
+	// Add the postgres_scan inserted by the replacement scan
+	auto &context = *connection->context;
+	quack::PostgresHeapScanFunction heap_scan_fun;
+	duckdb::CreateTableFunctionInfo heap_scan_info(heap_scan_fun);
+
+	auto &catalog = duckdb::Catalog::GetSystemCatalog(context);
+	context.transaction.BeginTransaction();
+	catalog.CreateTableFunction(context, &heap_scan_info);
+	context.transaction.Commit();
+
+	if (strlen(quack_secret) != 0) {
+		std::vector<std::string> quackSecret = quack::tokenizeString(quack_secret, '#');
+		StringInfo s3SecretKey = makeStringInfo();
+		appendStringInfoString(s3SecretKey, "CREATE SECRET s3Secret ");
+		appendStringInfo(s3SecretKey, "(TYPE S3, KEY_ID '%s', SECRET '%s', REGION '%s');", quackSecret[1].c_str(),
+		                 quackSecret[2].c_str(), quackSecret[3].c_str());
+		context.Query(s3SecretKey->data, false);
+		pfree(s3SecretKey->data);
+	}
+
+	return connection;
+}
+
+} // namespace quack

--- a/src/quack_heap_scan.cpp
+++ b/src/quack_heap_scan.cpp
@@ -143,12 +143,10 @@ FindMatchingHeapRelation(List *tables, const duckdb::string &to_find) {
 		RangeTblEntry *table = (RangeTblEntry *)lfirst(lc);
 		if (table->relid) {
 			auto rel = RelationIdGetRelation(table->relid);
-
 			if (!RelationIsValid(rel)) {
 				elog(ERROR, "Relation with OID %u is not valid", table->relid);
 				return nullptr;
 			}
-
 			char *rel_name = RelationGetRelationName(rel);
 			auto table_name = std::string(rel_name);
 			if (duckdb::StringUtil::CIEquals(table_name, to_find)) {
@@ -187,8 +185,8 @@ PostgresHeapReplacementScan(duckdb::ClientContext &context, const duckdb::string
 
 	auto &scan_data = reinterpret_cast<PostgresHeapReplacementScanData &>(*data);
 
-	/* Check name against query rtable list and verify that it is heap table */
-	auto table = FindMatchingHeapRelation(scan_data.m_parse->rtable, table_name);
+	/* Check name against query table list and verify that it is heap table */
+	auto table = FindMatchingHeapRelation(scan_data.m_tables, table_name);
 
 	if (!table) {
 		return nullptr;

--- a/src/quack_heap_seq_scan.cpp
+++ b/src/quack_heap_seq_scan.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "storage/bufmgr.h"
 }
 
+#include "quack/quack_heap_scan.hpp"
 #include "quack/quack_heap_seq_scan.hpp"
 #include "quack/quack_types.hpp"
 
@@ -15,7 +16,7 @@ extern "C" {
 
 namespace quack {
 PostgresHeapSeqScan::PostgresHeapSeqScan(RangeTblEntry *table)
-    : m_tableEntry(table), m_rel(nullptr), m_snapshot(nullptr) {
+    : m_table(table), m_rel(nullptr), m_snapshot(nullptr) {
 }
 
 PostgresHeapSeqScan::~PostgresHeapSeqScan() {
@@ -25,15 +26,15 @@ PostgresHeapSeqScan::~PostgresHeapSeqScan() {
 }
 
 PostgresHeapSeqScan::PostgresHeapSeqScan(PostgresHeapSeqScan &&other)
-    : m_tableEntry(other.m_tableEntry), m_rel(nullptr) {
+    : m_table(other.m_table), m_rel(nullptr) {
 	other.CloseRelation();
-	other.m_tableEntry = nullptr;
+	other.m_table = nullptr;
 }
 
 Relation
 PostgresHeapSeqScan::GetRelation() {
-	if (m_tableEntry && m_rel == nullptr) {
-		m_rel = RelationIdGetRelation(m_tableEntry->relid);
+	if (m_table && m_rel == nullptr) {
+		m_rel = RelationIdGetRelation(m_table->relid);
 	}
 	return m_rel;
 }

--- a/src/quack_node.cpp
+++ b/src/quack_node.cpp
@@ -13,7 +13,7 @@ static CustomExecMethods quack_scan_exec_methods;
 
 typedef struct QuackScanState {
 	CustomScanState css; /* must be first field */
-	duckdb::DuckDB *duckdb;
+	duckdb::Connection *duckdbConnection;
 	duckdb::PreparedStatement *preparedStatement;
 	bool is_executed;
 	bool fetch_next;
@@ -35,7 +35,7 @@ static Node *
 Quack_CreateCustomScanState(CustomScan *cscan) {
 	QuackScanState *quackScanState = (QuackScanState *)newNode(sizeof(QuackScanState), T_CustomScanState);
 	CustomScanState *customScanState = &quackScanState->css;
-	quackScanState->duckdb = (duckdb::DuckDB *)linitial(cscan->custom_private);
+	quackScanState->duckdbConnection = (duckdb::Connection *)linitial(cscan->custom_private);
 	quackScanState->preparedStatement = (duckdb::PreparedStatement *)lsecond(cscan->custom_private);
 	quackScanState->is_executed = false;
 	quackScanState->fetch_next = true;
@@ -106,7 +106,7 @@ Quack_EndCustomScan(CustomScanState *node) {
 	QuackScanState *quackScanState = (QuackScanState *)node;
 	quackScanState->queryResult.reset();
 	delete quackScanState->preparedStatement;
-	delete quackScanState->duckdb;
+	delete quackScanState->duckdbConnection;
 	RESUME_CANCEL_INTERRUPTS();
 }
 

--- a/src/quack_planner.cpp
+++ b/src/quack_planner.cpp
@@ -1,67 +1,34 @@
 #include "duckdb.hpp"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
 extern "C" {
 #include "postgres.h"
 #include "catalog/pg_type.h"
-#include "nodes/nodes.h"
 #include "nodes/makefuncs.h"
+#include "optimizer/optimizer.h"
 #include "utils/syscache.h"
 }
 
+#include "quack/quack_duckdb_connection.hpp"
 #include "quack/quack_heap_scan.hpp"
 #include "quack/quack_node.hpp"
 #include "quack/quack_planner.hpp"
 #include "quack/quack_types.hpp"
 #include "quack/quack_utils.hpp"
 
-namespace quack {
-
-static duckdb::unique_ptr<duckdb::DuckDB>
-quack_open_database() {
-	duckdb::DBConfig config;
-	// config.SetOption("memory_limit", "2GB");
-	// config.SetOption("threads", "8");
-	// config.allocator = duckdb::make_uniq<duckdb::Allocator>(QuackAllocate, QuackFree, QuackReallocate, nullptr);
-	return duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
-}
-
-} // namespace quack
-
 static Plan *
 quack_create_plan(Query *parse, const char *query) {
-	auto db = quack::quack_open_database();
+	/* Extract required vars for table */
+	int flags = PVC_RECURSE_AGGREGATES | PVC_RECURSE_WINDOWFUNCS | PVC_RECURSE_PLACEHOLDERS;
+	List *vars = list_concat(pull_var_clause((Node *)parse->targetList, flags),
+	                         pull_var_clause((Node *)parse->jointree->quals, flags));
 
-	/* Add heap tables */
-	db->instance->config.replacement_scans.emplace_back(
-	    quack::PostgresHeapReplacementScan,
-	    duckdb::make_uniq_base<duckdb::ReplacementScanData, quack::PostgresHeapReplacementScanData>(parse, query));
-	auto connection = duckdb::make_uniq<duckdb::Connection>(*db);
+	auto duckdbConnection = quack::quack_create_duckdb_connection(parse->rtable, vars , query);
+	auto context = duckdbConnection->context;
 
-	// Add the postgres_scan inserted by the replacement scan
-	auto &context = *connection->context;
-	quack::PostgresHeapScanFunction heap_scan_fun;
-	duckdb::CreateTableFunctionInfo heap_scan_info(heap_scan_fun);
-
-	auto &catalog = duckdb::Catalog::GetSystemCatalog(context);
-	context.transaction.BeginTransaction();
-	catalog.CreateTableFunction(context, &heap_scan_info);
-	context.transaction.Commit();
-
-	if (strlen(quack_secret) != 0) {
-		std::vector<std::string> quackSecret = quack::tokenizeString(quack_secret, '#');
-		StringInfo s3SecretKey = makeStringInfo();
-		appendStringInfoString(s3SecretKey, "CREATE SECRET s3Secret ");
-		appendStringInfo(s3SecretKey, "(TYPE S3, KEY_ID '%s', SECRET '%s', REGION '%s');", quackSecret[1].c_str(),
-		                 quackSecret[2].c_str(), quackSecret[3].c_str());
-		context.Query(s3SecretKey->data, false);
-		pfree(s3SecretKey->data);
-	}
-
-	auto preparedQuery = context.Prepare(query);
+	auto preparedQuery = context->Prepare(query);
 
 	if (preparedQuery->HasError()) {
-		elog(INFO, "(Quack) %s", preparedQuery->GetError().c_str());
+		elog(WARNING, "(Quack) %s", preparedQuery->GetError().c_str());
 		return nullptr;
 	}
 
@@ -93,7 +60,7 @@ quack_create_plan(Query *parse, const char *query) {
 		}
 	}
 
-	quackNode->custom_private = list_make2(db.release(), preparedQuery.release());
+	quackNode->custom_private = list_make2(duckdbConnection.release(), preparedQuery.release());
 	quackNode->methods = &quack_scan_scan_methods;
 
 	return (Plan *)quackNode;
@@ -101,7 +68,6 @@ quack_create_plan(Query *parse, const char *query) {
 
 PlannedStmt *
 quack_plan_node(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams) {
-
 	/* We need to check can we DuckDB create plan */
 	Plan *quackPlan = (Plan *)castNode(CustomScan, quack_create_plan(parse, query_string));
 

--- a/src/quack_types.cpp
+++ b/src/quack_types.cpp
@@ -187,7 +187,6 @@ typedef struct HeapTupleReadState {
 static Datum
 HeapTupleFetchNextColumnDatum(TupleDesc tupleDesc, HeapTuple tuple, HeapTupleReadState &heapTupleReadState, int attNum,
                               bool *isNull) {
-
 	HeapTupleHeader tup = tuple->t_data;
 	bool hasnulls = HeapTupleHasNulls(tuple);
 	int attnum;
@@ -300,9 +299,8 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresHeapSeqScanThreadInfo &t
 			idx_t projectionColumnIdx = parallelScanState.m_columns[parallelScanState.m_projections[idx]];
 			if (threadScanInfo.m_tuple_desc->attrs[parallelScanState.m_projections[idx]].attlen == -1) {
 				bool shouldFree = false;
-				values[projectionColumnIdx] =
-				    DetoastPostgresDatum(reinterpret_cast<varlena *>(values[projectionColumnIdx]),
-				                         parallelScanState.m_lock, &shouldFree);
+				values[projectionColumnIdx] = DetoastPostgresDatum(
+				    reinterpret_cast<varlena *>(values[projectionColumnIdx]), parallelScanState.m_lock, &shouldFree);
 				ConvertPostgresToDuckValue(values[projectionColumnIdx], result, threadScanInfo.m_output_vector_size);
 				if (shouldFree) {
 					duckdb_free(reinterpret_cast<void *>(values[projectionColumnIdx]));

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -1,0 +1,134 @@
+#include "duckdb.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "catalog/namespace.h"
+#include "commands/copy.h"
+#include "nodes/makefuncs.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_collate.h"
+#include "parser/parse_expr.h"
+#include "parser/parse_node.h"
+#include "parser/parse_relation.h"
+#include "tcop/tcopprot.h"
+#include "optimizer/optimizer.h"
+#include "utils/rls.h"
+#include "utils/lsyscache.h"
+}
+
+#include "quack/utility/copy.hpp"
+#include "quack/quack_heap_scan.hpp"
+#include "quack/quack_duckdb_connection.hpp"
+
+static constexpr char quackCopyS3FilenamePrefix[] = "s3://";
+
+static bool
+create_relation_copy_parse_state(ParseState *pstate, const CopyStmt *stmt, List **vars, int stmt_location,
+                                 int stmt_len) {
+	ParseNamespaceItem *nsitem;
+	RTEPermissionInfo *perminfo;
+	TupleDesc tupDesc;
+	List *attnums;
+	ListCell *cur;
+	Relation rel;
+	Oid relid;
+
+	/* Open and lock the relation, using the appropriate lock type. */
+	rel = table_openrv(stmt->relation, AccessShareLock);
+
+	relid = RelationGetRelid(rel);
+
+	nsitem = addRangeTableEntryForRelation(pstate, rel, AccessShareLock, NULL, false, false);
+
+	perminfo = nsitem->p_perminfo;
+	perminfo->requiredPerms = ACL_SELECT;
+
+	tupDesc = RelationGetDescr(rel);
+	attnums = CopyGetAttnums(tupDesc, rel, stmt->attlist);
+
+	foreach (cur, attnums) {
+		int attno;
+		Bitmapset **bms;
+		attno = lfirst_int(cur) - FirstLowInvalidHeapAttributeNumber;
+		bms = &perminfo->selectedCols;
+		*bms = bms_add_member(*bms, attno);
+		*vars = lappend(*vars, makeVar(1, lfirst_int(cur), tupDesc->attrs[lfirst_int(cur) - 1].atttypid,
+		                               tupDesc->attrs[lfirst_int(cur) - 1].atttypmod,
+		                               tupDesc->attrs[lfirst_int(cur) - 1].attcollation, 0));
+	}
+
+	if (!ExecCheckPermissions(pstate->p_rtable, list_make1(perminfo), false)) {
+		ereport(WARNING, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		                  errmsg("(Quack) Failed Permission \"%s\"", RelationGetRelationName(rel))));
+	}
+
+	table_close(rel, AccessShareLock);
+
+	/*
+	 * RLS for relation. We should probably bail out at this point.
+	 */
+	if (check_enable_rls(relid, InvalidOid, false) == RLS_ENABLED) {
+		ereport(WARNING, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+		                  errmsg("(Quack) RLS enabled on \"%s\"", RelationGetRelationName(rel))));
+		return false;
+	}
+
+	return true;
+}
+
+bool
+quack_copy(PlannedStmt *pstmt, const char *queryString, struct QueryEnvironment *queryEnv, uint64 *processed) {
+	CopyStmt *copyStmt = (CopyStmt *)pstmt->utilityStmt;
+
+	/* Copy `filename` should start with S3 prefix */
+	if (duckdb::string(copyStmt->filename).rfind(quackCopyS3FilenamePrefix, 0)) {
+		return false;
+	}
+
+	/* We handle only COPY .. TO */
+	if (copyStmt->is_from) {
+		return false;
+	}
+
+	List *tables = NIL;
+	List *vars = NIL;
+
+	if (copyStmt->query) {
+		List *rewritten;
+		RawStmt *rawStmt;
+		Query *query;
+
+		rawStmt = makeNode(RawStmt);
+		rawStmt->stmt = copyStmt->query;
+		rawStmt->stmt_location = pstmt->stmt_location;
+		rawStmt->stmt_len = pstmt->stmt_len;
+
+		rewritten = pg_analyze_and_rewrite_fixedparams(rawStmt, queryString, NULL, 0, NULL);
+		query = linitial_node(Query, rewritten);
+
+		/* Extract required vars for table */
+		int flags = PVC_RECURSE_AGGREGATES | PVC_RECURSE_WINDOWFUNCS | PVC_RECURSE_PLACEHOLDERS;
+		vars = list_concat(pull_var_clause((Node *)query->targetList, flags),
+		                   pull_var_clause((Node *)query->jointree->quals, flags));
+	} else {
+		ParseState *pstate = make_parsestate(NULL);
+		pstate->p_sourcetext = queryString;
+		pstate->p_queryEnv = queryEnv;
+		if (!create_relation_copy_parse_state(pstate, copyStmt, &vars, pstmt->stmt_location, pstmt->stmt_len)) {
+			return false;
+		}
+		tables = pstate->p_rtable;
+	}
+
+	auto duckdbConnection = quack::quack_create_duckdb_connection(tables, vars, queryString);
+	auto res = duckdbConnection->context->Query(queryString, false);
+
+	if (res->HasError()) {
+		elog(WARNING, "(Quack) %s", res->GetError().c_str());
+		return false;
+	}
+
+	auto chunk = res->Fetch();
+	*processed = chunk->GetValue(0, 0).GetValue<uint64>();
+	return true;
+}


### PR DESCRIPTION
* Now we are intercepting utility that will handle COPY utility. COPY through DuckDB will only be executed if COPY destination starts with 's3://' i.e. to S3 bucket. User first needs to setup valid `quack.cloud_secret`. Both COPY from table or specified query works.