### PR TITLE
Allow make installcheck to use the -j flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ check-regression-duckdb:
 clean-regression:
 	$(MAKE) -C test/regression clean-regression
 
-installcheck: all install check-regression-duckdb
+installcheck: all install
+	$(MAKE) check-regression-duckdb
 
 FULL_DUCKDB_LIB = third_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src/$(DUCKDB_LIB)
 duckdb: third_party/duckdb/Makefile $(FULL_DUCKDB_LIB)


### PR DESCRIPTION
When running with `make installcheck -j20`, the regression tests were
started in parallel with the build. This means regression tests will
test the old binaries if any of the source files changed since the last
`make install`. This fixes that by making sure the tests are only
started after the build has completed.
