### PR TITLE
Get rid of PostgresContextState

### DIFF
--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -41,19 +41,6 @@ public:
 	bool m_exhausted_scan;
 };
 
-struct PostgresContextState : public duckdb::ClientContextState {
-public:
-	PostgresContextState(List *rtables, List *needed_columns, const char *query_string)
-	    : m_rtables(rtables), m_needed_columns(needed_columns), m_query_string(query_string) {
-	}
-	~PostgresContextState() override {};
-
-public:
-	List *m_rtables;
-	List *m_needed_columns;
-	std::string m_query_string;
-};
-
 duckdb::unique_ptr<duckdb::TableRef> PostgresReplacementScan(duckdb::ClientContext &context,
                                                              duckdb::ReplacementScanInput &input,
                                                              duckdb::optional_ptr<duckdb::ReplacementScanData> data);

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -104,10 +104,6 @@ PostgresTransaction::GetSchema(const string &name) {
 
 optional_ptr<CatalogEntry>
 PostgresTransaction::GetCatalogEntry(CatalogType type, const string &schema, const string &name) {
-	auto scan_data = context.lock()->registered_state->Get<pgduckdb::PostgresContextState>("postgres_state");
-	if (!scan_data) {
-		throw InternalException("Could not find 'postgres_state' in 'PostgresTransaction::GetCatalogEntry'");
-	}
 	switch (type) {
 	case CatalogType::TABLE_ENTRY: {
 		auto it = schemas.find(schema);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -166,8 +166,6 @@ DuckdbCreateConnection(List *rtables, List *needed_columns, const char *query) {
 	auto con = duckdb::make_uniq<duckdb::Connection>(db);
 	auto &context = *con->context;
 
-	context.registered_state->Insert("postgres_state",
-	                                 duckdb::make_shared_ptr<PostgresContextState>(rtables, needed_columns, query));
 	auto res = context.Query("set search_path='pgduckdb.main'", false);
 	if (res->HasError()) {
 		elog(WARNING, "(DuckDB) %s", res->GetError().c_str());

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -126,15 +126,6 @@ PostgresReplacementScan(duckdb::ClientContext &context, duckdb::ReplacementScanI
 
 	auto &schema_name = input.schema_name;
 	auto &table_name = input.table_name;
-	auto scan_data = context.registered_state->Get<PostgresContextState>("postgres_state");
-	if (!scan_data) {
-		/* There is no scan data provided by postgres so we cannot access any
-		 * of postgres tables. This is the case for queries that are not
-		 * directly based on a Postgres query, such as queries that pg_duckdb
-		 * executes internally like CREATE SECRET.
-		 */
-		return nullptr;
-	}
 
 	auto relid = FindMatchingRelation(schema_name, table_name);
 


### PR DESCRIPTION
Since #247 is merged PostgresContextState is not actually used anymore. So this removes it completely. This will make a bunch of PRs easier to implement, specifically #241 and #206.
