### PR TITLE
Make DuckDB a singleton per con process

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -10,8 +10,47 @@ extern "C" {
 
 namespace pgduckdb {
 
-duckdb::unique_ptr<duckdb::DuckDB> DuckdbOpenDatabase();
-duckdb::unique_ptr<duckdb::Connection> DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info,
-                                                              List *needed_columns, const char *query);
+class Connection : public duckdb::Connection {
+public:
+	Connection(duckdb::DuckDB &db) : duckdb::Connection(db), tracked_replacement_scan_id(0) {
+	}
+
+	virtual ~Connection();
+
+	void
+	SetTrackedReplacementScanId(const uint32_t id) {
+		tracked_replacement_scan_id = id;
+	}
+
+private:
+	uint32_t tracked_replacement_scan_id;
+};
+
+class DuckDBManager {
+public:
+	static inline const DuckDBManager &
+	Get() {
+		static DuckDBManager instance;
+		return instance;
+	}
+
+	inline duckdb::DuckDB &
+	GetDatabase() const {
+		return *database;
+	}
+
+private:
+	DuckDBManager();
+	void InitializeDatabase();
+
+	void LoadSecrets(duckdb::ClientContext &);
+	void LoadExtensions(duckdb::ClientContext &);
+	void LoadFunctions(duckdb::ClientContext &);
+
+	duckdb::unique_ptr<duckdb::DuckDB> database;
+};
+
+duckdb::unique_ptr<Connection> DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info, List *needed_columns,
+                                                      const char *query);
 
 } // namespace pgduckdb

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -45,7 +45,9 @@ public:
 	                            const char *query_string)
 	    : m_rtables(rtables), m_query_planner_info(query_planner_info), m_needed_columns(needed_columns),
 	      m_query_string(query_string) {
+		id = id_counter.fetch_add(1);
 	}
+
 	~PostgresReplacementScanData() override {};
 
 public:
@@ -53,6 +55,10 @@ public:
 	PlannerInfo *m_query_planner_info;
 	List *m_needed_columns;
 	std::string m_query_string;
+	uint32_t id;
+
+private:
+	static std::atomic<uint32_t> id_counter;
 };
 
 duckdb::unique_ptr<duckdb::TableRef> PostgresReplacementScan(duckdb::ClientContext &context,

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -8,6 +8,7 @@ extern "C" {
 
 #include "pgduckdb/pgduckdb_node.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
 
 /* global variables */
 CustomScanMethods duckdb_scan_scan_methods;
@@ -17,7 +18,7 @@ static CustomExecMethods duckdb_scan_exec_methods;
 
 typedef struct DuckdbScanState {
 	CustomScanState css; /* must be first field */
-	duckdb::Connection *duckdb_connection;
+	pgduckdb::Connection *duckdb_connection;
 	duckdb::PreparedStatement *prepared_statement;
 	bool is_executed;
 	bool fetch_next;
@@ -46,7 +47,7 @@ static Node *
 Duckdb_CreateCustomScanState(CustomScan *cscan) {
 	DuckdbScanState *duckdb_scan_state = (DuckdbScanState *)newNode(sizeof(DuckdbScanState), T_CustomScanState);
 	CustomScanState *custom_scan_state = &duckdb_scan_state->css;
-	duckdb_scan_state->duckdb_connection = (duckdb::Connection *)linitial(cscan->custom_private);
+	duckdb_scan_state->duckdb_connection = (pgduckdb::Connection *)linitial(cscan->custom_private);
 	duckdb_scan_state->prepared_statement = (duckdb::PreparedStatement *)lsecond(cscan->custom_private);
 	duckdb_scan_state->is_executed = false;
 	duckdb_scan_state->fetch_next = true;

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -107,8 +107,8 @@ ReadDuckdbExtensions() {
 
 static bool
 DuckdbInstallExtension(Datum name) {
-	auto db = DuckdbOpenDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(*db);
+	auto &db = DuckDBManager::Get().GetDatabase();
+	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
 	auto &context = *connection->context;
 
 	auto extension_name = DatumToString(name);

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -29,6 +29,8 @@ extern "C" {
 
 namespace pgduckdb {
 
+std::atomic<uint32_t> PostgresReplacementScanData::id_counter = 0;
+
 void
 PostgresScanGlobalState::InitGlobalState(duckdb::TableFunctionInitInput &input) {
 	/* SELECT COUNT(*) FROM */


### PR DESCRIPTION
* add a `DuckDBManager` class to hold the singleton and manage instantiation
* give `PostgresReplacementScanData` an identifier (auto-incremented integer)
* extends `DuckDB::Connection` to hold replacement scan id and remove it when it is destroyed