### PR TITLE
Change "CREATE EXTENSION duckdb" to "CREATE EXTENSION pg_duckdb"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: duckdb install-duckdb clean-duckdb lintcheck check-regression-duckdb clean-regression .depend
 
-MODULE_big = duckdb
-EXTENSION = duckdb
-DATA = duckdb.control $(wildcard sql/duckdb--*.sql)
+MODULE_big = pg_duckdb
+EXTENSION = pg_duckdb
+DATA = pg_duckdb.control $(wildcard sql/pg_duckdb--*.sql)
 
 SRCS = src/scan/heap_reader.cpp \
 	   src/scan/index_scan_utils.cpp \

--- a/pg_duckdb.control
+++ b/pg_duckdb.control
@@ -1,4 +1,4 @@
 comment = 'DuckDB Embedded in Postgres'
 default_version = '0.0.1'
-module_pathname = '$libdir/duckdb'
+module_pathname = '$libdir/pg_duckdb'
 relocatable = false

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -1,4 +1,4 @@
-LOAD 'duckdb';
+LOAD 'pg_duckdb';
 
 CREATE OR REPLACE FUNCTION read_parquet(path text)
 RETURNS SETOF record LANGUAGE 'plpgsql' AS

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -18,7 +18,7 @@ static ProcessUtility_hook_type PrevProcessUtilityHook = NULL;
 
 static bool
 is_duckdb_extension_registered() {
-	return get_extension_oid("duckdb", true) != InvalidOid;
+	return get_extension_oid("pg_duckdb", true) != InvalidOid;
 }
 
 static bool

--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -7,8 +7,8 @@ include $(ROOT_DIR)/Makefile.global
 check-regression-duckdb:
 	TEST_DIR=$(CURDIR) $(pg_regress_check) \
 	--temp-config regression.conf \
-	--load-extension=duckdb \
-	--schedule schedule 
+	--load-extension=pg_duckdb \
+	--schedule schedule
 
 clean-regression:
 	rm -fr $(CURDIR)/tmp_check

--- a/test/regression/regression.conf
+++ b/test/regression/regression.conf
@@ -1,4 +1,4 @@
 # Configuration
 
-shared_preload_libraries = 'duckdb'
+shared_preload_libraries = 'pg_duckdb'
 log_temp_files = -1


### PR DESCRIPTION
The README mentioned that the way to install the extension is to use use
`CREATE EXTENSION pg_duckdb` but the actual code didn't actually match
that. Instead the extension was called `duckdb` not `pg_duckdb`.

This aligns both on `pg_duckdb`. I expect some ~~bike-shedding~~ healthy
discussion here. Another solution is obviously to align on `duckdb`
instead.

I definitely want to keep `duckdb` as the schema name, because it's
shorter and the tables/functions stored in this schema will read more
natural. But I think for `CREATE EXTENSION` it doesn't matter much which
of the two we use. The main reason why I went for `pg_duckdb` is because
we call the extension pg_duckdb in our readme all the time, and it
seemed a bit strange to then install something with a different name.

Closes #87