### PR TITLE
Create a single way of creating a connection

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -23,6 +23,8 @@ public:
 		return *database;
 	}
 
+	duckdb::unique_ptr<duckdb::Connection> GetConnection() const;
+
 private:
 	DuckDBManager();
 	void InitializeDatabase();
@@ -33,7 +35,5 @@ private:
 
 	duckdb::unique_ptr<duckdb::DuckDB> database;
 };
-
-duckdb::unique_ptr<duckdb::Connection> DuckdbCreateConnection(List *rtables, List *needed_columns, const char *query);
 
 } // namespace pgduckdb

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -30,8 +30,7 @@ extern "C" {
  */
 void
 DuckdbTruncateTable(Oid relation_oid) {
-	auto db = pgduckdb::DuckDBManager::Get().GetDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
+	auto connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto &context = *connection->context;
 	auto query = std::string("TRUNCATE ") + pgduckdb_relation_name(relation_oid);
 	auto result = context.Query(query, false);
@@ -163,8 +162,7 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
 
 	std::string query_string(pgduckdb_get_tabledef(relid));
 
-	auto db = pgduckdb::DuckDBManager::Get().GetDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
+	auto connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto &context = *connection->context;
 	auto result = context.Query(query_string, false);
 	if (result->HasError()) {
@@ -219,8 +217,7 @@ duckdb_drop_table_trigger(PG_FUNCTION_ARGS) {
 	if (ret != SPI_OK_DELETE_RETURNING)
 		elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
 
-	auto db = pgduckdb::DuckDBManager::Get().GetDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
+	auto connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto &context = *connection->context;
 
 	auto result = context.Query("BEGIN TRANSACTION", false);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -165,12 +165,8 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 }
 
 duckdb::unique_ptr<duckdb::Connection>
-DuckdbCreateConnection(List *rtables, List *needed_columns, const char *query) {
-	auto &db = DuckDBManager::Get().GetDatabase();
-	/* Add DuckDB replacement scan to read PG data */
-	auto con = duckdb::make_uniq<duckdb::Connection>(db);
-
-	return con;
+DuckDBManager::GetConnection() const {
+	return duckdb::make_uniq<duckdb::Connection>(*database);
 }
 
 } // namespace pgduckdb

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -115,8 +115,7 @@ ReadDuckdbExtensions() {
 
 static bool
 DuckdbInstallExtension(Datum name) {
-	auto &db = DuckDBManager::Get().GetDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
+	auto connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto &context = *connection->context;
 
 	auto extension_name = DatumToString(name);
@@ -169,8 +168,7 @@ PG_FUNCTION_INFO_V1(pgduckdb_raw_query);
 Datum
 pgduckdb_raw_query(PG_FUNCTION_ARGS) {
 	const char *query = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	auto db = pgduckdb::DuckDBManager::Get().GetDatabase();
-	auto connection = duckdb::make_uniq<duckdb::Connection>(db);
+	auto connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto &context = *connection->context;
 	auto result = context.Query(query, false);
 	if (result->HasError()) {

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -46,12 +46,7 @@ DuckdbPrepare(const Query *query) {
 
 	elog(DEBUG2, "(PGDuckDB/DuckdbPrepare) Preparing: %s", query_string);
 
-	List *rtables = copied_query->rtable;
-	/* Extract required vars for table */
-	int flags = PVC_RECURSE_AGGREGATES | PVC_RECURSE_WINDOWFUNCS | PVC_RECURSE_PLACEHOLDERS;
-	List *vars = list_concat(pull_var_clause((Node *)copied_query->targetList, flags),
-	                         pull_var_clause((Node *)copied_query->jointree->quals, flags));
-	auto duckdb_connection = pgduckdb::DuckdbCreateConnection(rtables, vars, query_string);
+	auto duckdb_connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto context = duckdb_connection->context;
 	auto prepared_query = context->Prepare(query_string);
 	return {std::move(prepared_query), std::move(duckdb_connection)};

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -27,81 +27,6 @@ static constexpr char s3_filename_prefix[] = "s3://";
 static constexpr char gcs_filename_prefix[] = "gs://";
 static constexpr char r2_filename_prefix[] = "r2://";
 
-static bool
-CreateRelationCopyParseState(ParseState *pstate, const CopyStmt *stmt, List **vars, int stmt_location, int stmt_len) {
-	ParseNamespaceItem *nsitem;
-#if PG_VERSION_NUM >= 160000
-	RTEPermissionInfo *perminfo;
-#else
-	RangeTblEntry *rte;
-#endif
-	TupleDesc tuple_desc;
-	List *attnums;
-	Relation rel;
-	Oid relid;
-
-	/* Open and lock the relation, using the appropriate lock type. */
-	rel = table_openrv(stmt->relation, AccessShareLock);
-
-	relid = RelationGetRelid(rel);
-
-	nsitem = addRangeTableEntryForRelation(pstate, rel, AccessShareLock, NULL, false, false);
-
-#if PG_VERSION_NUM >= 160000
-	perminfo = nsitem->p_perminfo;
-	perminfo->requiredPerms = ACL_SELECT;
-#else
-	rte = nsitem->p_rte;
-	rte->requiredPerms = ACL_SELECT;
-#endif
-
-	tuple_desc = RelationGetDescr(rel);
-	attnums = CopyGetAttnums(tuple_desc, rel, stmt->attlist);
-
-#if PG_VERSION_NUM >= 160000
-	foreach_int(cur, attnums) {
-		int attno;
-		Bitmapset **bms;
-		attno = cur - FirstLowInvalidHeapAttributeNumber;
-		bms = &perminfo->selectedCols;
-		*bms = bms_add_member(*bms, attno);
-		*vars =
-		    lappend(*vars, makeVar(1, cur, tuple_desc->attrs[cur - 1].atttypid, tuple_desc->attrs[cur - 1].atttypmod,
-		                           tuple_desc->attrs[cur - 1].attcollation, 0));
-	}
-#else
-	foreach_int(cur, attnums)
-	{
-		int	attno = cur - FirstLowInvalidHeapAttributeNumber;
-		rte->selectedCols = bms_add_member(rte->selectedCols, attno);
-	}
-#endif
-
-#if PG_VERSION_NUM >= 160000
-	if (!ExecCheckPermissions(pstate->p_rtable, list_make1(perminfo), false)) {
-		ereport(WARNING, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		                  errmsg("(Duckdb) Failed Permission \"%s\"", RelationGetRelationName(rel))));
-	}
-#else
-	if (!ExecCheckRTPerms(pstate->p_rtable, true)) {
-		ereport(WARNING, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		                  errmsg("(Duckdb) Failed Permission \"%s\"", RelationGetRelationName(rel))));
-	}
-#endif
-	table_close(rel, AccessShareLock);
-
-	/*
-	 * RLS for relation. We should probably bail out at this point.
-	 */
-	if (check_enable_rls(relid, InvalidOid, false) == RLS_ENABLED) {
-		ereport(WARNING, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		                  errmsg("(Duckdb) RLS enabled on \"%s\"", RelationGetRelationName(rel))));
-		return false;
-	}
-
-	return true;
-}
-
 bool
 DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment *query_env, uint64 *processed) {
 	CopyStmt *copy_stmt = (CopyStmt *)pstmt->utilityStmt;
@@ -118,37 +43,7 @@ DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment
 		return false;
 	}
 
-	List *rtables = NIL;
-	List *vars = NIL;
-
-	if (copy_stmt->query) {
-		List *rewritten;
-		RawStmt *raw_stmt;
-		Query *query;
-
-		raw_stmt = makeNode(RawStmt);
-		raw_stmt->stmt = copy_stmt->query;
-		raw_stmt->stmt_location = pstmt->stmt_location;
-		raw_stmt->stmt_len = pstmt->stmt_len;
-
-		rewritten = pg_analyze_and_rewrite_fixedparams(raw_stmt, query_string, NULL, 0, NULL);
-		query = linitial_node(Query, rewritten);
-
-		/* Extract required vars for table */
-		int flags = PVC_RECURSE_AGGREGATES | PVC_RECURSE_WINDOWFUNCS | PVC_RECURSE_PLACEHOLDERS;
-		vars = list_concat(pull_var_clause((Node *)query->targetList, flags),
-		                   pull_var_clause((Node *)query->jointree->quals, flags));
-	} else {
-		ParseState *pstate = make_parsestate(NULL);
-		pstate->p_sourcetext = query_string;
-		pstate->p_queryEnv = query_env;
-		if (!CreateRelationCopyParseState(pstate, copy_stmt, &vars, pstmt->stmt_location, pstmt->stmt_len)) {
-			return false;
-		}
-		rtables = pstate->p_rtable;
-	}
-
-	auto duckdb_connection = pgduckdb::DuckdbCreateConnection(rtables, vars, query_string);
+	auto duckdb_connection = pgduckdb::DuckDBManager::Get().GetConnection();
 	auto res = duckdb_connection->context->Query(query_string, false);
 
 	if (res->HasError()) {


### PR DESCRIPTION
Because of the changes made in #231 and #252 `DuckdbCreateConnection` isn't doing anything special anymore. This removes that function and replaces it with a `GetConnection` method on the `DuckDBManager`. This still returns a new connection every time it's called, but that should probably change in the future. Doing that requires a bit more complex changes to some logic, so for now this is just a refactoring.
