### PR TITLE
Makefile improvements

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -124,8 +124,7 @@ jobs:
         id: build
         run: |
           pushd duckdb
-          make
-          make install
+          make -j8 install
 
       - name: Run make installcheck
         id: installcheck

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -48,12 +48,13 @@ jobs:
         run: ruff check --output-format=github .
       - name: Run ruff format
         run: ruff format --diff
+
   build-and-test:
     name: 'Build and test'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         version: [REL_16_STABLE, REL_17_STABLE]
     runs-on: ${{ matrix.os }}
 
@@ -66,13 +67,14 @@ jobs:
           sudo apt-get update -qq
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
-            libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo5 cmake \
+            libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo6 cmake \
             libstdc++-12-dev
           echo "${PWD}/postgres/inst/bin:$PATH'" > $GITHUB_PATH
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
+          key: ${{ matrix.os }}
           create-symlink: true
 
       - name: Checkout pg_duckdb extension code
@@ -81,26 +83,34 @@ jobs:
           submodules: 'recursive'
           path: duckdb
 
-      - name: Compute DuckDB SHA
+      - name: Checkout PostgreSQL code
+        run: |
+          rm -rf postgres
+          git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/postgres/postgres.git
+
+      - name: Compute Version SHAs
         id: versions
         run: |
-          pushd duckdb
-          DUCKDB_SHA=`git ls-tree HEAD third_party/duckdb --format='%(objectname)'`
+          pushd duckdb/third_party/duckdb
+          DUCKDB_SHA=`git rev-parse HEAD`
           echo "duckdb_sha=${DUCKDB_SHA}" >> "$GITHUB_OUTPUT"
           echo "Got DUCKDB_SHA='${DUCKDB_SHA}'"
+          popd
+          pushd postgres
+          POSTGRES_SHA=`git rev-parse HEAD`
+          echo "postgres_sha=${POSTGRES_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Got POSTGRES_SHA='${POSTGRES_SHA}'"
 
       - name: Setup PG build cache
         id: cache-pg-build
         uses: actions/cache@v4
         with:
           path: postgres/inst
-          key: pg-build-${{ matrix.version }}
+          key: pg-build-${{ matrix.os }}-${{ steps.versions.outputs.postgres_sha }}
 
-      - name: Checkout and build PostgreSQL code
+      - name: Build PostgreSQL code
         if: steps.cache-pg-build.outputs.cache-hit != 'true'
         run: |
-          rm -rf postgres
-          git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/postgres/postgres.git
           pushd postgres
           git branch
           ./configure --prefix=$PWD/inst/ --enable-cassert --enable-debug --with-openssl --with-icu --with-libxml
@@ -115,7 +125,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: duckdb/third_party/duckdb/build/
-          key: duckdb-build-${{ steps.versions.outputs.duckdb_sha }}
+          key: duckdb-build-${{ matrix.os }}-${{ steps.versions.outputs.duckdb_sha }}
 
       - name: Install pytest and other test requirements
         run: python3 -m pip install -r duckdb/requirements.txt

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-latest]
         version: [REL_16_STABLE, REL_17_STABLE]
     runs-on: ${{ matrix.os }}
 
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
-            libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo6 cmake \
+            libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo5 cmake \
             libstdc++-12-dev
           echo "${PWD}/postgres/inst/bin:$PATH'" > $GITHUB_PATH
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ ifeq ($(UNAME_S),Linux)
 	DUCKDB_LIB = libduckdb.so
 endif
 
-all: duckdb $(OBJS)
+all: $(OBJS)
+all-lib: duckdb
 
 include Makefile.global
 

--- a/Makefile
+++ b/Makefile
@@ -4,39 +4,11 @@ MODULE_big = pg_duckdb
 EXTENSION = pg_duckdb
 DATA = pg_duckdb.control $(wildcard sql/pg_duckdb--*.sql)
 
