### PR TITLE
Add support for using http to connect S3

### DIFF
--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -6,13 +6,14 @@
 namespace pgduckdb {
 
 /* constants for duckdb.secrets */
-#define Natts_duckdb_secret              6
+#define Natts_duckdb_secret              7
 #define Anum_duckdb_secret_type          1
 #define Anum_duckdb_secret_id            2
 #define Anum_duckdb_secret_secret        3
 #define Anum_duckdb_secret_region        4
 #define Anum_duckdb_secret_endpoint      5
 #define Anum_duckdb_secret_r2_account_id 6
+#define Anum_duckdb_secret_use_ssl       7
 
 typedef struct DuckdbSecret {
 	std::string type;
@@ -21,6 +22,7 @@ typedef struct DuckdbSecret {
 	std::string region;
 	std::string endpoint;
 	std::string r2_account_id;
+	bool		use_ssl;
 } DuckdbSecret;
 
 extern std::vector<DuckdbSecret> ReadDuckdbSecrets();

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -117,6 +117,7 @@ CREATE TABLE secrets (
     region TEXT,
     endpoint TEXT,
     r2_account_id TEXT,
+    use_ssl BOOLEAN DEFAULT true,
     CONSTRAINT type_constraint CHECK (type IN ('S3', 'GCS', 'R2'))
 );
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -118,7 +118,7 @@ DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info, List *needed_co
 			appendStringInfo(secret_key, ", ACCOUNT_ID '%s'", secret.endpoint.c_str());
 		}
 		if (!secret.use_ssl) {
-			appendStringInfo(secret_key, ", USE_SSL '%s'", "FALSE");
+			appendStringInfo(secret_key, ", USE_SSL 'FALSE'");
 		}
 		appendStringInfo(secret_key, ");");
 		context.Query(secret_key->data, false);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -117,6 +117,9 @@ DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info, List *needed_co
 		if (is_r2_cloud_secret) {
 			appendStringInfo(secret_key, ", ACCOUNT_ID '%s'", secret.endpoint.c_str());
 		}
+		if (!secret.use_ssl) {
+			appendStringInfo(secret_key, ", USE_SSL '%s'", "FALSE");
+		}
 		appendStringInfo(secret_key, ");");
 		context.Query(secret_key->data, false);
 		pfree(secret_key->data);

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -71,6 +71,10 @@ ReadDuckdbSecrets() {
 		if (!is_null_array[Anum_duckdb_secret_r2_account_id - 1])
 			secret.endpoint = DatumToString(datum_array[Anum_duckdb_secret_r2_account_id - 1]);
 
+		if (!is_null_array[Anum_duckdb_secret_use_ssl - 1])
+			secret.use_ssl = DatumGetBool(DatumGetBool(datum_array[Anum_duckdb_secret_use_ssl - 1]));
+		else
+			secret.use_ssl = true;
 		duckdb_secrets.push_back(secret);
 	}
 


### PR DESCRIPTION
Currently, We always use HTTPS to connect to S3. We should also support HTTP to do so.