### PR TITLE
Harden against Postgres interactions with C++ destructors

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -82,6 +82,8 @@ __CPPFunctionGuard__(const char *func_name, FuncArgs... args) {
 
 #define InvokeCPPFunc(FUNC, ...) pgduckdb::__CPPFunctionGuard__<decltype(&FUNC), &FUNC>(__FUNCTION__, __VA_ARGS__)
 
+int SPI_exec_or_throw(const char *query, int tcount, int expected_ret_code);
+
 // Wrappers
 
 #define DECLARE_PG_FUNCTION(func_name)                                                                                 \

--- a/include/pgduckdb/types/decimal.hpp
+++ b/include/pgduckdb/types/decimal.hpp
@@ -108,6 +108,8 @@ extern "C" {
 #include "utils/numeric.h"
 }
 
+#include "duckdb/common/exception/conversion_exception.hpp"
+
 typedef int16_t NumericDigit;
 
 struct NumericShort {
@@ -258,7 +260,7 @@ CreateNumeric(const NumericVar &var, bool *have_error) {
 			*have_error = true;
 			return NULL;
 		} else {
-			ereport(ERROR, (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE), errmsg("value overflows numeric format")));
+			throw duckdb::ConversionException("value overflows numeric format");
 		}
 	}
 	return result;

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -60,7 +60,7 @@ SchemaItems::GetTable(const string &entry_name) {
 	// Check if the Relation is a VIEW
 	auto tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(rel_oid));
 	if (!HeapTupleIsValid(tuple)) {
-		elog(ERROR, "Cache lookup failed for relation %u", rel_oid);
+		throw std::runtime_error("Cache lookup failed for relation " + std::to_string(rel_oid));
 	}
 
 	auto relForm = (Form_pg_class)GETSTRUCT(tuple);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -132,30 +132,28 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 
 	int secret_id = 0;
 	for (auto &secret : duckdb_secrets) {
-		StringInfo secret_key = makeStringInfo();
+		std::ostringstream query;
 		bool is_r2_cloud_secret = (secret.type.rfind("R2", 0) == 0);
-		appendStringInfo(secret_key, "CREATE SECRET pgduckb_secret_%d ", secret_id);
-		appendStringInfo(secret_key, "(TYPE %s, KEY_ID '%s', SECRET '%s'", secret.type.c_str(), secret.key_id.c_str(),
-		                 secret.secret.c_str());
+		query << "CREATE SECRET pgduckb_secret_" << secret_id << " ";
+		query << "(TYPE " << secret.type << ", KEY_ID '" << secret.key_id << "', SECRET '" << secret.secret << "'";
 		if (secret.region.length() && !is_r2_cloud_secret) {
-			appendStringInfo(secret_key, ", REGION '%s'", secret.region.c_str());
+			query << ", REGION '" << secret.region << "'";
 		}
 		if (secret.session_token.length() && !is_r2_cloud_secret) {
-			appendStringInfo(secret_key, ", SESSION_TOKEN '%s'", secret.session_token.c_str());
+			query << ", SESSION_TOKEN '" << secret.session_token << "'";
 		}
 		if (secret.endpoint.length() && !is_r2_cloud_secret) {
-			appendStringInfo(secret_key, ", ENDPOINT '%s'", secret.endpoint.c_str());
+			query << ", ENDPOINT '" << secret.endpoint << "'";
 		}
 		if (is_r2_cloud_secret) {
-			appendStringInfo(secret_key, ", ACCOUNT_ID '%s'", secret.endpoint.c_str());
+			query << ", ACCOUNT_ID '" << secret.endpoint << "'";
 		}
 		if (!secret.use_ssl) {
-			appendStringInfo(secret_key, ", USE_SSL 'FALSE'");
+			query << ", USE_SSL 'FALSE'";
 		}
-		appendStringInfo(secret_key, ");");
-		DuckDBQueryOrThrow(context, secret_key->data);
+		query << ");";
 
-		pfree(secret_key->data);
+		DuckDBQueryOrThrow(context, query.str());
 		secret_id++;
 		secret_table_num_rows = secret_id;
 	}
