### PR TITLE
Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.o
+*.so
+*.dylib
+.depend
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
+.git
 *.o
 *.so
 *.dylib
-.depend
+*.bc
+.deps
 Dockerfile
+third_party/duckdb/build

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,12 +3,14 @@ name: Build Docker
 on:
   push:
     tags: ["v*"]
-    branches: ["main"]
   pull_request:
     paths:
       - Dockerfile
       - docker-bake.hcl
       - ".github/workflows/docker.yaml"
+  schedule:
+    - cron: "44 4 * * *"
+  workflow_dispatch:
 
 jobs:
   docker:
@@ -20,12 +22,6 @@ jobs:
         platform: ["linux/amd64", "linux/arm64"]
 
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -37,7 +33,11 @@ jobs:
           submodules: "recursive"
       - name: Set env
         run: |
-          echo "POSTGRES_IMAGE=pgduckdb/pgduckdb:${{matrix.postgres}}-${{github.sha}}" >> $GITHUB_ENV
+          # find the first tag for this commit starting with 'v'
+          tag=$(git tag --points-at HEAD | grep ^v | head -n 1)
+          # if no tag is found, use the sha
+          if [ "$tag" = "" ]; then tag="${{ github.sha }}"; fi
+          echo "POSTGRES_TAGS=pgduckdb/pgduckdb:${{ matrix.postgres }}-$tag" >> $GITHUB_ENV
           echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -54,4 +54,4 @@ jobs:
             *.platform=${{ matrix.platform }}
             *.cache-to=type=gha,mode=max
             *.cache-from=type=gha
-            postgres.tags=${{ env.POSTGRES_IMAGE }}
+            postgres.tags=${{ env.POSTGRES_TAGS }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,48 @@
+name: Build Docker
+
+on:
+  push:
+     tags: ["v*"]
+     branches: ['main']
+  pull_request:
+    paths:
+      - Dockerfile
+      - docker-bake.hcl
+      - '.github/workflows/docker.yaml'
+
+jobs:
+  docker:
+    name: Build Docker
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres: ["16", "17"]
+
+    steps:
+      -
+        name: setup POSTGRES_IMAGE env
+        run: echo "POSTGRES_IMAGE=${{ format('wuputah/pg_duckdb:{0}-{1}', matrix.postgres, github.sha) }}" >> $GITHUB_ENV
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+      # -
+      #   name: Login to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: docker bake
+        uses: docker/bake-action@v5
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,8 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,38 +2,36 @@ name: Build Docker
 
 on:
   push:
-     tags: ["v*"]
-     branches: ['main']
+    tags: ["v*"]
+    branches: ["main"]
   pull_request:
     paths:
       - Dockerfile
       - docker-bake.hcl
-      - '.github/workflows/docker.yaml'
+      - ".github/workflows/docker.yaml"
 
 jobs:
   docker:
     name: Build Docker
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      # fail-fast: false
       matrix:
-        postgres: ['15', '16', '17']
-        platform: ['linux/amd64', 'linux/arm64']
+        postgres: ["15", "16", "17"]
+        platform: ["linux/amd64", "linux/arm64"]
 
     steps:
-      -
-        name: Checkout pg_duckdb extension code
+      - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
-      -
-        name: Set POSTGRES_IMAGE env
-        run: echo "POSTGRES_IMAGE=${{ format('wuputah/pg_duckdb:{0}-{1}', matrix.postgres, github.sha) }}" >> $GITHUB_ENV
-      -
-        name: Set up QEMU
+          submodules: "recursive"
+      - name: Set env
+        run: |
+          echo "POSTGRES_IMAGE=${{ format('wuputah/pg_duckdb:{0}-{1}', matrix.postgres, github.sha) }}" >> $GITHUB_ENV
+          echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker buildx
+      - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ matrix.platform }}
@@ -43,8 +41,7 @@ jobs:
       #   with:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: docker bake
+      - name: docker bake
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,6 +27,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: pgduckdb
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,6 @@ jobs:
           submodules: "recursive"
       - name: Set env
         run: |
-          # find the first tag for this commit starting with 'v'
           echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,7 +44,6 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}
