### PR TITLE
fix builds that use older clang versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ override PG_CXXFLAGS += -std=c++17 -Wno-sign-compare -Wno-register ${DUCKDB_BUIL
 
 SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src -L$(PG_LIB) -lduckdb -lstdc++ -llz4
 
-COMPILE.cc.bc = $(CXX) -Wno-ignored-attributes -Wno-register $(BITCODE_CXXFLAGS) $(CXXFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -I$(INCLUDEDIR_SERVER) -emit-llvm -c
-COMPILE.cxx.bc = $(CLANG) -xc++ -Wno-ignored-attributes $(BITCODE_CXXFLAGS) $(CPPFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -flto=thin -emit-llvm -c
-
 include Makefile.global
 
 # We need the DuckDB header files to build the .o files. We depend on the
 # duckdb Makefile, because that target pulls in the submodule which includes
 # those header files.
 $(OBJS): third_party/duckdb/Makefile
+
+COMPILE.cc.bc += $(PG_CPPFLAGS) $(PG_CXXFLAGS)
+COMPILE.cxx.bc += $(PG_CPPFLAGS) $(PG_CXXFLAGS)
 
 # shlib is the final output product - make duckdb and all .o dependencies
 $(shlib): $(FULL_DUCKDB_LIB) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ include Makefile.global
 # those header files.
 $(OBJS): third_party/duckdb/Makefile
 
-COMPILE.cc.bc += $(PG_CPPFLAGS) $(PG_CXXFLAGS)
-COMPILE.cxx.bc += $(PG_CPPFLAGS) $(PG_CXXFLAGS)
+COMPILE.cc.bc += $(PG_CPPFLAGS)
+COMPILE.cxx.bc += $(PG_CXXFLAGS)
 
 # shlib is the final output product - make duckdb and all .o dependencies
 $(shlib): $(FULL_DUCKDB_LIB) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,6 @@ SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUI
 COMPILE.cc.bc = $(CXX) -Wno-ignored-attributes -Wno-register $(BITCODE_CXXFLAGS) $(CXXFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -I$(INCLUDEDIR_SERVER) -emit-llvm -c
 COMPILE.cxx.bc = $(CLANG) -xc++ -Wno-ignored-attributes $(BITCODE_CXXFLAGS) $(CPPFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -flto=thin -emit-llvm -c
 
-%.bc : %.cpp
-	$(COMPILE.cc.bc) $(SHLIB_LINK) -I$(INCLUDE_SERVER) -o $@ $<
-
 include Makefile.global
 
 # We need the DuckDB header files to build the .o files. We depend on the

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ override PG_CXXFLAGS += -std=c++17 -Wno-sign-compare -Wno-register ${DUCKDB_BUIL
 SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src -L$(PG_LIB) -lduckdb -lstdc++ -llz4
 
 COMPILE.cc.bc = $(CXX) -Wno-ignored-attributes -Wno-register $(BITCODE_CXXFLAGS) $(CXXFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -I$(INCLUDEDIR_SERVER) -emit-llvm -c
+COMPILE.cxx.bc = $(CLANG) -xc++ -Wno-ignored-attributes $(BITCODE_CXXFLAGS) $(CPPFLAGS) $(PG_CPPFLAGS) $(PG_CXXFLAGS) -flto=thin -emit-llvm -c
 
 %.bc : %.cpp
 	$(COMPILE.cc.bc) $(SHLIB_LINK) -I$(INCLUDE_SERVER) -o $@ $<


### PR DESCRIPTION
pass PG_CPPFLAGS and PG_CXXFLAGS to COMPILE.cxx.bc like we did for COMPILE.cc.bc

this fixes the build on ubuntu:22.04