### PR TITLE
Bump up Natts_duckdb_secret

### DIFF
--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -6,7 +6,7 @@
 namespace pgduckdb {
 
 /* constants for duckdb.secrets */
-#define Natts_duckdb_secret              7
+#define Natts_duckdb_secret              8
 #define Anum_duckdb_secret_type          1
 #define Anum_duckdb_secret_id            2
 #define Anum_duckdb_secret_secret        3

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -42,7 +42,7 @@ public:
 struct PostgresReplacementScanDataClientContextState : public duckdb::ClientContextState {
 public:
 	PostgresReplacementScanDataClientContextState(List *rtables, PlannerInfo *query_planner_info, List *needed_columns,
-	                            const char *query_string)
+	                                              const char *query_string)
 	    : m_rtables(rtables), m_query_planner_info(query_planner_info), m_needed_columns(needed_columns),
 	      m_query_string(query_string) {
 	}


### PR DESCRIPTION
In 4e1a48c another field was added to the `duckdb.secrets` table (`session_token`) but the total number of fields stored in `Natts_duckdb_secret` wasn't incremented resulting in reading beyond the `datum_array` and `is_null_array` arrays.