### PR TITLE
Make duckdb a singleton

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -10,7 +10,30 @@ extern "C" {
 
 namespace pgduckdb {
 
-duckdb::unique_ptr<duckdb::DuckDB> DuckdbOpenDatabase();
+class DuckDBManager {
+public:
+	static inline const DuckDBManager &
+	Get() {
+		static DuckDBManager instance;
+		return instance;
+	}
+
+	inline duckdb::DuckDB &
+	GetDatabase() const {
+		return *database;
+	}
+
+private:
+	DuckDBManager();
+	void InitializeDatabase();
+
+	void LoadSecrets(duckdb::ClientContext &);
+	void LoadExtensions(duckdb::ClientContext &);
+	void LoadFunctions(duckdb::ClientContext &);
+
+	duckdb::unique_ptr<duckdb::DuckDB> database;
+};
+
 duckdb::unique_ptr<duckdb::Connection> DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info,
                                                               List *needed_columns, const char *query);
 

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -39,14 +39,14 @@ public:
 	bool m_exhausted_scan;
 };
 
-struct PostgresReplacementScanData : public duckdb::ReplacementScanData {
+struct PostgresReplacementScanDataClientContextState : public duckdb::ClientContextState {
 public:
-	PostgresReplacementScanData(List *rtables, PlannerInfo *query_planner_info, List *needed_columns,
+	PostgresReplacementScanDataClientContextState(List *rtables, PlannerInfo *query_planner_info, List *needed_columns,
 	                            const char *query_string)
 	    : m_rtables(rtables), m_query_planner_info(query_planner_info), m_needed_columns(needed_columns),
 	      m_query_string(query_string) {
 	}
-	~PostgresReplacementScanData() override {};
+	~PostgresReplacementScanDataClientContextState() override {};
 
 public:
 	List *m_rtables;

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -1,3 +1,5 @@
+#include "duckdb.hpp"
+
 extern "C" {
 #include "postgres.h"
 #include "catalog/pg_namespace.h"

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -114,8 +114,8 @@ ReadDuckdbExtensions() {
 
 static bool
 DuckdbInstallExtension(Datum name) {
-	auto db = DuckdbOpenDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(*db);
+	auto &db = DuckDBManager::Get().GetDatabase();
+	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
 	auto &context = *connection->context;
 
 	auto extension_name = DatumToString(name);


### PR DESCRIPTION
Based on work by @Y-- and PR #102 and #147. This basically extracts the work from there into a separate PR, so it can be merged before some of the open TODOs related to prepared statements/extended protocol are resolved.
