### PR TITLE
Fix conversion of HUGEINT from DuckDB -> Postgres

### DIFF
--- a/src/quack_types.cpp
+++ b/src/quack_types.cpp
@@ -362,9 +362,11 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 			break;
 		}
 		NumericVar numeric_var;
-		D_ASSERT(value.type().id() == duckdb::LogicalTypeId::DECIMAL);
+		D_ASSERT(value.type().id() == duckdb::LogicalTypeId::DECIMAL || value.type().id() == duckdb::LogicalTypeId::HUGEINT);
 		auto physical_type = value.type().InternalType();
-		auto scale = duckdb::DecimalType::GetScale(value.type());
+		const bool is_decimal = value.type().id() == duckdb::LogicalTypeId::DECIMAL;
+		uint8_t scale = is_decimal ? duckdb::DecimalType::GetScale(value.type()) : 0;
+
 		switch (physical_type) {
 			case duckdb::PhysicalType::INT16: {
 				numeric_var = ConvertNumeric<int16_t>(value.GetValueUnsafe<int16_t>(), scale);

--- a/test/regression/expected/hugeint_conversion.out
+++ b/test/regression/expected/hugeint_conversion.out
@@ -1,0 +1,15 @@
+create table hugeint_sum(a int);
+insert into hugeint_sum select g from generate_series(1,100) g;
+select pg_typeof(sum(a)) from hugeint_sum;
+ pg_typeof(sum(a)) 
+-------------------
+ hugeint
+(1 row)
+
+select sum(a) result from hugeint_sum;
+ result 
+--------
+   5050
+(1 row)
+
+drop table hugeint_sum;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -6,3 +6,4 @@ test: array_type_support
 test: views
 test: projection_pushdown_unsupported_type
 test: materialized_view
+test: hugeint_conversion

--- a/test/regression/sql/hugeint_conversion.sql
+++ b/test/regression/sql/hugeint_conversion.sql
@@ -1,0 +1,6 @@
+create table hugeint_sum(a int);
+insert into hugeint_sum select g from generate_series(1,100) g;
+select pg_typeof(sum(a)) from hugeint_sum;
+select sum(a) result from hugeint_sum;
+
+drop table hugeint_sum;


### PR DESCRIPTION
HUGEINT is also converted to NUMERICOID, which was previously not expected by the NUMERICOID conversion path.
We now treat the hugeint as a DECIMAL(38,0).

I suspect this has a limitation, because DECIMAL only goes up to a width of 38, while HUGEINT can have a width of 39.
Which becomes a problem when `DecimalConversionHugeint::GetPowerOfTen` would be called with a value > 38.

I couldn't produce a test for this however, and looking at the code, the `OP::GetPowerOfTen` seems to only be used when scale is involved, which we've set to 0 for this case.