### PR TITLE
Handle errors in execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,10 +128,11 @@ coding styles.
 ## Error Handling
 
 * Use exceptions **only** when an error is encountered that terminates a query (e.g. parser error, table not found). Exceptions should only be used for **exceptional** situations. For regular errors that do not break the execution flow (e.g. errors you **expect** might occur) use a return value instead.
-* *Exception* should be used in code that is executed inside duckdb engine.
-* Use PostgreSQL *elog* API to report messages back to user. Using *ERROR* is strictly forbiden to use as it can brake execution and lead to
-unexpected memory problems - *ERROR* is only used in duckdb node to early bail out execution in case of query preparation error or execution interruption.
-* Calling PostgreSQL native functions needs to be used with *PostgresFunctionGuard*. *PostgresFunctionGuard* will handle correctly *ERROR* log messages that could be emmited from these functions.
+* There are two distinct parts of the code where error handling is done very differently: The code that executes before we enter DuckDB execution engine (e.g. initial part of the planner hook) and the part that gets executed inside the duckdb execution engine. Below are rules for how to handle errors in both parts of the code. Not following these guidelines can cause crashes, memory leaks and other unexpected problems.
+* Before we enter the DuckDB exection engine no exceptions should ever be thrown here. In cases where you would want to throw an exception here, use `elog(ERROR, ...)`. Any C++ code that might throw an exception is also problematic. Since C++ throws exceptions on allocation failures, this covers lots of C++ APIs. So try to use Postgres datastructures instead of C++ ones whenever possible (e.g. use `List` instead of `Vec`)
+* Inside the duckdb execution engine the opposite is true. `elog(ERROR, ...)` should never be used there, use exceptions instead.
+* Use PostgreSQL *elog* API can be used to report non-fatal messages back to user. Using *ERROR* is strictly forbiden to use in code that is executed inside the duckdb engine.
+* Calling PostgreSQL native functions from within DuckDB execution needs **extreme care**. Pretty much non of these functions are thread-safe, and they might throw errors using `elog(ERROR, ...)`. If you've solved the thread-safety issue by taking a lock (or by carefully asserting that the actual code is thread safe), then you can use *PostgresFunctionGuard* to solve the `elog(ERROR, ...) problem. *PostgresFunctionGuard* will correctly handle *ERROR* log messages that could be emmited from these functions.
 * Try to add test cases that trigger exceptions. If an exception cannot be easily triggered using a test case then it should probably be an assertion. This is not always true (e.g. out of memory errors are exceptions, but are very hard to trigger).
 * Use `D_ASSERT` to assert. Use **assert** only when failing the assert means a programmer error. Assert should never be triggered by user input. Avoid code like `D_ASSERT(a > b + 3);` without comments or context.
 * Assert liberally, but make it clear with comments next to the assert what went wrong when the assert is triggered.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,10 @@ coding styles.
 ## Error Handling
 
 * Use exceptions **only** when an error is encountered that terminates a query (e.g. parser error, table not found). Exceptions should only be used for **exceptional** situations. For regular errors that do not break the execution flow (e.g. errors you **expect** might occur) use a return value instead.
+* *Exception* should be used in code that is executed inside duckdb engine.
+* Use PostgreSQL *elog* API to report messages back to user. Using *ERROR* is strictly forbiden to use as it can brake execution and lead to
+unexpected memory problems - *ERROR* is only used in duckdb node to early bail out execution in case of query preparation error or execution interruption.
+* Calling PostgreSQL native functions needs to be used with *PostgresFunctionGuard*. *PostgresFunctionGuard* will handle correctly *ERROR* log messages that could be emmited from these functions.
 * Try to add test cases that trigger exceptions. If an exception cannot be easily triggered using a test case then it should probably be an assertion. This is not always true (e.g. out of memory errors are exceptions, but are very hard to trigger).
 * Use `D_ASSERT` to assert. Use **assert** only when failing the assert means a programmer error. Assert should never be triggered by user input. Avoid code like `D_ASSERT(a > b + 3);` without comments or context.
 * Assert liberally, but make it clear with comments next to the assert what went wrong when the assert is triggered.

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -20,7 +20,7 @@ constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET = INT64CONST(10957) * USECS_PER
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(duckdb::LogicalType type);
 void ConvertPostgresToDuckValue(Datum value, duckdb::Vector &result, idx_t offset);
