### PR TITLE
INSTALL/LOAD DuckDB extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRCS = src/scan/heap_reader.cpp \
 	   src/quack_hooks.cpp \
 	   src/quack_memory_allocator.cpp \
 	   src/quack_node.cpp \
+	   src/quack_options.cpp \
 	   src/quack_planner.cpp \
 	   src/quack_types.cpp \
 	   src/quack.cpp

--- a/include/quack/quack_duckdb.hpp
+++ b/include/quack/quack_duckdb.hpp
@@ -10,6 +10,7 @@ extern "C" {
 
 namespace quack {
 
+extern duckdb::unique_ptr<duckdb::DuckDB> quack_open_database();
 extern duckdb::unique_ptr<duckdb::Connection> quack_create_duckdb_connection(List *rtables, PlannerInfo *plannerInfo,
                                                                              List *neededColumns, const char *query);
 

--- a/include/quack/quack_options.hpp
+++ b/include/quack/quack_options.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace quack {
+
+/* constants for quack.secrets */
+#define Natts_quack_secret              6
+#define Anum_quack_secret_type          1
+#define Anum_quack_secret_id            2
+#define Anum_quack_secret_secret        3
+#define Anum_quack_secret_region        4
+#define Anum_quack_secret_endpoint      5
+#define Anum_quack_secret_r2_account_id 6
+
+typedef struct QuackSecret {
+	std::string type;
+	std::string id;
+	std::string secret;
+	std::string region;
+	std::string endpoint;
+	std::string r2_account_id;
+} QuackSecret;
+
+extern std::vector<QuackSecret> read_quack_secrets();
+
+/* constants for quack.extensions */
+#define Natts_quack_extension       2
+#define Anum_quack_extension_name   1
+#define Anum_quack_extension_enable 2
+
+typedef struct QuackExension {
+	std::string name;
+	bool enabled;
+} QuackExension;
+
+extern std::vector<QuackExension> read_quack_extensions();
+
+} // namespace quack

--- a/sql/quack--0.0.1.sql
+++ b/sql/quack--0.0.1.sql
@@ -32,6 +32,14 @@ BEGIN
 END;
 $func$;
 
+CREATE OR REPLACE FUNCTION iceberg_scan(path text)
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+   RAISE EXCEPTION 'Function `iceberg_scan(TEXT)` only works with Duckdb execution.';
+END;
+$func$;
+
 CREATE SCHEMA quack;
 SET search_path TO quack;
 
@@ -58,5 +66,13 @@ $$ LANGUAGE PLpgSQL;
 
 CREATE TRIGGER quack_secret_r2_tr BEFORE INSERT OR UPDATE ON secrets
 FOR EACH ROW EXECUTE PROCEDURE quack_secret_r2_check();
+
+CREATE TABLE extensions (
+   name TEXT NOT NULL,
+   enabled BOOL DEFAULT TRUE
+);
+
+CREATE OR REPLACE FUNCTION install_extension(extension_name TEXT) RETURNS bool
+    LANGUAGE C AS 'MODULE_PATHNAME', 'install_extension';
 
 RESET search_path;

--- a/src/quack_options.cpp
+++ b/src/quack_options.cpp
@@ -1,0 +1,159 @@
+
+#include "duckdb.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "access/genam.h"
+#include "access/relation.h"
+#include "access/table.h"
+#include "access/xact.h"
+#include "catalog/indexing.h"
+#include "catalog/namespace.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+#include "utils/snapmgr.h"
+}
+
+#include "quack/quack_options.hpp"
+#include "quack/quack_duckdb.hpp"
+
+namespace quack {
+
+static Oid
+quackGetNamespace(void) {
+	return get_namespace_oid("quack", false);
+}
+
+static Oid
+quackSecretsRelationId(void) {
+	return get_relname_relid("secrets", quackGetNamespace());
+}
+
+static Oid
+quackExtensionsRelationId(void) {
+	return get_relname_relid("extensions", quackGetNamespace());
+}
+
+static std::string
+quackDatumToString(Datum datum) {
+	std::string columnValue;
+	text *cloudType = DatumGetTextPP(datum);
+	columnValue = VARDATA_ANY(cloudType);
+	columnValue.resize(VARSIZE_ANY_EXHDR(cloudType));
+	return columnValue;
+}
+
+std::vector<QuackSecret>
+read_quack_secrets() {
+	HeapTuple tuple = NULL;
+	Oid quackSecretRelationId = quackSecretsRelationId();
+	Relation quackSecretRelation = table_open(quackSecretRelationId, AccessShareLock);
+	SysScanDescData *scan = systable_beginscan(quackSecretRelation, InvalidOid, false, GetActiveSnapshot(), 0, NULL);
+	std::vector<QuackSecret> quackSecrets;
+
+	while (HeapTupleIsValid(tuple = systable_getnext(scan))) {
+		Datum datumArray[Natts_quack_secret];
+		bool isNullArray[Natts_quack_secret];
+
+		heap_deform_tuple(tuple, RelationGetDescr(quackSecretRelation), datumArray, isNullArray);
+		QuackSecret secret;
+
+		secret.type = quackDatumToString(datumArray[Anum_quack_secret_type - 1]);
+		secret.id = quackDatumToString(datumArray[Anum_quack_secret_id - 1]);
+		secret.secret = quackDatumToString(datumArray[Anum_quack_secret_secret - 1]);
+
+		if (!isNullArray[Anum_quack_secret_region - 1])
+			secret.region = quackDatumToString(datumArray[Anum_quack_secret_region - 1]);
+
+		if (!isNullArray[Anum_quack_secret_endpoint - 1])
+			secret.endpoint = quackDatumToString(datumArray[Anum_quack_secret_endpoint - 1]);
+
+		if (!isNullArray[Anum_quack_secret_r2_account_id - 1])
+			secret.endpoint = quackDatumToString(datumArray[Anum_quack_secret_r2_account_id - 1]);
+
+		quackSecrets.push_back(secret);
+	}
+
+	systable_endscan(scan);
+	table_close(quackSecretRelation, NoLock);
+	return quackSecrets;
+}
+
+std::vector<QuackExension>
+read_quack_extensions() {
+	HeapTuple tuple = NULL;
+	Oid quackExtensionRelationId = quackExtensionsRelationId();
+	Relation quackExtensionRelation = table_open(quackExtensionRelationId, AccessShareLock);
+	SysScanDescData *scan = systable_beginscan(quackExtensionRelation, InvalidOid, false, GetActiveSnapshot(), 0, NULL);
+	std::vector<QuackExension> quackExtension;
+
+	while (HeapTupleIsValid(tuple = systable_getnext(scan))) {
+		Datum datumArray[Natts_quack_secret];
+		bool isNullArray[Natts_quack_secret];
+
+		heap_deform_tuple(tuple, RelationGetDescr(quackExtensionRelation), datumArray, isNullArray);
+		QuackExension secret;
+
+		secret.name = quackDatumToString(datumArray[Anum_quack_extension_name - 1]);
+		secret.enabled = DatumGetBool(datumArray[Anum_quack_extension_enable - 1]);
+		quackExtension.push_back(secret);
+	}
+
+	systable_endscan(scan);
+	table_close(quackExtensionRelation, NoLock);
+	return quackExtension;
+}
+
+static bool
+quackInstallExtension(Datum name) {
+	auto db = quack_open_database();
+	auto connection = duckdb::make_uniq<duckdb::Connection>(*db);
+	auto &context = *connection->context;
+
+	auto extensionName = quackDatumToString(name);
+
+	StringInfo installExtensionCommand = makeStringInfo();
+	appendStringInfo(installExtensionCommand, "INSTALL %s;", extensionName.c_str());
+
+	auto res = context.Query(installExtensionCommand->data, false);
+
+	pfree(installExtensionCommand->data);
+
+	if (res->HasError()) {
+		elog(WARNING, "(quack_install_extension) %s", res->GetError().c_str());
+		return false;
+	}
+
+	bool nulls[Natts_quack_extension] = {0};
+	Datum values[Natts_quack_extension] = {0};
+
+	values[Anum_quack_extension_name - 1] = name;
+	values[Anum_quack_extension_enable - 1] = 1;
+
+	/* create heap tuple and insert into catalog table */
+	Relation quackExtensionRelation = relation_open(quackExtensionsRelationId(), RowExclusiveLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(quackExtensionRelation);
+
+	/* inserting extension record */
+	HeapTuple newTuple = heap_form_tuple(tupleDescriptor, values, nulls);
+	CatalogTupleInsert(quackExtensionRelation, newTuple);
+
+	CommandCounterIncrement();
+	relation_close(quackExtensionRelation, RowExclusiveLock);
+
+	return true;
+}
+
+} // namespace quack
+
+extern "C" {
+
+PG_FUNCTION_INFO_V1(install_extension);
+Datum
+install_extension(PG_FUNCTION_ARGS) {
+	Datum extensionName = PG_GETARG_DATUM(0);
+	bool result = quack::quackInstallExtension(extensionName);
+	PG_RETURN_BOOL(result);
+}
+
+} // extern "C"

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -1,19 +1,13 @@
 CREATE TABLE t(a INT);
 INSERT INTO t SELECT g % 10 from generate_series(1,1000000) g;
-SET client_min_messages to 'DEBUG3';
+SET client_min_messages to 'DEBUG1';
 SELECT COUNT(*) FROM t;
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresReplacementScanGlobalState) Running 1 threads -- 
  count_star() 
 --------------
       1000000
 (1 row)
 
 SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresReplacementScanGlobalState) Running 1 threads -- 
  a | count_star() 
 ---+--------------
  6 |       100000
