### PR TITLE
Add support for filtering with varchar

### DIFF
--- a/src/pgduckdb_filter.cpp
+++ b/src/pgduckdb_filter.cpp
@@ -28,11 +28,8 @@ StringFilterOperation(Datum &value, const duckdb::Value &constant) {
 	}
 
 	bool should_free = false;
-	auto detoasted_value = DetoastPostgresDatum(reinterpret_cast<varlena *>(value), &should_free);
-
-	const auto ptr = (text*)DatumGetPointer(detoasted_value);
-	text* tunpacked = pg_detoast_datum_packed(ptr);
-	const auto datum_sv =  std::string_view((char*)VARDATA_ANY(tunpacked), VARSIZE_ANY_EXHDR(tunpacked));
+	const auto detoasted_value = DetoastPostgresDatum(reinterpret_cast<varlena *>(value), &should_free);
+	const auto datum_sv =  std::string_view((const char*)VARDATA_ANY(detoasted_value), VARSIZE_ANY_EXHDR(detoasted_value));
 	const auto val = duckdb::StringValue::Get(constant);
 	const auto val_sv =  std::string_view(val);
 	const bool res = OP::Operation(datum_sv, val_sv);

--- a/src/pgduckdb_filter.cpp
+++ b/src/pgduckdb_filter.cpp
@@ -23,34 +23,25 @@ FilterOperationSwitch(Datum &value, duckdb::Value &constant, Oid type_oid) {
 	switch (type_oid) {
 	case BOOLOID:
 		return TemplatedFilterOperation<bool, OP>(value, constant);
-		break;
 	case CHAROID:
 		return TemplatedFilterOperation<uint8_t, OP>(value, constant);
-		break;
 	case INT2OID:
 		return TemplatedFilterOperation<int16_t, OP>(value, constant);
-		break;
 	case INT4OID:
 		return TemplatedFilterOperation<int32_t, OP>(value, constant);
-		break;
 	case INT8OID:
 		return TemplatedFilterOperation<int64_t, OP>(value, constant);
-		break;
 	case FLOAT4OID:
 		return TemplatedFilterOperation<float, OP>(value, constant);
-		break;
 	case FLOAT8OID:
 		return TemplatedFilterOperation<double, OP>(value, constant);
-		break;
 	case DATEOID: {
 		Datum date_datum = static_cast<int32_t>(value + pgduckdb::PGDUCKDB_DUCK_DATE_OFFSET);
 		return TemplatedFilterOperation<int32_t, OP>(date_datum, constant);
-		break;
 	}
 	case TIMESTAMPOID: {
 		Datum timestamp_datum = static_cast<int64_t>(value + pgduckdb::PGDUCKDB_DUCK_TIMESTAMP_OFFSET);
 		return TemplatedFilterOperation<int64_t, OP>(timestamp_datum, constant);
-		break;
 	}
 	default:
 		elog(ERROR, "(DuckDB/FilterOperationSwitch) Unsupported duckdb type: %d", type_oid);

--- a/src/pgduckdb_filter.cpp
+++ b/src/pgduckdb_filter.cpp
@@ -60,6 +60,7 @@ FilterOperationSwitch(Datum &value, duckdb::Value &constant, Oid type_oid) {
 		Datum timestamp_datum = static_cast<int64_t>(value + pgduckdb::PGDUCKDB_DUCK_TIMESTAMP_OFFSET);
 		return TemplatedFilterOperation<int64_t, OP>(timestamp_datum, constant);
 	}
+	case TEXTOID:
 	case VARCHAROID:
 		return StringFilterOperation<OP>(value, constant);
 	default:

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -71,6 +71,24 @@ SELECT * FROM varchar_tbl WHERE a = 'test';
  test
 (1 row)
 
+--- TEXT
+CREATE TABLE text_tbl(a TEXT);
+INSERT INTO text_tbl SELECT CAST(a AS TEXT) from (VALUES (''), (NULL), ('test'), ('this is a long string')) t(a);
+SELECT * FROM text_tbl;
+           a           
+-----------------------
+ 
+ 
+ test
+ this is a long string
+(4 rows)
+
+SELECT * FROM text_tbl WHERE a = 'test';
+  a   
+------
+ test
+(1 row)
+
 -- DATE
 CREATE TABLE date_tbl(a DATE);
 INSERT INTO date_tbl SELECT CAST(a AS DATE) FROM (VALUES ('2022-04-29'::DATE), (NULL), ('2023-05-15'::DATE)) t(a);
@@ -249,6 +267,7 @@ DROP TABLE small;
 DROP TABLE intgr;
 DROP TABLE big;
 DROP TABLE varchar_tbl;
+DROP TABLE text_tbl;
 DROP TABLE date_tbl;
 DROP TABLE timestamp_tbl;
 DROP TABLE float4_tbl;

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -65,6 +65,12 @@ SELECT * FROM varchar_tbl;
  this is a long string
 (4 rows)
 
+SELECT * FROM varchar_tbl WHERE a = 'test';
+  a   
+------
+ test
+(1 row)
+
 -- DATE
 CREATE TABLE date_tbl(a DATE);
 INSERT INTO date_tbl SELECT CAST(a AS DATE) FROM (VALUES ('2022-04-29'::DATE), (NULL), ('2023-05-15'::DATE)) t(a);

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -27,6 +27,7 @@ SELECT * FROM bool_tbl;
 CREATE TABLE varchar_tbl(a VARCHAR);
 INSERT INTO varchar_tbl SELECT CAST(a AS VARCHAR) from (VALUES (''), (NULL), ('test'), ('this is a long string')) t(a);
 SELECT * FROM varchar_tbl;
+SELECT * FROM varchar_tbl WHERE a = 'test';
 
 -- DATE
 CREATE TABLE date_tbl(a DATE);

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -29,6 +29,12 @@ INSERT INTO varchar_tbl SELECT CAST(a AS VARCHAR) from (VALUES (''), (NULL), ('t
 SELECT * FROM varchar_tbl;
 SELECT * FROM varchar_tbl WHERE a = 'test';
 
+--- TEXT
+CREATE TABLE text_tbl(a TEXT);
+INSERT INTO text_tbl SELECT CAST(a AS TEXT) from (VALUES (''), (NULL), ('test'), ('this is a long string')) t(a);
+SELECT * FROM text_tbl;
+SELECT * FROM text_tbl WHERE a = 'test';
+
 -- DATE
 CREATE TABLE date_tbl(a DATE);
 INSERT INTO date_tbl SELECT CAST(a AS DATE) FROM (VALUES ('2022-04-29'::DATE), (NULL), ('2023-05-15'::DATE)) t(a);
@@ -135,6 +141,7 @@ DROP TABLE small;
 DROP TABLE intgr;
 DROP TABLE big;
 DROP TABLE varchar_tbl;
+DROP TABLE text_tbl;
 DROP TABLE date_tbl;
 DROP TABLE timestamp_tbl;
 DROP TABLE float4_tbl;


### PR DESCRIPTION
Allow to filter with a `VARCHAR`, eg:

```sql
SELECT * FROM varchar_tbl WHERE a = 'test';
```