### PR TITLE
Fix a typo for global_state variable

### DIFF
--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -110,9 +110,9 @@ duckdb::unique_ptr<duckdb::LocalTableFunctionState>
 PostgresSeqScanFunction::PostgresSeqScanInitLocal(duckdb::ExecutionContext &context,
                                                   duckdb::TableFunctionInitInput &input,
                                                   duckdb::GlobalTableFunctionState *gstate) {
-	auto glboal_state = reinterpret_cast<PostgresSeqScanGlobalState *>(gstate);
+	auto global_state = reinterpret_cast<PostgresSeqScanGlobalState *>(gstate);
 	return duckdb::make_uniq<PostgresSeqScanLocalState>(
-	    glboal_state->m_relation, glboal_state->m_heap_reader_global_state, glboal_state->m_global_state);
+	    global_state->m_relation, global_state->m_heap_reader_global_state, global_state->m_global_state);
 }
 
 void


### PR DESCRIPTION
As $subject said, there is a variable name typo in [src/scan/postgres_seq_scan.cpp](https://github.com/duckdb/pg_duckdb/blob/main/src/scan/postgres_seq_scan.cpp#L113).