### PR TITLE
Don't add newlines and indentation when deparsing query

### DIFF
--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -96,7 +96,7 @@
 /* Standard conversion of a "bool pretty" option to detailed flags */
 #define GET_PRETTY_FLAGS(pretty) \
 	((pretty) ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) \
-	 : PRETTYFLAG_INDENT)
+	 : 0)
 
 /* Default line length for pretty-print wrapping: 0 means wrap always */
 #define WRAP_COLUMN_DEFAULT		0

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -95,7 +95,7 @@
 /* Standard conversion of a "bool pretty" option to detailed flags */
 #define GET_PRETTY_FLAGS(pretty) \
 	((pretty) ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) \
-	 : PRETTYFLAG_INDENT)
+	 : 0)
 
 /* Default line length for pretty-print wrapping: 0 means wrap always */
 #define WRAP_COLUMN_DEFAULT		0

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -5,5 +5,5 @@ insert into int_as_varchar SELECT * from (
 ) t(a);
 select a::INTEGER from int_as_varchar;
 ERROR:  Duckdb execute returned an error: Conversion Error: Could not convert string 'abc' to INT32
-LINE 1:  SELECT (a)::integer AS a
-                   ^
+LINE 1: SELECT (a)::integer AS a FROM int_as_varchar
+                  ^

--- a/test/regression/expected/views.out
+++ b/test/regression/expected/views.out
@@ -29,8 +29,8 @@ create view vw2 as select * from "s.t";
 select * from vw1, vw2;
 WARNING:  (DuckDB) Binder Error: Referenced table "t" not found!
 Candidate tables: "s.t"
-LINE 3:    FROM ( SELECT t."?column?"
-                         ^
+LINE 1: ...?column?", vw2."?column?" FROM (SELECT t."?column?" FROM s.t) vw1, (SELECT "s....
+                                                  ^
  ?column? | ?column? 
 ----------+----------
        21 |       42


### PR DESCRIPTION
Without this change our query deparsing logic adds newlines and indentation to the query it sends to DuckDB. While you might expect this to be a nice thing for debugging it actually makes debugging harder in many common cases.

A major one is that it results in very little context being provided by DuckDB if a query fails, because it only shows the failing line of the query and even very simple queries are split into multiple lines by `PRETTYFLAG_INDENT`. See the changed tests for the improvement in this area.

Also in EXPLAIN ANALYZE the query actually gets more unreadable because DuckDB seems to strip newlines from the query there, but still keeps indentation. So now there's a bunch of weird whitespace being added.

Before:

```
> explain analyze select b, b, b from a;
                                              QUERY PLAN
──────────────────────────────────────────────────────────────────────────────────────────────────────
 Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0) (actual time=2.033..2.102 rows=1 loops=1)
   DuckDB Execution Plan:

 ┌─────────────────────────────────────┐
 │┌───────────────────────────────────┐│
 ││    Query Profiling Information    ││
 │└───────────────────────────────────┘│
 └─────────────────────────────────────┘
 EXPLAIN ANALYZE  SELECT b,     b,     b    FROM a
```

After:

```
> explain analyze select b, b, b from a;
                                              QUERY PLAN
──────────────────────────────────────────────────────────────────────────────────────────────────────
 Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0) (actual time=2.047..2.115 rows=1 loops=1)
   DuckDB Execution Plan:

 ┌─────────────────────────────────────┐
 │┌───────────────────────────────────┐│
 ││    Query Profiling Information    ││
 │└───────────────────────────────────┘│
 └─────────────────────────────────────┘
 EXPLAIN ANALYZE SELECT b, b, b FROM a
```
