### PR TITLE
Revert "Fix memory leaks in custom executor (#251)"

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -5,7 +5,6 @@ extern "C" {
 }
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/error_data.hpp"
 
 #include <vector>
 #include <string>
@@ -31,6 +30,7 @@ template <typename T, typename FuncType, typename... FuncArgs>
 T
 PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 	T return_value;
+	bool error = false;
 	MemoryContext ctx = CurrentMemoryContext;
 	ErrorData *edata = nullptr;
 	// clang-format off
@@ -43,10 +43,11 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 		MemoryContextSwitchTo(ctx);
 		edata = CopyErrorData();
 		FlushErrorState();
+		error = true;
 	}
 	PG_END_TRY();
 	// clang-format on
-	if (edata) {
+	if (error) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, edata->message);
 	}
 	return return_value;
@@ -55,6 +56,7 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 template <typename FuncType, typename... FuncArgs>
 void
 PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
+	bool error = false;
 	MemoryContext ctx = CurrentMemoryContext;
 	ErrorData *edata = nullptr;
 	// clang-format off
@@ -67,33 +69,13 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 		MemoryContextSwitchTo(ctx);
 		edata = CopyErrorData();
 		FlushErrorState();
+		error = true;
 	}
 	PG_END_TRY();
 	// clang-format on
-	if (edata) {
+	if (error) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, edata->message);
 	}
-}
-
-template <typename FuncType, typename... FuncArgs>
-const char*
-DuckDBFunctionGuard(FuncType duckdb_function, FuncArgs... args) {
-	try {
-		duckdb_function(args...);
-	} catch (duckdb::Exception &ex) {
-		duckdb::ErrorData edata(ex.what());
-		return pstrdup(edata.Message().c_str());
-	} catch (std::exception &ex) {
-		const auto msg = ex.what();
-		if (msg[0] == '{') {
-			duckdb::ErrorData edata(ex.what());
-			return pstrdup(edata.Message().c_str());
-		} else {
-			return pstrdup(ex.what());
-		}
-	}
-
-	return nullptr;
 }
 
 } // namespace pgduckdb


### PR DESCRIPTION
This reverts commit 59ada4b35c372f36aca0968273ed72ec341a23f9.

Seems that the previous PR is causing issues like:
```
2024-10-07 15:55:16.797 CEST client backend[159884] pg_regress/execution_error STATEMENT:  select a::INTEGER from int_as_varchar;
TRAP: failed Assert("rel->rd_refcnt > 0"), File: "relcache.c", Line: 2176, PID: 159884
postgres: jelte regression [local] idle(ExceptionalCondition+0x6e)[0x5ff6eb3300a4]
postgres: jelte regression [local] idle(RelationDecrementReferenceCount+0x38)[0x5ff6eb323998]
postgres: jelte regression [local] idle(RelationClose+0x15)[0x5ff6eb3239c5]
/home/jelte/.pgenv/pgsql-17beta9/lib/pg_duckdb.so(+0x2b836)[0x7c5b33ae6836]
/home/jelte/.pgenv/pgsql-17beta9/lib/pg_duckdb.so(+0x2bc7e)[0x7c5b33ae6c7e]
/home/jelte/.pgenv/pgsql-17beta9/lib/pg_duckdb.so(+0x2bdbd)[0x7c5b33ae6dbd]
/home/jelte/.pgenv/pgsql-17beta9/lib/pg_duckdb.so(+0x2e015)[0x7c5b33ae9015]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZN6duckdb16AttachedDatabaseD1Ev+0x2d)[0x7c5b2f707edd]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZN6duckdb16AttachedDatabaseD0Ev+0xd)[0x7c5b2f707f1d]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(+0x1409628)[0x7c5b2f009628]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZN6duckdb10CatalogSetD1Ev+0x2e)[0x7c5b2f00c66e]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZN6duckdb15DatabaseManager14ResetDatabasesERNS_10unique_ptrINS_13TaskSchedulerESt14default_deleteIS2_ELb1EEE+0xfd)[0x7c5b2f70830d]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZN6duckdb16DatabaseInstanceD1Ev+0x25)[0x7c5b2f70b5c5]
/home/jelte/.pgenv/pgsql-17beta9/lib/libduckdb.so(_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE24_M_release_last_use_coldEv+0xe)[0x7c5b2e5d9a6e]
/home/jelte/.pgenv/pgsql-17beta9/lib/pg_duckdb.so(+0x1a6f5)[0x7c5b33ad56f5]
/lib/x86_64-linux-gnu/libc.so.6(+0x47a66)[0x7c5b32e47a66]
/lib/x86_64-linux-gnu/libc.so.6(+0x47bae)[0x7c5b32e47bae]
postgres: jelte regression [local] idle(proc_exit+0x3d)[0x5ff6eb1b013a]
postgres: jelte regression [local] idle(PostgresMain+0x37e)[0x5ff6eb1e0ffe]
postgres: jelte regression [local] idle(BackendMain+0x51)[0x5ff6eb1da61b]
postgres: jelte regression [local] idle(postmaster_child_launch+0xc7)[0x5ff6eb131860]
postgres: jelte regression [local] idle(+0x444029)[0x5ff6eb136029]
postgres: jelte regression [local] idle(+0x4442ac)[0x5ff6eb1362ac]
postgres: jelte regression [local] idle(BackgroundWorkerInitializeConnection+0x0)[0x5ff6eb137920]
postgres: jelte regression [local] idle(main+0x20e)[0x5ff6eb053282]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7c5b32e2a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7c5b32e2a28b]
postgres: jelte regression [local] idle(_start+0x25)[0x5ff6eadcfef5]
```
Reverting to investigate