### PR TITLE
Sync after each insert/update/delete of `duckdb.secrets` table

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -12,25 +12,34 @@ namespace pgduckdb {
 
 class DuckDBManager {
 public:
-	static inline const DuckDBManager &
+	static inline DuckDBManager &
 	Get() {
 		static DuckDBManager instance;
 		return instance;
 	}
 
 	inline duckdb::DuckDB &
-	GetDatabase() const {
+	GetDatabase() {
+		if(CheckSecretsSeq()) {
+			auto connection = duckdb::make_uniq<duckdb::Connection>(*database);
+			auto &context = *connection->context;
+			DropSecrets(context);
+			LoadSecrets(context);
+		}
 		return *database;
 	}
 
 private:
 	DuckDBManager();
 	void InitializeDatabase();
-
+	bool CheckSecretsSeq();
 	void LoadSecrets(duckdb::ClientContext &);
+	void DropSecrets(duckdb::ClientContext &);
 	void LoadExtensions(duckdb::ClientContext &);
 	void LoadFunctions(duckdb::ClientContext &);
 
+	int secret_table_num_rows;
+	int secret_table_current_seq;
 	duckdb::unique_ptr<duckdb::DuckDB> database;
 };
 

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -108,6 +108,9 @@ $func$;
 CREATE SCHEMA duckdb;
 SET search_path TO duckdb;
 
+CREATE SEQUENCE secret_table_seq START WITH 1 INCREMENT BY 1;
+SELECT setval('secret_table_seq', 1);
+
 CREATE TABLE secrets (
     type TEXT NOT NULL,
     id TEXT NOT NULL,
@@ -119,6 +122,18 @@ CREATE TABLE secrets (
     use_ssl BOOLEAN DEFAULT true,
     CONSTRAINT type_constraint CHECK (type IN ('S3', 'GCS', 'R2'))
 );
+
+CREATE OR REPLACE FUNCTION duckdb_update_secret_table_seq()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    PERFORM nextval('duckdb.secret_table_seq');
+    RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+
+CREATE TRIGGER secrets_table_seq_tr AFTER INSERT OR UPDATE OR DELETE ON secrets
+EXECUTE FUNCTION duckdb_update_secret_table_seq();
 
 CREATE OR REPLACE FUNCTION duckdb_secret_r2_check()
 RETURNS TRIGGER AS

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -108,8 +108,8 @@ $func$;
 CREATE SCHEMA duckdb;
 SET search_path TO duckdb;
 
-CREATE SEQUENCE secret_table_seq START WITH 1 INCREMENT BY 1;
-SELECT setval('secret_table_seq', 1);
+CREATE SEQUENCE secrets_table_seq START WITH 1 INCREMENT BY 1;
+SELECT setval('secrets_table_seq', 1);
 
 CREATE TABLE secrets (
     type TEXT NOT NULL,
@@ -123,17 +123,17 @@ CREATE TABLE secrets (
     CONSTRAINT type_constraint CHECK (type IN ('S3', 'GCS', 'R2'))
 );
 
-CREATE OR REPLACE FUNCTION duckdb_update_secret_table_seq()
+CREATE OR REPLACE FUNCTION duckdb_update_secrets_table_seq()
 RETURNS TRIGGER AS
 $$
 BEGIN
-    PERFORM nextval('duckdb.secret_table_seq');
+    PERFORM nextval('duckdb.secrets_table_seq');
     RETURN NEW;
 END;
 $$ LANGUAGE PLpgSQL;
 
 CREATE TRIGGER secrets_table_seq_tr AFTER INSERT OR UPDATE OR DELETE ON secrets
-EXECUTE FUNCTION duckdb_update_secret_table_seq();
+EXECUTE FUNCTION duckdb_update_secrets_table_seq();
 
 CREATE OR REPLACE FUNCTION duckdb_secret_r2_check()
 RETURNS TRIGGER AS

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -114,7 +114,7 @@ DuckDBManager::LoadFunctions(duckdb::ClientContext &context) {
 bool
 DuckDBManager::CheckSecretsSeq() {
 	Oid duckdb_namespace = get_namespace_oid("duckdb", false);
-	Oid secret_table_seq_oid = get_relname_relid("secret_table_seq", duckdb_namespace);
+	Oid secret_table_seq_oid = get_relname_relid("secrets_table_seq", duckdb_namespace);
 	int64 seq =
 	    PostgresFunctionGuard<int64>(DirectFunctionCall1Coll, pg_sequence_last_value, InvalidOid, secret_table_seq_oid);
 	if (secret_table_current_seq < seq) {

--- a/test/regression/expected/secrets.out
+++ b/test/regression/expected/secrets.out
@@ -1,0 +1,57 @@
+SET duckdb.execution TO false;
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+NOTICE:  result: name	
+VARCHAR	
+[ Rows: 0]
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+-- INSERT SHOULD TRIGGER UPDATE OF SECRETS
+INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+NOTICE:  result: name	
+VARCHAR	
+[ Rows: 1]
+pgduckb_secret_0
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+NOTICE:  result: name	
+VARCHAR	
+[ Rows: 2]
+pgduckb_secret_0
+pgduckb_secret_1
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+-- DELETE SHOULD TRIGGER UPDATE OF SECRETS
+DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+NOTICE:  result: name	
+VARCHAR	
+[ Rows: 1]
+pgduckb_secret_0
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+SET duckdb.execution TO true;

--- a/test/regression/expected/secrets.out
+++ b/test/regression/expected/secrets.out
@@ -10,9 +10,21 @@ VARCHAR
  
 (1 row)
 
+SELECT last_value FROM duckdb.secrets_table_seq;
+ last_value 
+------------
+          1
+(1 row)
+
 -- INSERT SHOULD TRIGGER UPDATE OF SECRETS
 INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
+SELECT last_value FROM duckdb.secrets_table_seq;
+ last_value 
+------------
+          2
+(1 row)
+
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 NOTICE:  result: name	
 VARCHAR	
@@ -27,6 +39,12 @@ pgduckb_secret_0
 
 INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
+SELECT last_value FROM duckdb.secrets_table_seq;
+ last_value 
+------------
+          3
+(1 row)
+
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 NOTICE:  result: name	
 VARCHAR	
@@ -42,6 +60,12 @@ pgduckb_secret_1
 
 -- DELETE SHOULD TRIGGER UPDATE OF SECRETS
 DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+SELECT last_value FROM duckdb.secrets_table_seq;
+ last_value 
+------------
+          4
+(1 row)
+
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 NOTICE:  result: name	
 VARCHAR	

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -15,3 +15,4 @@ test: standard_conforming_strings
 test: query_filter
 test: altered_tables
 test: transaction_errors
+test: secrets

--- a/test/regression/sql/secrets.sql
+++ b/test/regression/sql/secrets.sql
@@ -3,20 +3,28 @@ SET duckdb.execution TO false;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
+SELECT last_value FROM duckdb.secrets_table_seq;
+
 -- INSERT SHOULD TRIGGER UPDATE OF SECRETS
 
 INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
+
+SELECT last_value FROM duckdb.secrets_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
 INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
 
+SELECT last_value FROM duckdb.secrets_table_seq;
+
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
 -- DELETE SHOULD TRIGGER UPDATE OF SECRETS
 DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+
+SELECT last_value FROM duckdb.secrets_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 

--- a/test/regression/sql/secrets.sql
+++ b/test/regression/sql/secrets.sql
@@ -1,0 +1,23 @@
+
+SET duckdb.execution TO false;
+
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+
+-- INSERT SHOULD TRIGGER UPDATE OF SECRETS
+
+INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
+
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+
+INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
+
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+
+-- DELETE SHOULD TRIGGER UPDATE OF SECRETS
+DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+
+SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
+
+SET duckdb.execution TO true;


### PR DESCRIPTION
If duckdb.secrets table is inserted, updated or deleted in same connection we would not sync changes for next query. Introduce sequence that keeps track of each change so we can compare with and sync if required.