### PR TITLE
Add a clang-format GitHub action

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,6 +13,18 @@ on:
       - '.github/workflows/**'
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout pg_duckdb extension code
+        uses: actions/checkout@v4
+      - name: Fetch main branch
+        run: git fetch --depth=1 origin +main:refs/remotes/origin/main
+      - name: Install clang-format
+        run: sudo apt-get install clang-format
+      - name: Run clang-format
+        run: git clang-format refs/remotes/origin/main --diff
   build-and-test:
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,7 @@ lintcheck:
 	$(RM) -f .depend
 	$(foreach SRC,$(SRCS),$(CXX) $(CPPFLAGS) -I$(INCLUDEDIR) -I$(INCLUDEDIR_SERVER) -MM -MT $(SRC:.cpp=.o) $(SRC) >> .depend;)
 
+format:
+	git clang-format origin/main
+
 include .depend

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -21,7 +21,6 @@ _PG_init(void) {
 	duckdb_init_hooks();
 	duckdb_init_node();
 }
-
 }
 
 /* clang-format off */

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -75,7 +75,7 @@ duckdb_planner(Query *parse, const char *query_string, int cursorOptions, ParamL
 
 static void
 duckdb_utility(PlannedStmt *pstmt, const char *queryString, bool readOnlyTree, ProcessUtilityContext context,
-              ParamListInfo params, struct QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc) {
+               ParamListInfo params, struct QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc) {
 	Node *parsetree = pstmt->utilityStmt;
 	if (duckdb_execution && is_duckdb_extension_registered() && IsA(parsetree, CopyStmt)) {
 		uint64 processed;

--- a/src/pgduckdb_memory_allocator.cpp
+++ b/src/pgduckdb_memory_allocator.cpp
@@ -20,7 +20,7 @@ DuckdbFree(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t pointe
 
 duckdb::data_ptr_t
 DuckdbReallocate(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t pointer, duckdb::idx_t old_size,
-                duckdb::idx_t size) {
+                 duckdb::idx_t size) {
 	return reinterpret_cast<duckdb::data_ptr_t>(repalloc(pointer, size));
 }
 

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -82,8 +82,8 @@ duckdb_create_plan(Query *query, const char *queryString, ParamListInfo boundPar
 		Var *var = makeVar(INDEX_VAR, i + 1, postgresColumnOid, typtup->typtypmod, typtup->typcollation, 0);
 
 		duckdbNode->custom_scan_tlist =
-			lappend(duckdbNode->custom_scan_tlist,
-					makeTargetEntry((Expr *)var, i + 1, (char *)preparedQuery->GetNames()[i].c_str(), false));
+		    lappend(duckdbNode->custom_scan_tlist,
+		            makeTargetEntry((Expr *)var, i + 1, (char *)preparedQuery->GetNames()[i].c_str(), false));
 
 		ReleaseSysCache(tp);
 	}

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -87,7 +87,7 @@ duckdb_copy(PlannedStmt *pstmt, const char *queryString, struct QueryEnvironment
 	/* Copy `filename` should start with S3/GS/R2 prefix */
 	if (duckdb::string(copyStmt->filename).rfind(duckdbCopyS3FilenamePrefix, 0) &&
 	    duckdb::string(copyStmt->filename).rfind(duckdbCopyGCSFilenamePrefix, 0) &&
-		duckdb::string(copyStmt->filename).rfind(duckdbCopyR2FilenamePrefix, 0)) {
+	    duckdb::string(copyStmt->filename).rfind(duckdbCopyR2FilenamePrefix, 0)) {
 		return false;
 	}
 


### PR DESCRIPTION
I had a few times that clang-format would change code that I did not
touch. This adds a GitHub action that checks if the code in a PR is
correctly formatted.
