### PR TITLE
cleanup duckdb build

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-24.04
-    name: 'Linting and formatting'
+    name: "Linting and formatting"
 
     steps:
       - name: Checkout pg_duckdb extension code
@@ -17,7 +17,7 @@ jobs:
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install clang-format (11.0.1) and ruff
         run: python3 -m pip install "clang-format==11.0.1" ruff
@@ -29,7 +29,7 @@ jobs:
         run: ruff format --diff
 
   build-and-test:
-    name: 'Build and test'
+    name: "Build and test"
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +46,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
             libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo6 cmake \
-            libstdc++-12-dev
+            libstdc++-12-dev ninja-build
           echo "${PWD}/postgres/inst/bin:$PATH'" > $GITHUB_PATH
 
       - name: ccache
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
           path: duckdb
 
       - name: Checkout PostgreSQL code
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Setup DuckDB build cache
         id: cache-duckdb-build

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: duckdb/third_party/duckdb/build/
-          key: duckdb-build-ubuntu-24.04-${{ steps.versions.outputs.duckdb_sha }}
+          key: duckdb-build-ubuntu-24.04-${{ steps.versions.outputs.duckdb_sha }}-ninja
 
       - name: Install pytest and other test requirements
         run: python3 -m pip install -r duckdb/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: duckdb install-duckdb clean-duckdb clean-all lintcheck check-regression-duckdb clean-regression
 
+DUCKDB_VERSION = v1.1.1
+
 MODULE_big = pg_duckdb
 EXTENSION = pg_duckdb
 DATA = pg_duckdb.control $(wildcard sql/pg_duckdb--*.sql)
@@ -69,7 +71,7 @@ duckdb_cmake_vars = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
-	OVERRIDE_GIT_DESCRIBE=v1.1.1 \
+	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
 	GEN=ninja \
 	CMAKE_VARS="$(duckdb_cmake_vars)"
 	DISABLE_SANITIZER=1 \

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,13 @@ duckdb: $(FULL_DUCKDB_LIB)
 third_party/duckdb/Makefile:
 	git submodule update --init --recursive
 
+duckdb_gen ?= ninja
 duckdb_cmake_vars = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
 	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
-	GEN=ninja \
+	GEN=$(duckdb_gen) \
 	CMAKE_VARS="$(duckdb_cmake_vars)"
 	DISABLE_SANITIZER=1 \
 	DISABLE_UBSAN=1 \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY: duckdb install-duckdb clean-duckdb clean-all lintcheck check-regression-duckdb clean-regression
 
-DUCKDB_VERSION = v1.1.1
-
 MODULE_big = pg_duckdb
 EXTENSION = pg_duckdb
 DATA = pg_duckdb.control $(wildcard sql/pg_duckdb--*.sql)
@@ -12,9 +10,15 @@ OBJS = $(subst .cpp,.o, $(SRCS))
 C_SRCS = $(wildcard src/*.c src/*/*.c)
 OBJS += $(subst .c,.o, $(C_SRCS))
 
+# set to `make` to disable ninja
+DUCKDB_GEN ?= ninja
+# used to know what version of extensions to download
+DUCKDB_VERSION = v1.1.1
+# duckdb build tweaks
+DUCKDB_CMAKE_VARS = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
+
 DUCKDB_BUILD_CXX_FLAGS=
 DUCKDB_BUILD_TYPE=
-
 ifeq ($(DUCKDB_BUILD), Debug)
 	DUCKDB_BUILD_CXX_FLAGS = -g -O0
 	DUCKDB_BUILD_TYPE = debug
@@ -67,14 +71,12 @@ duckdb: $(FULL_DUCKDB_LIB)
 third_party/duckdb/Makefile:
 	git submodule update --init --recursive
 
-duckdb_gen ?= ninja
-duckdb_cmake_vars = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
 	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
-	GEN=$(duckdb_gen) \
-	CMAKE_VARS="$(duckdb_cmake_vars)"
+	GEN=$(DUCKDB_GEN) \
+	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)"
 	DISABLE_SANITIZER=1 \
 	DISABLE_UBSAN=1 \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake"

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,15 @@ duckdb: $(FULL_DUCKDB_LIB)
 third_party/duckdb/Makefile:
 	git submodule update --init --recursive
 
+duckdb_cmake_vars = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
+	OVERRIDE_GIT_DESCRIBE=v1.1.1 \
+	GEN=ninja \
+	CMAKE_VARS="$(duckdb_cmake_vars)"
 	DISABLE_SANITIZER=1 \
-	ENABLE_UBSAN=0 \
-	BUILD_UNITTESTS=OFF \
+	DISABLE_UBSAN=1 \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake"
 
 install-duckdb: $(FULL_DUCKDB_LIB) $(shlib)


### PR DESCRIPTION
* dont build duckdb shell and other things we aren't using
* use correct flags that are supported by the Makefile
* start using ninja
* specify `OVERRIDE_GIT_DESCRIBE` via `DUCKDB_VERSION`