-          # push: ${{ github.event_name != 'pull_request' }}
           push: true
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,6 +21,12 @@ jobs:
         platform: ["linux/amd64", "linux/arm64"]
 
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
@@ -35,12 +41,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ matrix.platform }}
-      # -
-      #   name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: docker bake
         uses: docker/bake-action@v5
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: ['16', '17']
+        postgres: ['15', '16', '17']
         platform: ['linux/amd64', 'linux/arm64']
 
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,6 @@ jobs:
     name: Build Docker
     runs-on: ubuntu-24.04
     strategy:
-      # fail-fast: false
       matrix:
         postgres: ["15", "16", "17"]
         platform: ["linux/amd64", "linux/arm64"]
@@ -38,7 +37,7 @@ jobs:
           submodules: "recursive"
       - name: Set env
         run: |
-          echo "POSTGRES_IMAGE=${{ format('wuputah/pg_duckdb:{0}-{1}', matrix.postgres, github.sha) }}" >> $GITHUB_ENV
+          echo "POSTGRES_IMAGE="pgduckdb/pgduckdb:${{matrix.postgres}}-${{github.sha}}" >> $GITHUB_ENV
           echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -50,6 +49,7 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}
+          push: true
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,10 +34,6 @@ jobs:
       - name: Set env
         run: |
           # find the first tag for this commit starting with 'v'
-          tag=$(git tag --points-at HEAD | grep ^v | head -n 1)
-          # if no tag is found, use the sha
-          if [ "$tag" = "" ]; then tag="${{ github.sha }}"; fi
-          echo "POSTGRES_TAGS=pgduckdb/pgduckdb:${{ matrix.postgres }}-$tag" >> $GITHUB_ENV
           echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -54,4 +50,5 @@ jobs:
             *.platform=${{ matrix.platform }}
             *.cache-to=type=gha,mode=max
             *.cache-from=type=gha
-            postgres.tags=${{ env.POSTGRES_TAGS }}
+            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}
+            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.ref_name }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,7 +37,7 @@ jobs:
           submodules: "recursive"
       - name: Set env
         run: |
-          echo "POSTGRES_IMAGE="pgduckdb/pgduckdb:${{matrix.postgres}}-${{github.sha}}" >> $GITHUB_ENV
+          echo "POSTGRES_IMAGE=pgduckdb/pgduckdb:${{matrix.postgres}}-${{github.sha}}" >> $GITHUB_ENV
           echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -52,4 +52,4 @@ jobs:
             *.cache-to=type=gha,mode=max
             *.cache-from=type=gha
             postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}
