### PR TITLE
Always run CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -3,28 +3,7 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'include/**'
-      - 'sql/**'
-      - Makefile
-      - Makefile.global
-      - duckdb.control
-      - third_party/duckdb
-      - '.github/workflows/**'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'include/**'
-      - 'sql/**'
-      - Makefile
-      - Makefile.global
-      - duckdb.control
-      - third_party/duckdb
-      - '.github/workflows/**'
-      - .clang-format
 
 jobs:
   format:


### PR DESCRIPTION
We were skipping CI when certain files were not touched. This is prone to causing problems.

1. Because it's an include and not exclude list, we need to be careful to add files to it. This caused some confusing in #98
2. Branch protection rules and this skipping work terribly together, because the branch protection rules will not allow merging the PR unless the job was actually run. We ran into this in #230. There are ways to work around this, such as described in the following blogpost, but it's quite a bit of hackery: <https://www.pantsbuild.org/blog/2022/10/10/skipping-github-actions-jobs-without-breaking-branch-protection>

So the most pragmatic solution seems to be not to skip CI anymore. CI is now pretty quick so the benefit of skipping it is already fairly small, and the number of PRs where we can actually skip CI is also really limited (basically only for docs-only PRs).
