### PR TITLE
Add a NOTICE file which contains the Postgres license

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,31 @@
+NOTICES
+
+This repoisitory contains some source code from other projects. The original
+copyright notices are included below to abide by their licenses. These notices
+**do not** apply to the entire repository.
+
+-------------------------------------------------------------------------------
+
+PostgreSQL Database Management System
+(formerly known as Postgres, then as Postgres95)
+
+Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.


### PR DESCRIPTION
The PostgreSQL license is very liberal but, like MIT and BSD, it does
require attribution and requires that the original license is included.
This adds a NOTICE file containing the license, because we've vendored
in a few files/functions from the Postgres repository and we'll likely need
to vendor in more.

If/when we decide to to merge #143 we should also include PgBouncer its
license. Which is the ISC license, which is also attribution-only.