### PR TITLE
Allocate for enough data in the 'values' Datum array

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1026,7 +1026,7 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanG
 	}
 
 	/* FIXME: all calls to duckdb_malloc/duckdb_free should be changed in future */
-	Datum *values = (Datum *)duckdb_malloc(sizeof(Datum) * scan_global_state->m_output_columns_ids.size());
+	Datum *values = (Datum *)duckdb_malloc(sizeof(Datum) * scan_global_state->m_read_columns_ids.size());
 	bool *nulls = (bool *)duckdb_malloc(sizeof(bool) * scan_global_state->m_read_columns_ids.size());
 
 	bool valid_tuple = true;


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/duckdb/pg_duckdb/pull/195#issuecomment-2368390471

Fix found by Mario.

I don't think we quite understand why this caused a crash/bad access violation on Mac but Linux was unaffected.
either way this is now fixed

Some debugging:
```
(lldb) p scan_global_state->m_output_columns_ids.size()
(std::map<unsigned long long, unsigned long long>::size_type) 2
(lldb) p scan_global_state->m_read_columns_ids.size()
(std::map<unsigned long long, unsigned long long>::size_type) 3
```

I imagine this wrote to memory we do own, and is managed by duckdb, containing a pointer value that got overwritten, when it gets dereferenced it segfaults because the address is bogus
The difference in system allocators likely caused this problem to fly under the radar on Linux