### PR TITLE
Automatically download git submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ COMPILE.cc.bc = $(CXX) -Wno-ignored-attributes -Wno-register $(BITCODE_CXXFLAGS)
 
 include Makefile.global
 
+# We need the DuckDB header files to build the .o files. We depend on the
+# duckdb Makefile, because that target pulls in the submodule which includes
+# those header files.
+$(OBJS): third_party/duckdb/Makefile
+
 # shlib is the final output product - make duckdb and all .o dependencies
 $(shlib): $(FULL_DUCKDB_LIB) $(OBJS)
 


### PR DESCRIPTION
It was reported on Discord that `make install` failed due to the submodule not being downloaded. This fixes that by having our object files depend on the duckdb submodule in the Makefile.
