### PR TITLE
Add EXPLAIN ANALYZE support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ SRCS = src/scan/heap_reader.cpp \
 	   src/scan/postgres_scan.cpp \
 	   src/scan/postgres_seq_scan.cpp \
 	   src/utility/copy.cpp \
+	   src/vendor/pg_explain.cpp \
 	   src/pgduckdb_metadata_cache.cpp \
 	   src/pgduckdb_detoast.cpp \
 	   src/pgduckdb_duckdb.cpp \

--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -5,4 +5,6 @@ extern "C" {
 #include "optimizer/planner.h"
 }
 
+extern bool duckdb_explain_analyze;
+
 PlannedStmt *DuckdbPlanNode(Query *parse, int cursor_options, ParamListInfo bound_params);

--- a/include/pgduckdb/vendor/pg_explain.hpp
+++ b/include/pgduckdb/vendor/pg_explain.hpp
@@ -1,0 +1,11 @@
+#pragma once
+extern "C" {
+#include "postgres.h"
+
+#include "commands/explain.h"
+
+#if PG_VERSION_NUM < 170000
+void standard_ExplainOneQuery(Query *query, int cursorOptions, IntoClause *into, ExplainState *es,
+                              const char *queryString, ParamListInfo params, QueryEnvironment *queryEnv);
+#endif
+}

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -17,6 +17,8 @@ extern "C" {
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
 
+bool duckdb_explain_analyze = false;
+
 static PlannerInfo *
 PlanQuery(Query *parse, ParamListInfo bound_params) {
 
@@ -106,7 +108,11 @@ DuckdbPlanNode(Query *parse, int cursor_options, ParamListInfo bound_params) {
 	const char *query_string = pg_get_querydef(parse, false);
 
 	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
-		query_string = psprintf("EXPLAIN %s", query_string);
+		if (duckdb_explain_analyze) {
+			query_string = psprintf("EXPLAIN ANALYZE %s", query_string);
+		} else {
+			query_string = psprintf("EXPLAIN %s", query_string);
+		}
 	}
 	/* We need to check can we DuckDB create plan */
 	Plan *duckdb_plan = (Plan *)castNode(CustomScan, CreatePlan(parse, query_string, bound_params));

--- a/src/vendor/pg_explain.cpp
+++ b/src/vendor/pg_explain.cpp
@@ -1,0 +1,55 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_explain.cpp
+ *	  Explain query execution plans
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994-5, Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+extern "C" {
+#include "postgres.h"
+
+#include "optimizer/planner.h"
+#include "tcop/tcopprot.h"
+
+#include "pgduckdb/vendor/pg_explain.hpp"
+
+#if PG_VERSION_NUM < 170000
+
+/*
+ * standard_ExplainOneQuery -
+ *	  print out the execution plan for one Query, without calling a hook.
+ *
+ * This is a PG16 version of the standard ExplainOneQuery function that was
+ * introduced in PG17.
+ */
+void
+standard_ExplainOneQuery(Query *query, int cursorOptions, IntoClause *into, ExplainState *es, const char *queryString,
+                         ParamListInfo params, QueryEnvironment *queryEnv) {
+	PlannedStmt *plan;
+	instr_time planstart, planduration;
+	BufferUsage bufusage_start, bufusage;
+
+	if (es->buffers)
+		bufusage_start = pgBufferUsage;
+	INSTR_TIME_SET_CURRENT(planstart);
+
+	/* plan the query */
+	plan = pg_plan_query(query, queryString, cursorOptions, params);
+
+	INSTR_TIME_SET_CURRENT(planduration);
+	INSTR_TIME_SUBTRACT(planduration, planstart);
+
+	/* calc differences of buffer counters. */
+	if (es->buffers) {
+		memset(&bufusage, 0, sizeof(BufferUsage));
+		BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &bufusage_start);
+	}
+
+	/* run it (if needed) and produce output */
+	ExplainOnePlan(plan, into, es, queryString, params, queryEnv, &planduration, (es->buffers ? &bufusage : NULL));
+}
+#endif
+}


### PR DESCRIPTION
This adds support for forwarding `EXPLAIN ANALYZE` to DuckDB.

A useful side-effect for debugging issues of running `EXPLAIN ANALYZE`, is that it shows the actual query that was executed in duckdb.