### PR TITLE
Explicitly convert datum values before filter operation

### DIFF
--- a/test/regression/expected/query_filter.out
+++ b/test/regression/expected/query_filter.out
@@ -1,0 +1,30 @@
+CREATE TABLE query_filter_int(a INT);
+INSERT INTO query_filter_int SELECT g FROM generate_series(1,100) g;
+SELECT COUNT(*) FROM query_filter_int WHERE a  <= 50;
+ count 
+-------
+    50
+(1 row)
+
+DROP TABLE query_filter_int;
+CREATE TABLE query_filter_float(a FLOAT8);
+INSERT INTO query_filter_float VALUES (0.9), (1.0), (1.1);
+SELECT COUNT(*) FROM query_filter_float WHERE a < 1.0;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM query_filter_float WHERE a <= 1.0;
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM query_filter_float WHERE a < 1.1;
+ count 
+-------
+     2
+(1 row)
+
+DROP TABLE query_filter_float;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -12,3 +12,4 @@ test: duckdb_only_functions
 test: cte
 test: create_table_as
 test: standard_conforming_strings
+test: query_filter

--- a/test/regression/sql/query_filter.sql
+++ b/test/regression/sql/query_filter.sql
@@ -1,0 +1,12 @@
+CREATE TABLE query_filter_int(a INT);
+INSERT INTO query_filter_int SELECT g FROM generate_series(1,100) g;
+SELECT COUNT(*) FROM query_filter_int WHERE a  <= 50;
+DROP TABLE query_filter_int;
+
+CREATE TABLE query_filter_float(a FLOAT8);
+INSERT INTO query_filter_float VALUES (0.9), (1.0), (1.1);
+SELECT COUNT(*) FROM query_filter_float WHERE a < 1.0;
+SELECT COUNT(*) FROM query_filter_float WHERE a <= 1.0;
+SELECT COUNT(*) FROM query_filter_float WHERE a < 1.1;
+
+DROP TABLE query_filter_float;


### PR DESCRIPTION
Datums can contain a pass-by-value or a pass-by-reference type. We were simply casting the `Datum` for a pass by value type, but that is not always correct. Specifically for floating point numbers this would not always result in the correct floating point number. And int64 values are pass-by-reference on 32bit systems, but pass-by-value on 64bit systems. Postgres provides the `DatumGetXyz` macros/functions to work around these problems. This starts using these functions in `FilterOperationSwitch` to avoid these casting problems there.

Fixes #189