### PR TITLE
Enable LZ4 in CI postgres build

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -103,7 +103,7 @@ jobs:
           git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/postgres/postgres.git
           pushd postgres
           git branch
-          ./configure --prefix=$PWD/inst/ --enable-cassert --enable-debug --with-openssl --with-icu --with-libxml
+          ./configure --prefix=$PWD/inst/ --enable-cassert --enable-debug --with-openssl --with-icu --with-libxml --with-lz4
           make -j8 install
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This can be useful for certain tests. I had to change a test in #231 to use pglz instead of lz4 to make it pass in CI.
