### PR TITLE
remove hash in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "third_party/duckdb"]
 	path = third_party/duckdb
 	url = https://github.com/duckdb/duckdb.git
-	hash = 17d598fc4472c64969f47f86c30fce75c4d64ed4


### PR DESCRIPTION
~completes the update made in ee3526d, possibly addresses #184~

removes the hash from .gitmodules as it has no effect