### PR TITLE
Add .deps directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .clangd
 .depend
+.deps
 
 .vscode
 .ccls


### PR DESCRIPTION
This directory is generated if Postgres is compiled with --enable-depend
