### PR TITLE
Fix install_extension mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ CREATE EXTENSION pg_duckdb;
 	- `SELECT n FROM read_parquet('s3://bucket/file.parquet') AS (n int)`
 	- `SELECT n FROM read_csv('s3://bucket/file.csv') AS (n int)`
 	- You can pass globs and arrays to these functions, just like in DuckDB
-- Enable the DuckDB Iceberg extension using `SELECT duckdb.enable_extension('iceberg')` and read Iceberg files with `iceberg_scan`.
+- Enable the DuckDB Iceberg extension using `SELECT duckdb.install_extension('iceberg')` and read Iceberg files with `iceberg_scan`.
 - Write a query — or an entire table — to parquet in object storage.
 	- `COPY (SELECT foo, bar FROM baz) TO 's3://...'`
 	- `COPY table TO 's3://...'`


### PR DESCRIPTION
The readme was using an outdated/incorrect name for the `install_extension` function. This corrects that.

Fixes #209
Partially fixes #177
