### PR TITLE
Remove trailing whitespace and unnecessary newlines

### DIFF
--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -55,8 +55,6 @@ CREATE OR REPLACE FUNCTION read_csv(path text, all_varchar BOOLEAN DEFAULT FALSE
                                                timestampformat VARCHAR DEFAULT '',
                                                types TEXT[] DEFAULT ARRAY[]::TEXT[],
                                                union_by_name BOOLEAN DEFAULT FALSE)
-
-    
 RETURNS SETOF record LANGUAGE 'plpgsql' AS
 $func$
 BEGIN


### PR DESCRIPTION
In #99 some unnecessary whitespace was added. @mkaruza do you have editorconfig set up for your editor? Because the trailing whitespace should be handled by that.
