### PR TITLE
Create a dedicated clean-all rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: duckdb install-duckdb clean-duckdb lintcheck check-regression-duckdb clean-regression .depend
+.PHONY: duckdb install-duckdb clean-duckdb clean-all lintcheck check-regression-duckdb clean-regression .depend
 
 MODULE_big = pg_duckdb
 EXTENSION = pg_duckdb

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean-duckdb:
 
 install: install-duckdb
 
-clean: clean-regression clean-duckdb
+clean-all: clean clean-regression clean-duckdb
 
 lintcheck:
 	clang-tidy $(SRCS) -- -I$(INCLUDEDIR) -I$(INCLUDEDIR_SERVER) -Iinclude $(CPPFLAGS) -std=c++17


### PR DESCRIPTION
DuckDB takes a long time to compile (even with `ccache`/`sccache`) and often I don't actually want to rebuild it. For instance I only want to rebuild the actual extension whenever I switch between Postgres versions, the DuckDB library can stay the same. This changes the `clean` rule to only clean the actual extension files and adds a clean-all rule to clean everything.
