### PR TITLE
Use -Werror in CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -113,7 +113,7 @@ jobs:
         id: build
         run: |
           pushd duckdb
-          make -j8 install
+          make -j8 install CFLAGS=-Werror CXXFLAGS=-Werror
 
       - name: Run make installcheck
         id: installcheck

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DUCKDB_LIB = libduckdb$(DLSUFFIX)
 FULL_DUCKDB_LIB = third_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src/$(DUCKDB_LIB)
 
 override PG_CPPFLAGS += -Iinclude -Ithird_party/duckdb/src/include -Ithird_party/duckdb/third_party/re2
-override PG_CXXFLAGS += -std=c++17 -Wno-sign-compare ${DUCKDB_BUILD_CXX_FLAGS}
+override PG_CXXFLAGS += -std=c++17 -Wno-sign-compare -Wno-register ${DUCKDB_BUILD_CXX_FLAGS}
 
 SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src -L$(PG_LIB) -lduckdb -lstdc++ -llz4
 


### PR DESCRIPTION
The PG15 support that was introduced in #180 introduced a bunch of warnings when compiling. To avoid getting numb to warnings, this adds the -Werror to our CI builds, so we catch warnings before merging to main.

This also starts to ignore the register warning which was introduced by PG15 support.
