### PR TITLE
Cleanup after incorrect merge in #97

### DIFF
--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -151,14 +151,6 @@ CreatePlan(Query *query, ParamListInfo bound_params) {
 
 PlannedStmt *
 DuckdbPlanNode(Query *parse, int cursor_options, ParamListInfo bound_params) {
-	const char *query_string = pgduckdb_pg_get_querydef(parse, false);
-	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
-		if (duckdb_explain_analyze) {
-			query_string = psprintf("EXPLAIN ANALYZE %s", query_string);
-		} else {
-			query_string = psprintf("EXPLAIN %s", query_string);
-		}
-	}
 	/* We need to check can we DuckDB create plan */
 	Plan *duckdb_plan = (Plan *)castNode(CustomScan, CreatePlan(parse, bound_params));
 


### PR DESCRIPTION
I think @Tishj misunderstood my review comment in #97 about the merge being incorrect. I meant that the whole `pgduckdb_pg_get_querydef` stuff could be removed from `DuckdbPlanNode`, since that is now moved to `DuckdbPrepare`.