-void ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);
+bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);
 void InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanGlobalState> scan_global_state,
                           duckdb::shared_ptr<PostgresScanLocalState> scan_local_state, HeapTupleData *tuple);
 

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -46,8 +46,8 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 }
 
 template <typename FuncType, typename... FuncArgs>
-bool
-PostgresVoidFunctionGuard(FuncType postgres_function, FuncArgs... args) {
+std::optional<bool>
+PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 	bool error = false;
 	// clang-format off
 	PG_TRY();

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
+extern "C" {
+#include "postgres.h"
+}
+
 #include <vector>
 #include <string>
 #include <sstream>
-
 #include <cstdio>
+#include <optional>
 
 namespace pgduckdb {
 
@@ -18,5 +22,45 @@ TokenizeString(char *str, const char delimiter) {
 	}
 	return v;
 };
+
+template <typename T, typename FuncType, typename... FuncArgs>
+std::optional<T>
+PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
+	T return_value;
+	bool error = false;
+	// clang-format off
+	PG_TRY();
+	{
+		return_value = postgres_function(args...);
+	}
+	PG_CATCH();
+	{
+		error = true;
+	}
+	PG_END_TRY();
+	// clang-format on
+	if (error) {
+		return std::nullopt;
+	}
+	return return_value;
+}
+
+template <typename FuncType, typename... FuncArgs>
+bool
+PostgresVoidFunctionGuard(FuncType postgres_function, FuncArgs... args) {
+	bool error = false;
+	// clang-format off
+	PG_TRY();
+	{
+		postgres_function(args...);
+	}
+	PG_CATCH();
+	{
+		error = true;
+	}
+	PG_END_TRY();
+	// clang-format on
+	return error;
+}
 
 } // namespace pgduckdb

