### PR TITLE
Disallow modifying CTEs

### DIFF
--- a/test/regression/expected/cte.out
+++ b/test/regression/expected/cte.out
@@ -1,0 +1,11 @@
+CREATE TABLE t(a INT);
+-- Not supported by DuckDB, so we shouldn't send it there
+WITH modifying_cte AS (
+    INSERT INTO t VALUES (1) RETURNING *
+) select * from modifying_cte;
+ a 
+---
+ 1
+(1 row)
+
+DROP TABLE t;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -7,3 +7,4 @@ test: views
 test: projection_pushdown_unsupported_type
 test: materialized_view
 test: hugeint_conversion
+test: cte

--- a/test/regression/sql/cte.sql
+++ b/test/regression/sql/cte.sql
@@ -1,0 +1,8 @@
+CREATE TABLE t(a INT);
+
+-- Not supported by DuckDB, so we shouldn't send it there
+WITH modifying_cte AS (
+    INSERT INTO t VALUES (1) RETURNING *
+) select * from modifying_cte;
+
+DROP TABLE t;


### PR DESCRIPTION
This adds support to detect modifying CTEs and not use DuckDB in that case.