-SRCS = src/scan/heap_reader.cpp \
-	   src/scan/index_scan_utils.cpp \
-	   src/scan/postgres_index_scan.cpp \
-	   src/scan/postgres_scan.cpp \
-	   src/scan/postgres_seq_scan.cpp \
-	   src/utility/copy.cpp \
-	   src/vendor/pg_explain.cpp \
-	   src/pgduckdb_metadata_cache.cpp \
-	   src/pgduckdb_detoast.cpp \
-	   src/pgduckdb_duckdb.cpp \
-	   src/pgduckdb_filter.cpp \
-	   src/pgduckdb_hooks.cpp \
-	   src/pgduckdb_memory_allocator.cpp \
-	   src/pgduckdb_node.cpp \
-	   src/pgduckdb_options.cpp \
-	   src/pgduckdb_planner.cpp \
-	   src/pgduckdb_ruleutils.cpp \
-	   src/pgduckdb_types.cpp \
-	   src/pgduckdb.cpp \
-	   src/catalog/pgduckdb_storage.cpp \
-	   src/catalog/pgduckdb_schema.cpp \
-	   src/catalog/pgduckdb_table.cpp \
-	   src/catalog/pgduckdb_transaction.cpp \
-	   src/catalog/pgduckdb_transaction_manager.cpp \
-	   src/catalog/pgduckdb_catalog.cpp
-
+SRCS = $(wildcard src/*.cpp src/*/*.cpp)
 OBJS = $(subst .cpp,.o, $(SRCS))
 
-
-C_SRCS = src/vendor/pg_ruleutils_16.c \
-		 src/vendor/pg_ruleutils_17.c
+C_SRCS = $(wildcard src/*.c src/*/*.c)
 OBJS += $(subst .c,.o, $(C_SRCS))
-
 
 DUCKDB_BUILD_CXX_FLAGS=
 DUCKDB_BUILD_TYPE=
@@ -92,13 +64,12 @@ pycheck: all install
 check: installcheck pycheck
 
 FULL_DUCKDB_LIB = third_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src/$(DUCKDB_LIB)
-duckdb: third_party/duckdb/Makefile $(FULL_DUCKDB_LIB)
-
+duckdb: $(FULL_DUCKDB_LIB)
 
 third_party/duckdb/Makefile:
 	git submodule update --init --recursive
 
-$(FULL_DUCKDB_LIB):
+$(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
 	DISABLE_SANITIZER=1 \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	BUILD_UNITTESTS=OFF \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake"
 
-install-duckdb: $(FULL_DUCKDB_LIB)
+install-duckdb: $(FULL_DUCKDB_LIB) $(shlib)
 	$(install_bin) -m 755 $(FULL_DUCKDB_LIB) $(DESTDIR)$(PG_LIB)
 
 clean-duckdb:

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,10 @@ COMPILE.cc.bc = $(CXX) -Wno-ignored-attributes -Wno-register $(BITCODE_CXXFLAGS)
 %.bc : %.cpp
 	$(COMPILE.cc.bc) $(SHLIB_LINK) -I$(INCLUDE_SERVER) -o $@ $<
 
-all: $(OBJS)
-
 include Makefile.global
+
+# shlib is the final output product - make duckdb and all .o dependencies
+$(shlib): $(FULL_DUCKDB_LIB) $(OBJS)
 
 NO_INSTALLCHECK = 1
 
@@ -57,8 +58,6 @@ pycheck: all install
 check: installcheck pycheck
 
 duckdb: $(FULL_DUCKDB_LIB)
-# make completing duckdb a dependency of linking
-$(shlib): $(FULL_DUCKDB_LIB)
 
 third_party/duckdb/Makefile:
 	git submodule update --init --recursive


### PR DESCRIPTION
This fixes issues with `-j` when on a clean build.

* cleanup dependency chain of duckdb
* use wildcard for c and cpp files
* build duckdb completely before building pg_duckdb
* complete the build before installing
* change CI caching for Postgres to use sha