@@ -163,7 +161,7 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 
 void
 DuckDBManager::DropSecrets(duckdb::ClientContext &context) {
-	for (auto secret_id = 0; secret_id < secret_table_num_rows; secret_id++) {
+	for (auto secret_id = 0; secret_id < secret_table_num_rows; ++secret_id) {
 		auto drop_secret_cmd = duckdb::StringUtil::Format("DROP SECRET pgduckb_secret_%d;", secret_id);
 		pgduckdb::DuckDBQueryOrThrow(context, drop_secret_cmd);
 	}

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -200,7 +200,8 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 duckdb::unique_ptr<duckdb::Connection>
 DuckDBManager::CreateConnection() {
 	if (!pgduckdb::IsDuckdbExecutionAllowed()) {
-		elog(ERROR, "DuckDB execution is not allowed because you have not been granted the duckdb.postgres_role");
+		throw std::runtime_error(
+		    "DuckDB execution is not allowed because you have not been granted the duckdb.postgres_role");
 	}
 
 	auto &instance = Get();

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -131,8 +131,9 @@ DuckdbInstallExtension(Datum name_datum) {
 		ON CONFLICT (name) DO UPDATE SET enabled = true
 		)",
 	                                 lengthof(arg_types), arg_types, values, NULL, false, 0);
-	if (ret != SPI_OK_INSERT)
-		elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
+	if (ret != SPI_OK_INSERT) {
+		throw std::runtime_error("SPI_exec failed: error code " + std::string(SPI_result_code_string(ret)));
+	}
 	SPI_finish();
 
 	return true;

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -782,7 +782,8 @@ ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type) {
 	case FLOAT8OID:
 		return duckdb::Value::DOUBLE(DatumGetFloat8(value));
 	default:
-		elog(ERROR, "Could not convert Postgres parameter of type: %d to DuckDB type", postgres_type);
+		throw duckdb::NotImplementedException("Could not convert Postgres parameter of type: %d to DuckDB type",
+		                                      postgres_type);
 	}
 }
 

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -61,6 +61,15 @@ CreateOrGetDirectoryPath(const char* directory_name) {
 	return duckdb_data_directory;
 }
 
