### PR TITLE
Revert: Use -Werror in CI (#237)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -112,7 +112,7 @@ jobs:
         id: build
         run: |
           pushd duckdb
-          make -j8 install CFLAGS=-Werror CXXFLAGS=-Werror
+          make -j8 install
 
       - name: Run make installcheck
         id: installcheck


### PR DESCRIPTION
It seems my `-Werror` flag addition was waiting until the next time CI thought
it was necessary to rebuild DuckDB to blow up our build. This reverts the
change for now to fix the build on the main branch.
