### PR TITLE
Make DuckDB connection a singleton

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -12,7 +12,7 @@ namespace pgduckdb {
 
 class DuckDBManager {
 public:
-	static inline const DuckDBManager &
+	static inline DuckDBManager &
 	Get() {
 		static DuckDBManager instance;
 		return instance;
@@ -23,6 +23,15 @@ public:
 		return *database;
 	}
 
+	inline duckdb::Connection *
+	GetConnection() const {
+		connection->context->registered_state->Remove("postgres_scan");
+		return connection.get();
+	}
+
+	duckdb::Connection *GetConnection(List *rtables, PlannerInfo *planner_info, List *needed_columns,
+	                                  const char *query);
+
 private:
 	DuckDBManager();
 	void InitializeDatabase();
@@ -32,9 +41,7 @@ private:
 	void LoadFunctions(duckdb::ClientContext &);
 
 	duckdb::unique_ptr<duckdb::DuckDB> database;
+	duckdb::unique_ptr<duckdb::Connection> connection;
 };
-
-duckdb::unique_ptr<duckdb::Connection> DuckdbCreateConnection(List *rtables, PlannerInfo *planner_info,
-                                                              List *needed_columns, const char *query);
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -12,5 +12,5 @@ extern "C" {
 extern bool duckdb_explain_analyze;
 
 PlannedStmt *DuckdbPlanNode(Query *parse, int cursor_options, ParamListInfo bound_params);
-std::tuple<duckdb::unique_ptr<duckdb::PreparedStatement>, duckdb::unique_ptr<duckdb::Connection>>
+std::tuple<duckdb::unique_ptr<duckdb::PreparedStatement>, duckdb::Connection *>
 DuckdbPrepare(const Query *query, ParamListInfo bound_params);

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -125,7 +125,8 @@ DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment
 		rtables = pstate->p_rtable;
 	}
 
-	auto duckdb_connection = pgduckdb::DuckdbCreateConnection(rtables, nullptr, vars, query_string);
+	duckdb::Connection *duckdb_connection =
+	    pgduckdb::DuckDBManager::Get().GetConnection(rtables, nullptr, vars, query_string);
 	auto res = duckdb_connection->context->Query(query_string, false);
 
 	if (res->HasError()) {


### PR DESCRIPTION
In #174 we made the DuckDB database a singleton, but a new DuckDB connection was still being created for every query. This means that any connection state, such as SET commands or temporary tables don't survive a single query, which is pretty confusing. This addresses that by also making the `duckdb::Connection` a singleton, this way a Postgres connection and a DuckDB connection are linked 1-to-1.
