### PR TITLE
Cache pg & duckdb builds

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -53,9 +53,26 @@ jobs:
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
+          submodules: 'recursive'
           path: duckdb
 
+      - name: Compute DuckDB SHA
+        id: versions
+        run: |
+          pushd duckdb
+          DUCKDB_SHA=`git ls-tree HEAD third_party/duckdb --format='%(objectname)'`
+          echo "duckdb_sha=${DUCKDB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Got DUCKDB_SHA='${DUCKDB_SHA}'"
+
+      - name: Setup PG build cache
+        id: cache-pg-build
+        uses: actions/cache@v4
+        with:
+          path: postgres/inst
+          key: pg-build-${{ matrix.version }}
+
       - name: Checkout and build PostgreSQL code
+        if: steps.cache-pg-build.outputs.cache-hit != 'true'
         run: |
           rm -rf postgres
           git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/postgres/postgres.git
@@ -64,12 +81,18 @@ jobs:
           ./configure --prefix=$PWD/inst/ --enable-cassert --enable-debug --with-openssl --with-icu --with-libxml
           make -j8 install
 
+      - name: Setup DuckDB build cache
+        id: cache-duckdb-build
+        uses: actions/cache@v4
+        with:
+          path: duckdb/third_party/duckdb/build/
+          key: duckdb-build-${{ steps.versions.outputs.duckdb_sha }}
+
       - name: Build and test pg_duckdb extension
         id: regression-tests
         run: |
           export PATH="${PWD}/postgres/inst/bin:$PATH"
           pushd duckdb
-          git submodule update --init --recursive
           make
           make install
           make installcheck


### PR DESCRIPTION
Bring the build time from [~4minutes](https://github.com/duckdb/pg_duckdb/actions/runs/10310110288/attempts/1) down to [~1 minute](https://github.com/duckdb/pg_duckdb/actions/runs/10310257549) by caching PG and DuckDB's builds.

* PG is cached based on the branch checked out
* DuckDB is cached based on the sha committed as the submodule