### PR TITLE
Add support for `REGCLASSOID` type

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -543,8 +543,10 @@ ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute) {
 		}
 		return duck_type;
 	}
-	default:
-		return duckdb::LogicalType::USER("UnsupportedPostgresType");
+	default: {
+		std::string name = "UnsupportedPostgresType (Oid=" + std::to_string(type) + ")";
+		return duckdb::LogicalType::USER(name);
+	}
 	}
 }
 

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -543,6 +543,8 @@ ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute) {
 		}
 		return duck_type;
 	}
+	case REGCLASSOID:
+		return duckdb::LogicalTypeId::INTEGER;
 	default: {
 		std::string name = "UnsupportedPostgresType (Oid=" + std::to_string(type) + ")";
 		return duckdb::LogicalType::USER(name);

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -228,6 +228,15 @@ SELECT * FROM json_tbl;
  {}
 (4 rows)
 
+-- REGCLASSOID
+CREATE TABLE regclass_tbl (a REGCLASS);
+INSERT INTO regclass_tbl SELECT CAST(42 as REGCLASS);
+SELECT * FROM regclass_tbl;
+ a
+----
+ 42
+(1 row)
+
 DROP TABLE chr;
 DROP TABLE small;
 DROP TABLE intgr;
@@ -244,3 +253,4 @@ DROP TABLE bigint_numeric;
 DROP TABLE hugeint_numeric;
 DROP TABLE uuid_tbl;
 DROP TABLE json_tbl;
+DROP TABLE regclass_tbl;

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -232,7 +232,7 @@ SELECT * FROM json_tbl;
 CREATE TABLE regclass_tbl (a REGCLASS);
 INSERT INTO regclass_tbl SELECT CAST(42 as REGCLASS);
 SELECT * FROM regclass_tbl;
- a
+ a  
 ----
  42
 (1 row)

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -128,10 +128,6 @@ SELECT * FROM json_tbl;
 CREATE TABLE regclass_tbl (a REGCLASS);
 INSERT INTO regclass_tbl SELECT CAST(42 as REGCLASS);
 SELECT * FROM regclass_tbl;
- a
-----
- 42
-(1 row)
 
 DROP TABLE chr;
 DROP TABLE small;

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -124,6 +124,15 @@ INSERT INTO json_tbl SELECT CAST(a as JSON) FROM (VALUES
 ) t(a);
 SELECT * FROM json_tbl;
 
+-- REGCLASSOID
+CREATE TABLE regclass_tbl (a REGCLASS);
+INSERT INTO regclass_tbl SELECT CAST(42 as REGCLASS);
+SELECT * FROM regclass_tbl;
+ a
+----
+ 42
+(1 row)
+
 DROP TABLE chr;
 DROP TABLE small;
 DROP TABLE intgr;
@@ -140,3 +149,4 @@ DROP TABLE bigint_numeric;
 DROP TABLE hugeint_numeric;
 DROP TABLE uuid_tbl;
 DROP TABLE json_tbl;
+DROP TABLE regclass_tbl;


### PR DESCRIPTION
Small QoL PR that does two minor thing:
* shows the Oid when the type in unsupported
* add mapping for PG's `REGCLASSOID` type