--- a/include/pgduckdb/types/decimal.hpp
+++ b/include/pgduckdb/types/decimal.hpp
@@ -199,8 +199,11 @@ CreateNumeric(const NumericVar &var, bool *have_error) {
 		 * but it seems worthwhile to expend a few cycles to ensure that we
 		 * never write any nonzero reserved bits to disk.
 		 */
-		if (!(sign == NUMERIC_NAN || sign == NUMERIC_PINF || sign == NUMERIC_NINF))
-			elog(ERROR, "invalid numeric sign value 0x%x", sign);
+		if (!(sign == NUMERIC_NAN || sign == NUMERIC_PINF || sign == NUMERIC_NINF)) {
+			elog(WARNING, "(PGDuckdDB/CreateNumeric) Invalid numeric sign value 0x%x", sign);
+			*have_error = true;
+			return NULL;
+		}
 
 		result = (Numeric)palloc(NUMERIC_HDRSZ_SHORT);
 

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -5,7 +5,6 @@ extern "C" {
 
 #include "pgduckdb/pgduckdb.h"
 #include "pgduckdb/pgduckdb_node.hpp"
-#include "pgduckdb/pgduckdb_utils.hpp"
 
 static void DuckdbInitGUC(void);
 

--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -124,8 +124,8 @@ ToastFetchDatum(struct varlena *attr) {
 	}
 
 	bool error_fetch_toast = false;
-	if (PostgresVoidFunctionGuard(table_relation_fetch_toast_slice, toast_rel, toast_pointer.va_valueid, attrsize, 0,
-	                              attrsize, result)) {
+	if (PostgresFunctionGuard(table_relation_fetch_toast_slice, toast_rel, toast_pointer.va_valueid, attrsize, 0,
+	                          attrsize, result).value()) {
 		error_fetch_toast = true;
 	}
 

--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -85,7 +85,7 @@ ToastDecompressDatum(struct varlena *attr) {
 
 static struct varlena *
 ToastFetchDatum(struct varlena *attr) {
-	Relation toastrel;
+	Relation toast_rel;
 	struct varlena *result;
 	struct varatt_external toast_pointer;
 	int32 attrsize;
@@ -110,9 +110,9 @@ ToastFetchDatum(struct varlena *attr) {
 		return result;
 
 	DuckdbProcessLock::GetLock().lock();
-	toastrel = table_open(toast_pointer.va_toastrelid, AccessShareLock);
-	table_relation_fetch_toast_slice(toastrel, toast_pointer.va_valueid, attrsize, 0, attrsize, result);
-	table_close(toastrel, AccessShareLock);
+	toast_rel = table_open(toast_pointer.va_toastrelid, AccessShareLock);
+	table_relation_fetch_toast_slice(toast_rel, toast_pointer.va_valueid, attrsize, 0, attrsize, result);
+	table_close(toast_rel, AccessShareLock);
 	DuckdbProcessLock::GetLock().unlock();
 
 	return result;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -24,21 +24,21 @@ CheckDataDirectory(const char *data_directory) {
 
 	if (lstat(data_directory, &info) != 0) {
 		if (errno == ENOENT) {
-			elog(DEBUG2, "Directory `%s` doesn't exists.", data_directory);
+			elog(DEBUG2, "(PGDuckDB/CheckDataDirectory) Directory `%s` doesn't exists", data_directory);
 			return false;
 		} else if (errno == EACCES) {
-			elog(ERROR, "Can't access `%s` directory.", data_directory);
+			elog(ERROR, "(PGDuckDB/CheckDataDirectory) Can't access `%s` directory", data_directory);
 		} else {
-			elog(ERROR, "Other error when reading `%s`.", data_directory);
+			elog(ERROR, "(PGDuckDB/CheckDataDirectory) Other error when reading `%s`", data_directory);
 		}
 	}
 
 	if (!S_ISDIR(info.st_mode)) {
-		elog(WARNING, "`%s` is not directory.", data_directory);
+		elog(WARNING, "(PGDuckDB/CheckDataDirectory) `%s` is not directory", data_directory);
 	}
 
 	if (access(data_directory, R_OK | W_OK)) {
-		elog(ERROR, "Directory `%s` permission problem.", data_directory);
+		elog(ERROR, "(PGDuckDB/CheckDataDirectory) Directory `%s` permission problem", data_directory);
 	}
 
 	return true;
@@ -53,9 +53,12 @@ GetExtensionDirectory() {
 		if (mkdir(duckdb_extension_data_directory->data, S_IRWXU | S_IRWXG | S_IRWXO) == -1) {
 			int error = errno;
 			pfree(duckdb_extension_data_directory->data);
-			elog(ERROR, "Creating duckdb extensions directory failed with reason `%s`\n", strerror(error));
+			elog(ERROR,
+			     "(PGDuckDB/GetExtensionDirectory) Creating duckdb extensions directory failed with reason `%s`\n",
+			     strerror(error));
 		}
-		elog(DEBUG2, "Created %s as `duckdb.data_dir`", duckdb_extension_data_directory->data);
+		elog(DEBUG2, "(PGDuckDB/GetExtensionDirectory) Created %s as `duckdb.data_dir`",
+		     duckdb_extension_data_directory->data);
 	};
 
 	std::string duckdb_extension_directory(duckdb_extension_data_directory->data);
@@ -64,7 +67,7 @@ GetExtensionDirectory() {
 }
 
 DuckDBManager::DuckDBManager() {
-	elog(DEBUG2, "Creating DuckDB instance");
+	elog(DEBUG2, "(PGDuckDB/DuckDBManager) Creating DuckDB instance");
 
 	duckdb::DBConfig config;
 	config.SetOptionByName("extension_directory", GetExtensionDirectory());
@@ -139,7 +142,7 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 			appendStringInfo(duckdb_extension, "LOAD %s;", extension.name.c_str());
 			auto res = context.Query(duckdb_extension->data, false);
 			if (res->HasError()) {
-				elog(ERROR, "Extension `%s` could not be loaded with DuckDB", extension.name.c_str());
+				elog(ERROR, "(PGDuckDB/LoadExtensions) `%s` could not be loaded with DuckDB", extension.name.c_str());
 			}
 		}
 		pfree(duckdb_extension->data);

--- a/src/pgduckdb_filter.cpp
+++ b/src/pgduckdb_filter.cpp
@@ -70,7 +70,8 @@ FilterOperationSwitch(Datum &value, duckdb::Value &constant, Oid type_oid) {
 	case VARCHAROID:
 		return StringFilterOperation<OP>(value, constant);
 	default:
-		elog(ERROR, "(DuckDB/FilterOperationSwitch) Unsupported duckdb type: %d", type_oid);
+		throw duckdb::InvalidTypeException(
+		    duckdb::string("(DuckDB/FilterOperationSwitch) Unsupported duckdb type: %d", type_oid));
 	}
 }
 

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -115,7 +115,7 @@ DuckdbPlannerHook(Query *parse, const char *query_string, int cursor_options, Pa
 
 		if (NeedsDuckdbExecution(parse)) {
 			if (!IsAllowedStatement(parse)) {
-				elog(ERROR, "only SELECT statements involving DuckDB are supported");
+				elog(ERROR, "(PGDuckDB/DuckdbPlannerHook) Only SELECT statements involving DuckDB are supported.");
 			}
 			PlannedStmt *duckdbPlan = DuckdbPlanNode(parse, cursor_options, bound_params);
 			if (duckdbPlan) {

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -81,12 +81,12 @@ ExecuteQuery(DuckdbScanState *state) {
 			CleanupDuckdbScanState(state);
 			// Process the interrupt on the Postgres side
 			ProcessInterrupts();
-			elog(ERROR, "(PGDuckDB/ExecuteQuery) Query cancelled");
+			elog(ERROR, "Query cancelled");
 		}
 	} while (!duckdb::PendingQueryResult::IsResultReady(execution_result));
 	if (execution_result == duckdb::PendingExecutionResult::EXECUTION_ERROR) {
 		CleanupDuckdbScanState(state);
-		elog(ERROR, "(PGDuckDB/ExecuteQuery) Query execution returned an error: %s", pending->GetError().c_str());
+		elog(ERROR, "(PGDuckDB/ExecuteQuery) %s", pending->GetError().c_str());
 	}
 	query_results = pending->Execute();
 	state->column_count = query_results->ColumnCount();

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -128,7 +128,7 @@ DuckdbInstallExtension(Datum name) {
 	pfree(install_extension_command->data);
 
 	if (res->HasError()) {
-		elog(WARNING, "(duckdb_install_extension) %s", res->GetError().c_str());
+		elog(WARNING, "(PGDuckDB/DuckdbInstallExtension) %s", res->GetError().c_str());
 		return false;
 	}
 

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -321,7 +321,7 @@ ConvertDuckToPostgresArray(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 	slot->tts_values[col] = PointerGetDatum(arr);
 }
 
-void
+bool
 ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col) {
 	Oid oid = slot->tts_tupleDescriptor->attrs[col].atttypid;
 
@@ -423,8 +423,8 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 			break;
 		}
 		default: {
-			throw duckdb::InternalException("Unrecognized physical type for DECIMAL value");
-			break;
+			elog(WARNING, "(PGDuckDB/ConvertDuckToPostgresValue) Unrecognized physical type for DECIMAL value");
+			return false;
 		}
 		}
 		auto numeric = CreateNumeric(numeric_var, NULL);
@@ -463,8 +463,10 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 		break;
 	}
 	default:
-		throw duckdb::NotImplementedException("(DuckDB/ConvertDuckToPostgresValue) Unsuported pgduckdb type: %d", oid);
+		elog(WARNING, "(PGDuckDB/ConvertDuckToPostgresValue) Unsuported pgduckdb type: %d", oid);
+		return false;
 	}
+	return true;
 }
 
 static inline int
@@ -599,7 +601,6 @@ GetPostgresDuckDBType(duckdb::LogicalType type) {
 			duck_type = &child_type;
 		}
 		auto child_type_id = duck_type->id();
-
 		switch (child_type_id) {
 		case duckdb::LogicalTypeId::BOOLEAN:
 			return BOOLARRAYOID;
@@ -607,13 +608,17 @@ GetPostgresDuckDBType(duckdb::LogicalType type) {
 			return INT4ARRAYOID;
 		case duckdb::LogicalTypeId::BIGINT:
 			return INT8ARRAYOID;
-		default:
-			throw duckdb::InvalidInputException("(DuckDB/GetPostgresDuckDBType) Unsupported pgduckdb type: %s",
-			                                    type.ToString().c_str());
+		default: {
+			elog(WARNING, "(PGDuckDB/GetPostgresDuckDBType) Unsupported `LIST` subtype %d to Postgres type",
+			     (uint8)child_type_id);
+			return InvalidOid;
+		}
 		}
 	}
 	default: {
-		elog(ERROR, "Could not convert DuckDB type: %s to Postgres type", type.ToString().c_str());
+		elog(WARNING, "(PGDuckDB/GetPostgresDuckDBType) Could not convert DuckDB type: %s to Postgres type",
+		     type.ToString().c_str());
+		return InvalidOid;
 	}
 	}
 }

--- a/src/scan/heap_reader.cpp
+++ b/src/scan/heap_reader.cpp
@@ -100,7 +100,7 @@ HeapReader::ReadPageTuples(duckdb::DataChunk &output) {
 
 			m_buffer = opt_buffer.value();
 
-			if (PostgresVoidFunctionGuard(LockBuffer, m_buffer, BUFFER_LOCK_SHARE)) {
+			if (PostgresFunctionGuard(LockBuffer, m_buffer, BUFFER_LOCK_SHARE).value()) {
 				DuckdbProcessLock::GetLock().unlock();
 				throw duckdb::InternalException("(PGDuckdDB/ReadPageTuples) LockBuffer failed");
 			}

--- a/src/scan/postgres_index_scan.cpp
+++ b/src/scan/postgres_index_scan.cpp
@@ -95,7 +95,8 @@ PostgresIndexScanFunction::PostgresIndexScanBind(duckdb::ClientContext &context,
 	auto relation_descr = RelationGetDescr(rel);
 
 	if (!relation_descr) {
-		elog(ERROR, "Failed to get tuple descriptor for relation with OID %u", rel->rd_id);
+		elog(WARNING, "(PGDuckDB/PostgresIndexScanBind) Failed to get tuple descriptor for relation with OID %u",
+		     rel->rd_id);
 		return nullptr;
 	}
 
@@ -106,7 +107,7 @@ PostgresIndexScanFunction::PostgresIndexScanBind(duckdb::ClientContext &context,
 		return_types.push_back(duck_type);
 		names.push_back(col_name);
 		/* Log column name and type */
-		elog(DEBUG3, "-- (DuckDB/PostgresHeapBind) Column name: %s, Type: %s --", col_name.c_str(),
+		elog(DEBUG2, "(PGDuckDB/PostgresIndexScanBind) Column name: %s, Type: %s --", col_name.c_str(),
 		     duck_type.ToString().c_str());
 	}
 

--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -14,7 +14,7 @@ PostgresSeqScanGlobalState::PostgresSeqScanGlobalState(Relation relation, duckdb
       m_heap_reader_global_state(duckdb::make_shared_ptr<HeapReaderGlobalState>(relation)), m_relation(relation) {
 	m_global_state->InitGlobalState(input);
 	m_global_state->m_tuple_desc = RelationGetDescr(m_relation);
-	elog(DEBUG3, "-- (DuckDB/PostgresReplacementScanGlobalState) Running %lu threads -- ", MaxThreads());
+	elog(DEBUG2, "(PGDuckDB/PostgresSeqScanGlobalState) Running %lu threads -- ", MaxThreads());
 }
 
 PostgresSeqScanGlobalState::~PostgresSeqScanGlobalState() {
@@ -76,7 +76,7 @@ PostgresSeqScanFunction::PostgresSeqScanBind(duckdb::ClientContext &context, duc
 	auto relation_descr = RelationGetDescr(rel);
 
 	if (!relation_descr) {
-		elog(ERROR, "Failed to get tuple descriptor for relation with OID %u", relid);
+		elog(WARNING, "(PGDuckDB/PostgresSeqScanBind) Failed to get tuple descriptor for relation with OID %u", relid);
 		RelationClose(rel);
 		return nullptr;
 	}
@@ -88,7 +88,7 @@ PostgresSeqScanFunction::PostgresSeqScanBind(duckdb::ClientContext &context, duc
 		return_types.push_back(duck_type);
 		names.push_back(col_name);
 		/* Log column name and type */
-		elog(DEBUG3, "-- (DuckDB/PostgresHeapBind) Column name: %s, Type: %s --", col_name.c_str(),
+		elog(DEBUG2, "(PGDuckDB/PostgresSeqScanBind) Column name: %s, Type: %s --", col_name.c_str(),
 		     duck_type.ToString().c_str());
 	}
 

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -129,7 +129,7 @@ DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment
 	auto res = duckdb_connection->context->Query(query_string, false);
 
 	if (res->HasError()) {
-		elog(WARNING, "(Duckdb) %s", res->GetError().c_str());
+		elog(WARNING, "(PGDuckDB/DuckdbCopy) Execution failed with an error: %s", res->GetError().c_str());
 		return false;
 	}
 

--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -34,7 +34,7 @@ INSERT INTO int_array_2d VALUES
     ('{{11, 12, 13}, {14, 15, 16}}'),
     ('{{17, 18}, {19, 20}}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/ExecuteQuery) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (single dimensional data, two dimensionsal type)
 CREATE TABLE int_array_2d(a INT[][]);
@@ -44,7 +44,7 @@ INSERT INTO int_array_2d VALUES
     ('{11, 12, 13}'),
     ('{17, 18}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/ExecuteQuery) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (two dimensional data and type)
 CREATE TABLE int_array_2d(a INT[][]);

--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -34,7 +34,7 @@ INSERT INTO int_array_2d VALUES
     ('{{11, 12, 13}, {14, 15, 16}}'),
     ('{{17, 18}, {19, 20}}');
 SELECT * FROM int_array_2d;
-ERROR:  Duckdb execute returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (single dimensional data, two dimensionsal type)
 CREATE TABLE int_array_2d(a INT[][]);
@@ -44,7 +44,7 @@ INSERT INTO int_array_2d VALUES
     ('{11, 12, 13}'),
     ('{17, 18}');
 SELECT * FROM int_array_2d;
-ERROR:  Duckdb execute returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (two dimensional data and type)
 CREATE TABLE int_array_2d(a INT[][]);

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -4,6 +4,6 @@ insert into int_as_varchar SELECT * from (
 		('abc')
 ) t(a);
 select a::INTEGER from int_as_varchar;
-ERROR:  Duckdb execute returned an error: Conversion Error: Could not convert string 'abc' to INT32
+ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Conversion Error: Could not convert string 'abc' to INT32
 LINE 1: SELECT (a)::integer AS a FROM int_as_varchar
                   ^

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -4,6 +4,6 @@ insert into int_as_varchar SELECT * from (
 		('abc')
 ) t(a);
 select a::INTEGER from int_as_varchar;
-ERROR:  (PGDuckDB/ExecuteQuery) Query execution returned an error: Conversion Error: Could not convert string 'abc' to INT32
+ERROR:  (PGDuckDB/ExecuteQuery) Conversion Error: Could not convert string 'abc' to INT32
 LINE 1: SELECT (a)::integer AS a FROM int_as_varchar
                   ^

--- a/test/regression/expected/views.out
+++ b/test/regression/expected/views.out
@@ -27,7 +27,7 @@ create table "s.t" as select 42;
 create view vw1 as select * from s.t;
 create view vw2 as select * from "s.t";
 select * from vw1, vw2;
-WARNING:  (DuckDB) Binder Error: Referenced table "t" not found!
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Binder Error: Referenced table "t" not found!
 Candidate tables: "s.t"
 LINE 1: ...?column?", vw2."?column?" FROM (SELECT t."?column?" FROM s.t) vw1, (SELECT "s....
                                                   ^


### PR DESCRIPTION
* Unify reporting of WARNING with log
* Throw exception in functions that are used inside duckdb execution
* Report WARNING for functions that are part of "normal" postgres execution
* Cleanup duckdb_state before reporting error in DuckDBNode (clean up)