### PR TITLE
Run CI on PRs from forks

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,6 +1,19 @@
 name: pg_duckdb Build and Test
 on:
   push:
+    branches: ["main"]
+    tags: ["v*"]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'include/**'
+      - 'sql/**'
+      - Makefile
+      - Makefile.global
+      - duckdb.control
+      - third_party/duckdb
+      - '.github/workflows/**'
+  pull_request:
     paths:
       - 'src/**'
       - 'test/**'


### PR DESCRIPTION
Because CI was only triggered on push it would not be run on PRs created from forks. This fixes that. I noticed this in #122. This continues to run CI on `main` and tags starting with `v` so we get nice green check marks for both of those.
