### PR TITLE
Adding new Duckdb read functions

### DIFF
--- a/quack--0.0.1.sql
+++ b/quack--0.0.1.sql
@@ -4,6 +4,30 @@ CREATE OR REPLACE FUNCTION read_parquet(path text)
 RETURNS SETOF record LANGUAGE 'plpgsql' AS
 $func$
 BEGIN
-  RETURN QUERY EXECUTE 'SELECT 1';
+   RAISE EXCEPTION 'Function `read_parquet(TEXT)` only works with Duckdb execution.';
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION read_parquet(path text[])
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+   RAISE EXCEPTION 'Function `read_parquet(TEXT[])` only works with Duckdb execution.';
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION read_csv(path text)
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+   RAISE EXCEPTION 'Function `read_csv(TEXT)` only works with Duckdb execution.';
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION read_csv(path text[])
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+   RAISE EXCEPTION 'Function `read_csv(TEXT[])` only works with Duckdb execution.';
 END;
 $func$;


### PR DESCRIPTION
* Added `read_parquet(path TEXT[])` function that can be used to read multiple parquet files. Argument for this function should be provided in PostgreSQL syntax. To read multiple parquet files function should be called with argument `ARRAY['...','...']`.

* Added `read_csv(path TEXT)` and `read_parquet(path TEXT[])` reading single and multiple CSV file