### PR TITLE
Only load pg_duckdb extension if set in shared_preload_variables

### DIFF
--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -1,5 +1,6 @@
 extern "C" {
 #include "postgres.h"
+#include "miscadmin.h"
 #include "utils/guc.h"
 }
 
@@ -13,14 +14,17 @@ int duckdb_max_threads_per_query = 1;
 
 extern "C" {
 PG_MODULE_MAGIC;
-
 void
 _PG_init(void) {
+	if (!process_shared_preload_libraries_in_progress) {
+		ereport(ERROR, (errmsg("pg_duckdb needs to be loaded via shared_preload_libraries"),
+		                errhint("Add pg_duckdb to shared_preload_libraries.")));
+	}
 	DuckdbInitGUC();
 	DuckdbInitHooks();
 	DuckdbInitNode();
 }
-}
+} // extern "C"
 
 /* clang-format off */
 static void

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -155,7 +155,6 @@ DuckdbInstallExtension(Datum name) {
 } // namespace pgduckdb
 
 extern "C" {
-
 PG_FUNCTION_INFO_V1(install_extension);
 Datum
 install_extension(PG_FUNCTION_ARGS) {
@@ -163,5 +162,4 @@ install_extension(PG_FUNCTION_ARGS) {
 	bool result = pgduckdb::DuckdbInstallExtension(extension_name);
 	PG_RETURN_BOOL(result);
 }
-
 } // extern "C"


### PR DESCRIPTION
* We want to enforce that pg_duckdb extension is loaded only if it is set in shared_preload_variables.