@@ -24,18 +18,12 @@ DEBUG:  -- (DuckDB/PostgresReplacementScanGlobalState) Running 1 threads --
 
 SET quack.max_threads_per_query to 4;
 SELECT COUNT(*) FROM t;
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresReplacementScanGlobalState) Running 4 threads -- 
  count_star() 
 --------------
       1000000
 (1 row)
 
 SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresHeapBind) Column name: a, Type: INTEGER --
-DEBUG:  -- (DuckDB/PostgresReplacementScanGlobalState) Running 4 threads -- 
  a | count_star() 
 ---+--------------
  6 |       100000

--- a/test/regression/sql/basic.sql
+++ b/test/regression/sql/basic.sql
@@ -2,7 +2,7 @@ CREATE TABLE t(a INT);
 
 INSERT INTO t SELECT g % 10 from generate_series(1,1000000) g;
 
-SET client_min_messages to 'DEBUG3';
+SET client_min_messages to 'DEBUG1';
 
 SELECT COUNT(*) FROM t;
 SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;


### PR DESCRIPTION
* DuckDB extensions can be installed with `quack.install_extension()` function. Extensions will be installed in PGDIR/quack_extensions directory and extension will be added to `quack.extensions` table. By default extension will be loaded automatically for each query. This can be disabled by setting `quack.extension.enabled` column to `false`.

* Added `iceberg_scan(path)` function that will read iceberg file format if `iceberg` extension is installed.