### PR TITLE
Fix crash running DuckDB query after interruption

### DIFF
--- a/src/scan/heap_reader.cpp
+++ b/src/scan/heap_reader.cpp
@@ -112,6 +112,10 @@ HeapReader::ReadPageTuples(duckdb::DataChunk &output) {
 			ItemPointerSet(&(m_tuple.t_self), block, m_current_tuple_index);
 
 			if (!m_page_tuples_all_visible) {
+				if (!TransactionIdFollowsOrEquals(HeapTupleHeaderGetRawXmin(m_tuple.t_data), TransactionXmin)) {
+					continue;
+				}
+
 				visible = HeapTupleSatisfiesVisibility(&m_tuple, m_global_state->m_snapshot, m_buffer);
 				/* skip tuples not visible to this snapshot */
 				if (!visible)


### PR DESCRIPTION
Scenario:

* Run multiple queries in a row and interrupt them with Ctrl+C
* `set duckdb.execution = true;`
* `select 1 from foo;`

-> this would crash before this PR