-            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.ref_name }}
+            ${{ !contains(github.ref_name, '/') && format('postgres.tags=pgduckdb/pgduckdb:{0}-{1}', matrix.postgres, github.ref_name) || '' }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,23 +17,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: ["16", "17"]
+        postgres: ['16', '17']
+        platform: ['linux/amd64', 'linux/arm64']
 
     steps:
       -
-        name: setup POSTGRES_IMAGE env
+        name: Checkout pg_duckdb extension code
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      -
+        name: Set POSTGRES_IMAGE env
         run: echo "POSTGRES_IMAGE=${{ format('wuputah/pg_duckdb:{0}-{1}', matrix.postgres, github.sha) }}" >> $GITHUB_ENV
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
         name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
       # -
       #   name: Login to DockerHub
       #   uses: docker/login-action@v3
@@ -44,5 +47,9 @@ jobs:
         name: docker bake
         uses: docker/bake-action@v5
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          targets: pg_duckdb_${{ matrix.postgres }}
+          set: |
+            *.platform=${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max
+            *.cache-from=type=gha
+            postgres.tags=${{ env.POSTGRES_IMAGE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ RUN mkdir /out
 RUN chown -R postgres:postgres . /usr/lib/postgresql /usr/share/postgresql /out
 
 USER postgres
+# build
+RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make -j$(nproc)
 # install into location specified by pg_config for tests
-RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make -j$(nproc) install
+RUN make install
 # install into /out for packaging
-RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 DESTDIR=/out make install
+RUN DESTDIR=/out make install
 
 ###
 ### CHECKER
@@ -41,7 +43,7 @@ RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 DESTDIR=/out make install
 FROM builder AS checker
 
 USER postgres
-RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make installcheck
+RUN make installcheck
 
 ###
 ### OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM postgres:16-bookworm AS base
+
+###
+### BUILDER
+###
+FROM base AS builder
+
+RUN --mount=type=cache,target=/var/cache/apt \
+  apt-get update -qq && \
+  apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
+  libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo5 cmake \
+  libstdc++-12-dev postgresql-server-dev-16 liblz4-dev ccache
+
+WORKDIR /build
+
+ENV PATH=/usr/lib/ccache:$PATH
+ENV CCACHE_DIR=/ccache
+
+# A more selective copy might be nice, but the git submodules are not cooperative.
+# Instead, use .dockerignore to not copy files here.
+COPY . .
+
+RUN make clean
+
+# permissions so we can run as `postgres` (uid=999,gid=999)
+RUN mkdir /out
+RUN chown -R postgres:postgres . /usr/lib/postgresql /usr/share/postgresql /out
+
+USER postgres
+# install into location specified by pg_config for tests
+RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make -j$(nproc) install
+# install into /out for packaging
+RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 DESTDIR=/out make install
+
+###
+### CHECKER
+###
+FROM builder AS checker
+
+USER postgres
+RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make installcheck
+
+###
+### OUTPUT
+###
+# this creates a usable postgres image but without the packages needed to build
+FROM base AS output
+COPY --from=builder /out /

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chown -R postgres:postgres . /usr/lib/postgresql /usr/share/postgresql /out
 
 USER postgres
 # build
-RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 make -j$(nproc)
+RUN --mount=type=cache,target=/ccache/,uid=999,gid=999 echo "Available CPUs=$(nproc)" && make -j$(nproc)
 # install into location specified by pg_config for tests
 RUN make install
 # install into /out for packaging

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,6 @@ RUN make installcheck
 # this creates a usable postgres image but without the packages needed to build
 FROM base AS output
 COPY --from=builder /out /
+
+# set default config
+RUN echo shared_preload_libraries = \'pg_duckdb\' >> /var/lib/postgresql/data/postgresql.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ FROM postgres_base AS base
 ### BUILDER
 ###
 FROM base AS builder
+ARG POSTGRES_VERSION
 
 RUN apt-get update -qq && \
   apt-get install -y \
+    postgresql-server-dev-${POSTGRES_VERSION} \
     build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
     libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev \
-    libtinfo5 cmake libstdc++-12-dev postgresql-server-dev-16 liblz4-dev ccache && \
+    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && \
     postgresql-server-dev-${POSTGRES_VERSION} \
     build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
     libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev \
-    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache && \
+    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache ninja-build && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,3 @@ RUN make installcheck
 # this creates a usable postgres image but without the packages needed to build
 FROM base AS output
 COPY --from=builder /out /
-
-# set default config
-RUN echo shared_preload_libraries = \'pg_duckdb\' >> /var/lib/postgresql/data/postgresql.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM postgres:16-bookworm AS base
+FROM postgres_base AS base
 
 ###
 ### BUILDER
 ###
 FROM base AS builder
 
-RUN --mount=type=cache,target=/var/cache/apt \
-  apt-get update -qq && \
-  apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
-  libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo5 cmake \
-  libstdc++-12-dev postgresql-server-dev-16 liblz4-dev ccache
+RUN apt-get update -qq && \
+  apt-get install -y \
+    build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
+    libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev \
+    libtinfo5 cmake libstdc++-12-dev postgresql-server-dev-16 liblz4-dev ccache && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
@@ -20,7 +21,7 @@ ENV CCACHE_DIR=/ccache
 # Instead, use .dockerignore to not copy files here.
 COPY . .
 
-RUN make clean
+RUN make clean-all
 
 # permissions so we can run as `postgres` (uid=999,gid=999)
 RUN mkdir /out

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -39,7 +39,7 @@ target "pg_duckdb_15" {
   inherits = ["pg_duckdb"]
 
   args = {
-    POSTGRES_VERSION = 15
+    POSTGRES_VERSION = "15"
   }
 }
 
@@ -47,7 +47,7 @@ target "pg_duckdb_16" {
   inherits = ["pg_duckdb"]
 
   args = {
-    POSTGRES_VERSION = 16
+    POSTGRES_VERSION = "16"
   }
 }
 
@@ -55,7 +55,7 @@ target "pg_duckdb_17" {
   inherits = ["pg_duckdb"]
 
   args = {
-    POSTGRES_VERSION = 17
+    POSTGRES_VERSION = "17"
   }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,5 @@
 variable "REPO" {
-  # temp repo on dockerhub
-  default = "wuputah/pg_duckdb"
+  default = "pgduckdb/pgduckdb"
 }
 
 variable "POSTGRES_VERSION" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,57 @@
+variable "REPO" {
+  # temp repo on dockerhub
+  default = "wuputah/pg_duckdb"
+}
+
+variable "POSTGRES_VERSION" {
+  default = "16"
+}
+
+target "shared" {
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}
+
+target "postgres" {
+  inherits = ["shared"]
+
+  contexts = {
+    // pg_duckdb = "target:pg_duckdb_${POSTGRES_VERSION}"
+    postgres_base = "docker-image://postgres:${POSTGRES_VERSION}-bookworm"
+  }
+
+  args = {
+    POSTGRES_VERSION = "${POSTGRES_VERSION}"
+  }
+
+  tags = [
+    "${REPO}:${POSTGRES_VERSION}",
+  ]
+}
+
+target "pg_duckdb" {
+  inherits = ["postgres"]
+  target = "output"
+}
+
+target "pg_duckdb_16" {
+  inherits = ["pg_duckdb"]
+
+  args = {
+    POSTGRES_VERSION = 16
+  }
+}
+
+target "pg_duckdb_17" {
+  inherits = ["pg_duckdb"]
+
+  args = {
+    POSTGRES_VERSION = 17
+  }
+}
+
+target "default" {
+  inherits = ["pg_duckdb_16"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,14 @@ target "pg_duckdb" {
   target = "output"
 }
 
+target "pg_duckdb_15" {
+  inherits = ["pg_duckdb"]
+
+  args = {
+    POSTGRES_VERSION = 15
+  }
+}
+
 target "pg_duckdb_16" {
   inherits = ["pg_duckdb"]
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,7 +18,6 @@ target "postgres" {
   inherits = ["shared"]
 
   contexts = {
-    // pg_duckdb = "target:pg_duckdb_${POSTGRES_VERSION}"
     postgres_base = "docker-image://postgres:${POSTGRES_VERSION}-bookworm"
   }
 
@@ -27,7 +26,7 @@ target "postgres" {
   }
 
   tags = [
-    "${REPO}:${POSTGRES_VERSION}",
+    "${REPO}:${POSTGRES_VERSION}-dev",
   ]
 }
 


### PR DESCRIPTION
* Usage follows https://hub.docker.com/_/postgres/
* Images are pushed to [`pgduckdb/pgduckdb`](https://hub.docker.com/r/pgduckdb/pgduckdb)
* Anytime an image is built, it's pushed to `17-$sha`, `16-$sha`, `15-$sha`
* Nightly images pushed to `17-main`, `16-main`, `15-main`
* Version tags (tags beginning with `v`) will be built automatically and pushed to `17-$tag`, `16-$tag`, `15-$tag`
* Only built on PR when the Docker-related files are changed

To test, [grab a tag](https://hub.docker.com/r/pgduckdb/pgduckdb/tags), for instance:

```
TAG=17-b203b63b052df8a7fece37f79face6b7522a498f
PORT=6543
```

Then:

```
docker run --name pgduckdb -e POSTGRES_PASSWORD=secret -p $PORT:5432 \
  pgduckdb/pgduckdb:$TAG -c shared_preload_libraries=pg_duckdb

psql postgres://postgres:secret@127.0.0.1:$PORT/postgres
```

Cleanup:

```
docker stop pgduckdb
docker rm pgduckdb
```

This can be made easier with a `docker-compose.yml`, which will be forthcoming.