### PR TITLE
Add the ability to run a single test

### DIFF
--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -9,7 +9,7 @@ check-regression-duckdb:
 	--temp-instance=./tmp_check \
 	--temp-config regression.conf \
 	--load-extension=pg_duckdb \
-	--schedule schedule
+	$(if $(TEST),$(TEST),--schedule=schedule)
 
 clean-regression:
 	rm -fr $(CURDIR)/tmp_check


### PR DESCRIPTION
By setting `TEST=<test_name>` it will override the schedule and instead run only the test(s?) that was provided.