### PR TITLE
Add support for CREATE TABLE AS for duckdb TableAM

### DIFF
--- a/test/pycheck/explain_test.py
+++ b/test/pycheck/explain_test.py
@@ -1,5 +1,8 @@
 from .utils import Cursor
 
+import pytest
+import psycopg.errors
+
 
 def test_explain(cur: Cursor):
     cur.sql("CREATE TABLE test_table (id int, name text)")
@@ -27,3 +30,31 @@ def test_explain(cur: Cursor):
     assert "UNGROUPED_AGGREGATE" in plan
     assert "id=1 AND id IS NOT NULL" in plan
     assert "Total Time:" in plan
+
+
+def test_explain_ctas(cur: Cursor):
+    cur.sql("CREATE TEMP TABLE heap1(id) AS SELECT 1")
+    result = cur.sql("EXPLAIN CREATE TEMP TABLE heap2(id) AS SELECT * from heap1")
+    plan = "\n".join(result)
+    assert "POSTGRES_SEQ_SCAN" in plan
+    assert "Total Time:" not in plan
+
+    result = cur.sql(
+        "EXPLAIN ANALYZE CREATE TEMP TABLE heap2(id) AS SELECT * from heap1"
+    )
+    plan = "\n".join(result)
+    assert "POSTGRES_SEQ_SCAN" in plan
+    assert "Total Time:" in plan
+
+    result = cur.sql(
+        "EXPLAIN CREATE TEMP TABLE duckdb1(id) USING duckdb AS SELECT * from heap1"
+    )
+    plan = "\n".join(result)
+    assert "POSTGRES_SEQ_SCAN" in plan
+    assert "Total Time:" not in plan
+
+    # EXPLAIN ANALYZE is not supported for DuckDB CTAS (yet)
+    with pytest.raises(psycopg.errors.FeatureNotSupported):
+        cur.sql(
+            "EXPLAIN ANALYZE CREATE TEMP TABLE duckdb2(id) USING duckdb AS SELECT * from heap1"
+        )

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -206,8 +206,47 @@ DROP TABLE t;
 -- unsupported
 CREATE TEMP TABLE t(a int) ON COMMIT DROP;
 ERROR:  DuckDB does not support ON COMMIT DROP
+-- CTAS fully in Duckdb
 CREATE TEMP TABLE webpages USING duckdb AS SELECT * FROM read_csv('../../data/web_page.csv') as (column00 int, column01 text, column02 date);
-ERROR:  DuckDB does not support CREATE TABLE AS yet
+SELECT * FROM webpages ORDER BY column00 LIMIT 2;
+ column00 |     column01     |  column02  
+----------+------------------+------------
+        1 | AAAAAAAABAAAAAAA | 1997-09-03
+        2 | AAAAAAAACAAAAAAA | 1997-09-03
+(2 rows)
+
+CREATE TEMP TABLE t_heap(a int) USING heap;
+INSERT INTO t_heap VALUES (1);
+-- CTAS from postgres table to duckdb table
+CREATE TEMP TABLE t(b) USING duckdb AS SELECT * FROM t_heap;
+SELECT * FROM t;
+ b 
+---
+ 1
+(1 row)
+
+-- CTAS from DuckDB table to postgres table
+CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t_heap;
+SELECT * FROM t_heap2;
+ c 
+---
+ 1
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
+NOTICE:  result: database_name	schema_name	sql	
+VARCHAR	VARCHAR	VARCHAR	
+[ Rows: 2]
+memory	pg_temp	CREATE TABLE pg_temp.t(b INTEGER);
+memory	pg_temp	CREATE TABLE pg_temp.webpages(column00 INTEGER, column01 VARCHAR, column02 DATE);
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+DROP TABLE webpages, t, t_heap, t_heap2;
 CREATE TEMP TABLE t(a int);
 ALTER TABLE t ADD COLUMN b int;
 ERROR:  DuckDB does not support ALTER TABLE yet

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -146,7 +146,25 @@ DROP TABLE t;
 -- unsupported
 CREATE TEMP TABLE t(a int) ON COMMIT DROP;
 
+-- CTAS fully in Duckdb
 CREATE TEMP TABLE webpages USING duckdb AS SELECT * FROM read_csv('../../data/web_page.csv') as (column00 int, column01 text, column02 date);
+SELECT * FROM webpages ORDER BY column00 LIMIT 2;
+
+CREATE TEMP TABLE t_heap(a int) USING heap;
+INSERT INTO t_heap VALUES (1);
+
+-- CTAS from postgres table to duckdb table
+CREATE TEMP TABLE t(b) USING duckdb AS SELECT * FROM t_heap;
+SELECT * FROM t;
+
+-- CTAS from DuckDB table to postgres table
+CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t_heap;
+SELECT * FROM t_heap2;
+
+SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
+
+DROP TABLE webpages, t, t_heap, t_heap2;
+
 
 CREATE TEMP TABLE t(a int);
 ALTER TABLE t ADD COLUMN b int;


### PR DESCRIPTION
This is a follow up PR to #231 which adds support for CREATE TABLE AS for tables created with `USING duckdb`. With this change you can now run queries such as the following:

```
CREATE TEMP TABLE webpages USING duckdb AS SELECT * FROM read_csv('../../data/web_page.csv') as (column00 int, column01 text, column02 date);
```

The implementation does have the following limitations:
1. `EXPLAIN ANALYZE CREATE TABLE ... USING duckdb AS ...` does not work
2. It's not possible to use parameters of a prepared statement in the query that's part of the CREATE TABLE AS.