### PR TITLE
Add duckdb.raw_query function

### DIFF
--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -142,6 +142,9 @@ CREATE TABLE extensions (
 CREATE OR REPLACE FUNCTION install_extension(extension_name TEXT) RETURNS bool
     LANGUAGE C AS 'MODULE_PATHNAME', 'install_extension';
 
+CREATE OR REPLACE FUNCTION raw_query(query TEXT) RETURNS void
+    LANGUAGE C AS 'MODULE_PATHNAME', 'pgduckdb_raw_query';
+
 DO $$
 BEGIN
     RAISE WARNING 'To actually execute queries using DuckDB you need to run "SET duckdb.execution TO true;"';

--- a/test/regression/expected/raw_query.out
+++ b/test/regression/expected/raw_query.out
@@ -1,0 +1,23 @@
+SELECT duckdb.raw_query($$ CREATE TABLE t(a int) $$);
+NOTICE:  result: Count	
+BIGINT	
+[ Rows: 0]
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT * FROM duckdb_tables() $$);
+NOTICE:  result: database_name	database_oid	schema_name	schema_oid	table_name	table_oid	comment	tags	internal	temporary	has_primary_key	estimated_size	column_count	index_count	check_constraint_count	sql	
+VARCHAR	BIGINT	VARCHAR	BIGINT	VARCHAR	BIGINT	VARCHAR	MAP(VARCHAR, VARCHAR)	BOOLEAN	BOOLEAN	BOOLEAN	BIGINT	BIGINT	BIGINT	BIGINT	VARCHAR	
+[ Rows: 1]
+memory	1148	main	1150	t	1266	NULL	{}	false	false	false	0	1	0	0	CREATE TABLE t(a INTEGER);
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -13,3 +13,4 @@ test: cte
 test: create_table_as
 test: standard_conforming_strings
 test: query_filter
+test: raw_query

--- a/test/regression/sql/raw_query.sql
+++ b/test/regression/sql/raw_query.sql
@@ -1,0 +1,2 @@
+SELECT duckdb.raw_query($$ CREATE TABLE t(a int) $$);
+SELECT duckdb.raw_query($$ SELECT * FROM duckdb_tables() $$);


### PR DESCRIPTION
For upcoming features, specifically MotherDuck support it is quite useful to be able to send raw queries to DuckDB to inspect the current state of the database. Such as `DESCRIBE` or `SELECT * FROM duckdb_tables();` or even queries to debug the our current `SECRET` support. This adds a small helper function to do this. The result is shown in a NOTICE message instead of actually returning them as rows, so that there's no need for the `AS (some_column int, some_other_column text)` stuff. We'll probably want a function that returns actual rows too for use in scripts, but this is a bit easier to use for debugging at the moment. It's specifically named `duckdb.raw_query`, so we can use `duckdb.query` for the function that actually returns rows.