+int
+SPI_exec_or_throw(const char *query, int tcount, int expected_ret_code) {
+	int ret = SPI_exec(query, tcount);
+	if (ret != expected_ret_code) {
+		throw std::runtime_error(std::string("SPI_exec failed: error code ") + SPI_result_code_string(ret));
+	}
+	return ret;
+}
+
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
 	auto res = context.Query(query, false);

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -63,21 +63,11 @@ CreateOrGetDirectoryPath(const char* directory_name) {
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
-	const char *error_message = nullptr;
-	{
-		auto res = context.Query(query, false);
-		if (!res->HasError()) {
-			return res;
-		}
-
-		error_message = pstrdup(res->GetError().c_str());
+	auto res = context.Query(query, false);
+	if (res->HasError()) {
+		res->ThrowError();
 	}
-
-	if (error_message) {
-		elog(ERROR, "(PGDuckDB/DuckDBQuery) %s", error_message);
-	}
-
-	return nullptr; // unreachable
+	return res;
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -110,10 +110,9 @@ CheckQueryPermissions(Query *query, const char *query_string) {
 
 	foreach_node(RangeTblEntry, rte, postgres_plan->rtable) {
 		if (check_enable_rls(rte->relid, InvalidOid, false) == RLS_ENABLED) {
-			ereport(ERROR,
-			        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			         errmsg("(PGDuckDB/CheckQueryPermissions) RLS enabled on \"%s\", cannot use DuckDB based COPY",
-			                get_rel_name(rte->relid))));
+			throw duckdb::NotImplementedException("(PGDuckDB/CheckQueryPermissions) RLS enabled on \"" +
+			                                      std::string(get_rel_name(rte->relid)) +
+			                                      "\", cannot use DuckDB based COPY");
 		}
 	}
 }

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -38,7 +38,7 @@ ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Permission Erro
 -- Should fail because DuckDB execution is not allowed for this user
 SET ROLE user3;
 SELECT * FROM t;
-ERROR:  DuckDB execution is not allowed because you have not been granted the duckdb.postgres_role
+ERROR:  (PGDuckDB/DuckdbPlanNode) DuckDB execution is not allowed because you have not been granted the duckdb.postgres_role
 -- Should work with regular posgres execution though, because this user is
 -- allowed to read the table.
 SET duckdb.force_execution = false;
@@ -60,7 +60,7 @@ SELECT * FROM t;
 -- Should fail now, we don't support RLS
 SET ROLE user1;
 SELECT * FROM t;
-ERROR:  (PGDuckDB/pgduckdb_relation_name) Cannot use "t" in a DuckDB query, because RLS is enabled on it
+ERROR:  (PGDuckDB/DuckdbPlanNode) Not implemented Error: (PGDuckDB/pgduckdb_relation_name) Cannot use "t" in a DuckDB query, because RLS is enabled on it
 RESET ROLE;
 DROP TABLE t;
 DROP USER user1, user2;

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -132,7 +132,7 @@ VARCHAR	VARCHAR	VARCHAR
 (1 row)
 
 CREATE TABLE t(a int);
-ERROR:  Only TEMP tables are supported in DuckDB if MotherDuck support is not enabled
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: Only TEMP tables are supported in DuckDB if MotherDuck support is not enabled
 -- XXX: A better error message would be nice here, but for now this is acceptable.
 CREATE TEMP TABLE t(a int PRIMARY KEY);
 ERROR:  duckdb does not implement duckdb_index_build_range_scan
@@ -140,12 +140,12 @@ ERROR:  duckdb does not implement duckdb_index_build_range_scan
 CREATE TEMP TABLE t(a int UNIQUE);
 ERROR:  duckdb does not implement duckdb_index_build_range_scan
 CREATE TEMP TABLE t(a int, b int GENERATED ALWAYS AS (a + 1) STORED);
-ERROR:  DuckDB does not support STORED generated columns
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: DuckDB does not support STORED generated columns
 CREATE TEMP TABLE t(a int GENERATED ALWAYS AS IDENTITY);
-ERROR:  Identity columns are not supported in DuckDB
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: Identity columns are not supported in DuckDB
 CREATE TEMP TABLE theap(b int PRIMARY KEY) USING heap;
 CREATE TEMP TABLE t(a int REFERENCES theap(b));
-ERROR:  DuckDB tables do not support foreign keys
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: DuckDB tables do not support foreign keys
 DROP TABLE theap;
 -- allowed but all other collations are not supported
 CREATE TEMP TABLE t(a text COLLATE "default");
@@ -155,11 +155,11 @@ DROP TABLE t;
 CREATE TEMP TABLE t(a text COLLATE "POSIX");
 DROP TABLE t;
 CREATE TEMP TABLE t(a text COLLATE "de-x-icu");
-ERROR:  DuckDB does not support column collations
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: DuckDB does not support column collations
 CREATE TEMP TABLE t(A text COMPRESSION "pglz");
-ERROR:  Column compression is not supported in DuckDB
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: Column compression is not supported in DuckDB
 CREATE TEMP TABLE t(a int) WITH (fillfactor = 50);
-ERROR:  Storage options are not supported in DuckDB
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: Storage options are not supported in DuckDB
 CREATE TEMP TABLE cities_duckdb (
   name       text,
   population real,
@@ -205,7 +205,7 @@ SELECT * FROM t;
 DROP TABLE t;
 -- unsupported
 CREATE TEMP TABLE t(a int) ON COMMIT DROP;
-ERROR:  DuckDB does not support ON COMMIT DROP
+ERROR:  (PGDuckDB/duckdb_create_table_trigger) Not implemented Error: DuckDB does not support ON COMMIT DROP
 -- CTAS fully in Duckdb
 CREATE TEMP TABLE webpages USING duckdb AS SELECT * FROM read_csv('../../data/web_page.csv') as (column00 int, column01 text, column02 date);
 SELECT * FROM webpages ORDER BY column00 LIMIT 2;


### PR DESCRIPTION
Fixes https://github.com/duckdb/pg_duckdb/issues/93

* make sure that no function uses `elog(ERROR...` which would bypass C++ dtors, and instead throw regular exceptions
* wraps every PG hooks in a try/catch block that converts the C++ exception to an PG equivalent (`elog(ERROR, ...` form)