### PR TITLE
Call `GetActiveSnapshot` when creating TX

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_storage.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_storage.hpp
@@ -10,18 +10,9 @@ extern "C" {
 
 namespace duckdb {
 
-class PostgresStorageExtensionInfo : public StorageExtensionInfo {
-public:
-	PostgresStorageExtensionInfo(Snapshot snapshot) : snapshot(snapshot) {
-	}
-
-public:
-	Snapshot snapshot;
-};
-
 class PostgresStorageExtension : public StorageExtension {
 public:
-	PostgresStorageExtension(Snapshot snapshot);
+	PostgresStorageExtension();
 };
 
 } // namespace duckdb

--- a/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 class PostgresTransactionManager : public TransactionManager {
 public:
-	PostgresTransactionManager(AttachedDatabase &db_p, PostgresCatalog &catalog, Snapshot snapshot);
+	PostgresTransactionManager(AttachedDatabase &db_p, PostgresCatalog &catalog);
 
 	Transaction &StartTransaction(ClientContext &context) override;
 	ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override;
@@ -19,7 +19,6 @@ public:
 
 private:
 	PostgresCatalog &catalog;
-	Snapshot snapshot;
 	mutex transaction_lock;
 	reference_map_t<Transaction, unique_ptr<Transaction>> transactions;
 };

--- a/src/catalog/pgduckdb_storage.cpp
+++ b/src/catalog/pgduckdb_storage.cpp
@@ -6,16 +6,12 @@ namespace duckdb {
 
 static unique_ptr<TransactionManager>
 CreateTransactionManager(StorageExtensionInfo *storage_info, AttachedDatabase &db, Catalog &catalog) {
-	auto &pg_storage_info = *(reinterpret_cast<PostgresStorageExtensionInfo *>(storage_info));
-	auto snapshot = pg_storage_info.snapshot;
-
-	return make_uniq<PostgresTransactionManager>(db, catalog.Cast<PostgresCatalog>(), snapshot);
+	return make_uniq<PostgresTransactionManager>(db, catalog.Cast<PostgresCatalog>());
 }
 
-PostgresStorageExtension::PostgresStorageExtension(Snapshot snapshot) {
+PostgresStorageExtension::PostgresStorageExtension() {
 	attach = PostgresCatalog::Attach;
 	create_transaction_manager = CreateTransactionManager;
-	storage_info = make_uniq<PostgresStorageExtensionInfo>(snapshot);
 }
 
 } // namespace duckdb

--- a/src/catalog/pgduckdb_transaction_manager.cpp
+++ b/src/catalog/pgduckdb_transaction_manager.cpp
@@ -10,13 +10,7 @@ PostgresTransactionManager::PostgresTransactionManager(AttachedDatabase &db_p, P
 
 Transaction &
 PostgresTransactionManager::StartTransaction(ClientContext &context) {
-	Snapshot snapshot;
-	{
-		std::lock_guard<std::mutex> lock(pgduckdb::DuckdbProcessLock::GetLock());
-		snapshot = GetActiveSnapshot();
-	}
-
-	auto transaction = make_uniq<PostgresTransaction>(*this, context, catalog, snapshot);
+	auto transaction = make_uniq<PostgresTransaction>(*this, context, catalog, GetActiveSnapshot());
 	auto &result = *transaction;
 	lock_guard<mutex> l(transaction_lock);
 	transactions[result] = std::move(transaction);

--- a/src/catalog/pgduckdb_transaction_manager.cpp
+++ b/src/catalog/pgduckdb_transaction_manager.cpp
@@ -3,16 +3,15 @@
 
 namespace duckdb {
 
-PostgresTransactionManager::PostgresTransactionManager(AttachedDatabase &db_p, PostgresCatalog &catalog,
-                                                       Snapshot snapshot)
-    : TransactionManager(db_p), catalog(catalog), snapshot(snapshot) {
+PostgresTransactionManager::PostgresTransactionManager(AttachedDatabase &db_p, PostgresCatalog &catalog)
+    : TransactionManager(db_p), catalog(catalog) {
 }
 
 Transaction &
 PostgresTransactionManager::StartTransaction(ClientContext &context) {
-	auto transaction = make_uniq<PostgresTransaction>(*this, context, catalog, snapshot);
-	auto &result = *transaction;
 	lock_guard<mutex> l(transaction_lock);
+	auto transaction = make_uniq<PostgresTransaction>(*this, context, catalog, GetActiveSnapshot());
+	auto &result = *transaction;
 	transactions[result] = std::move(transaction);
 	return result;
 }

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -80,7 +80,7 @@ DuckDBManager::DuckDBManager() {
 
 	database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
 	duckdb::DBConfig::GetConfig(*database->instance).storage_extensions["pgduckdb"] =
-	    duckdb::make_uniq<duckdb::PostgresStorageExtension>(GetActiveSnapshot());
+	    duckdb::make_uniq<duckdb::PostgresStorageExtension>();
 	duckdb::ExtensionInstallInfo extension_install_info;
 	database->instance->SetExtensionLoaded("pgduckdb", extension_install_info);
 

--- a/test/regression/expected/transaction_errors.out
+++ b/test/regression/expected/transaction_errors.out
@@ -1,0 +1,12 @@
+CREATE TABLE foo AS SELECT 'bar' AS t;
+BEGIN; SET duckdb.execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
+ERROR:  (PGDuckDB/ExecuteQuery) Conversion Error: Could not convert string 'bar' to INT32
+LINE 1: SELECT (t)::integer AS t1 FROM public.foo
+                  ^
+SET duckdb.execution = true;
+SELECT 1 FROM foo;
+ ?column? 
+----------
+        1
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -14,3 +14,4 @@ test: create_table_as
 test: standard_conforming_strings
 test: query_filter
 test: altered_tables
+test: transaction_errors

--- a/test/regression/sql/transaction_errors.sql
+++ b/test/regression/sql/transaction_errors.sql
@@ -1,0 +1,4 @@
+CREATE TABLE foo AS SELECT 'bar' AS t;
+BEGIN; SET duckdb.execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
+SET duckdb.execution = true;
+SELECT 1 FROM foo;


### PR DESCRIPTION
When moving from the creation of a DuckDB instance for each query to a singleton, we kept the same snapshot. This is obviously not correct.

This PR calls `GetActiveSnapshot` under a lock when creating a transaction.

Fixes https://github.com/duckdb/pg_duckdb/issues/245