### PR TITLE
Set the version of clang-format to be the same as used in DuckDB

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,6 @@ AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AlwaysBreakAfterReturnType: AllDefinitions
 AlignAfterOpenBracket: Align
-BracedInitializerIndentWidth: 4
 IncludeBlocks: Preserve
 IncludeCategories: # we want to ensure postgres.h appear first
   - Regex:           '^"postgres\.h"'
@@ -36,4 +35,3 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: Yes
 Language: Cpp
 AccessModifierOffset: -4
-InsertNewlineAtEOF: true

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -21,6 +21,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
+      - name: Add LLVM repository
+        run: sudo apt-get install -y wget software-properties-common && \
+             wget https://apt.llvm.org/llvm-snapshot.gpg.key && \
+             sudo apt-key add llvm-snapshot.gpg.key && \
+             sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
       - name: Install clang-format
         run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11
       - name: Run clang-format

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,9 +22,11 @@ jobs:
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Add LLVM repository
-        run: curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-             sudo apt-get install -y software-properties-common && \
-             sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+        run: |
+          apt-get update
+          apt-get install -y curl software-properties-common
+          curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+          add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
 
       - name: Install clang-format
         run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Add LLVM repository
-        run: sudo apt-get install -y wget software-properties-common && \
-             wget https://apt.llvm.org/llvm-snapshot.gpg.key && \
-             sudo apt-key add llvm-snapshot.gpg.key && \
+        run: curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
+             sudo apt-get install -y software-properties-common && \
              sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+
       - name: Install clang-format
         run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11
       - name: Run clang-format

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Install clang-format
-        run: sudo apt-get install clang-format-11
+        run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11
       - name: Run clang-format
         run: git clang-format refs/remotes/origin/main --diff
   build-and-test:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -21,16 +21,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
-      - name: Add LLVM repository
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl software-properties-common
-          sudo add-apt-repository universe
-          curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+      - name: Set up Python 3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-      - name: Install clang-format
-        run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11
+      - name: Install clang-format (11.0.1)
+        run: python3 -m pip install "clang-format==11.0.1"
       - name: Run clang-format
         run: git clang-format refs/remotes/origin/main --diff
   build-and-test:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -23,10 +23,10 @@ jobs:
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Add LLVM repository
         run: |
-          apt-get update
-          apt-get install -y curl software-properties-common
-          curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-          add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+          sudo apt-get update
+          sudo apt-get install -y curl software-properties-common
+          curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
 
       - name: Install clang-format
         run: sudo apt-get update -y -qq && sudo apt-get install clang-format-11

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
-      - name: Set up Python 3
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -11,6 +11,7 @@ on:
       - duckdb.control
       - third_party/duckdb
       - '.github/workflows/**'
+      - .clang-format
 
 jobs:
   clang-format:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Install clang-format
-        run: sudo apt-get install "clang-format=11.0.1"
+        run: sudo apt-get install clang-format-11
       - name: Run clang-format
         run: git clang-format refs/remotes/origin/main --diff
   build-and-test:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Fetch main branch
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - name: Install clang-format
-        run: sudo apt-get install clang-format
+        run: sudo apt-get install "clang-format=11.0.1"
       - name: Run clang-format
         run: git clang-format refs/remotes/origin/main --diff
   build-and-test:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y curl software-properties-common
+          sudo add-apt-repository universe
           curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
 


### PR DESCRIPTION
Behavior differs between versions of clang-format, to be sure that the entire codebase doesn't have to be reformatted when clang-format updates I've locked it to 11.0.1 (the same that DuckDB uses)

Primary reason I'm making this change is that I am currently having to switch back and forth my clang-format version, which I would prefer to not do.