### PR TITLE
Fix memory leaks in custom executor

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -74,4 +74,16 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 	}
 }
 
+template <typename FuncType, typename... FuncArgs>
+const char*
+DuckDBFunctionGuard(FuncType duckdb_function, FuncArgs... args) {
+	try {
+		duckdb_function(args...);
+	} catch (std::exception &ex) {
+		return pstrdup(ex.what());
+	}
+
+	return nullptr;
+}
+
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -30,7 +30,6 @@ template <typename T, typename FuncType, typename... FuncArgs>
 T
 PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 	T return_value;
-	bool error = false;
 	MemoryContext ctx = CurrentMemoryContext;
 	ErrorData *edata = nullptr;
 	// clang-format off
@@ -43,11 +42,10 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 		MemoryContextSwitchTo(ctx);
 		edata = CopyErrorData();
 		FlushErrorState();
-		error = true;
 	}
 	PG_END_TRY();
 	// clang-format on
-	if (error) {
+	if (edata) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, edata->message);
 	}
 	return return_value;
@@ -56,7 +54,6 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 template <typename FuncType, typename... FuncArgs>
 void
 PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
-	bool error = false;
 	MemoryContext ctx = CurrentMemoryContext;
 	ErrorData *edata = nullptr;
 	// clang-format off
@@ -69,11 +66,10 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 		MemoryContextSwitchTo(ctx);
 		edata = CopyErrorData();
 		FlushErrorState();
-		error = true;
 	}
 	PG_END_TRY();
 	// clang-format on
-	if (error) {
+	if (edata) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, edata->message);
 	}
 }

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -124,7 +124,7 @@ ExecuteQuery(DuckdbScanState *state) {
 
 	auto pending = prepared.PendingQuery(duckdb_params, true);
 	if (pending->HasError()) {
-		throw std::runtime_error(pending->GetError());
+		return pending->ThrowError();
 	}
 
 	duckdb::PendingExecutionResult execution_result;
@@ -144,7 +144,7 @@ ExecuteQuery(DuckdbScanState *state) {
 	} while (!duckdb::PendingQueryResult::IsResultReady(execution_result));
 
 	if (execution_result == duckdb::PendingExecutionResult::EXECUTION_ERROR) {
-		throw std::runtime_error(pending->GetError());
+		return pending->ThrowError();
 	}
 
 	query_results = pending->Execute();


### PR DESCRIPTION
When one calls `elog(ERROR,...` it `longjmp` out of the current stack leaving no chance for the C++ to be executed.

This PR is a first iteration toward what we want to rationalize (cf. https://github.com/duckdb/pg_duckdb/issues/93 ):
* keep a function with a pure C++ "flavor" (object creation, exceptions, etc.)
* call it in a new wrapper that copies out the error message and uses PG mechanism to throw the error

This fixes https://github.com/duckdb/pg_duckdb/issues/120, even though there still seem to be a small leak with DuckDB's `PrepareQuery` leftover (to be followed-up separately)