### PR TITLE
Move the error into the function where we still have the context

### DIFF
--- a/src/quack_planner.cpp
+++ b/src/quack_planner.cpp
@@ -70,9 +70,6 @@ quack_create_plan(Query *query, const char *queryString, ParamListInfo boundPara
 		auto &column = preparedResultTypes[i];
 		Oid postgresColumnOid = quack::GetPostgresDuckDBType(column);
 
-		if (!OidIsValid(postgresColumnOid)) {
-			elog(ERROR, "Could not convert DuckDB to Postgres type, likely because the postgres->duckdb conversion was not supported");
-		}
 		HeapTuple tp;
 		Form_pg_type typtup;
 

--- a/src/quack_types.cpp
+++ b/src/quack_types.cpp
@@ -584,7 +584,7 @@ GetPostgresDuckDBType(duckdb::LogicalType type) {
 		}
 	}
 	default: {
-		return InvalidOid;
+		elog(ERROR, "Could not convert DuckDB type: %s to Postgres type", type.ToString().c_str());
 	}
 	}
 }


### PR DESCRIPTION
edit: this addresses the error message mentioned in #69