### PR TITLE
Fix memory leaks in custom executor

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -5,6 +5,7 @@ extern "C" {
 }
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/error_data.hpp"
 
 #include <vector>
 #include <string>
@@ -72,6 +73,32 @@ PostgresFunctionGuard(FuncType postgres_function, FuncArgs... args) {
 	if (edata) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, edata->message);
 	}
+}
+
+template <typename FuncRetT, typename FuncType, typename... FuncArgs>
+FuncRetT
+DuckDBFunctionGuard(FuncType duckdb_function, const char* function_name, FuncArgs... args) {
+	const char *error_message = nullptr;
+	try {
+		return duckdb_function(args...);
+	} catch (duckdb::Exception &ex) {
+		duckdb::ErrorData edata(ex.what());
+		error_message = pstrdup(edata.Message().c_str());
+	} catch (std::exception &ex) {
+		const auto msg = ex.what();
+		if (msg[0] == '{') {
+			duckdb::ErrorData edata(ex.what());
+			error_message = pstrdup(edata.Message().c_str());
+		} else {
+			error_message = pstrdup(ex.what());
+		}
+	}
+
+	if (error_message) {
+		elog(ERROR, "(PGDuckDB/%s) %s", function_name, error_message);
+	}
+
+	std::abort(); // Cannot reach.
 }
 
 } // namespace pgduckdb

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -108,7 +108,8 @@ CreatePlan(Query *query) {
 PlannedStmt *
 DuckdbPlanNode(Query *parse, int cursor_options) {
 	/* We need to check can we DuckDB create plan */
-	Plan *duckdb_plan = (Plan *)castNode(CustomScan, CreatePlan(parse));
+	Plan *plan = pgduckdb::DuckDBFunctionGuard<Plan*>(CreatePlan, "CreatePlan", parse);
+	Plan *duckdb_plan = (Plan *)castNode(CustomScan, plan);
 
 	if (!duckdb_plan) {
 		return nullptr;


### PR DESCRIPTION
When one calls `elog(ERROR,...` it `longjmp` out of the current stack leaving no chance for the C++ to be executed.

This PR is a first iteration toward what we want to rationalize (cf. https://github.com/duckdb/pg_duckdb/issues/93 ):
* keep a function with a pure C++ "flavor" (object creation, exceptions, etc.)
* call it in a new wrapper that copies out the error message and uses PG mechanism to throw the error

This fixes https://github.com/duckdb/pg_duckdb/issues/120, even though there still seem to be a small leak with DuckDB's `PrepareQuery` leftover (to be followed-up separately)