### PR TITLE
Cleanup duckdb build with working extensions

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-24.04
-    name: 'Linting and formatting'
+    name: "Linting and formatting"
 
     steps:
       - name: Checkout pg_duckdb extension code
@@ -17,7 +17,7 @@ jobs:
         run: git fetch --depth=1 origin +main:refs/remotes/origin/main
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install clang-format (11.0.1) and ruff
         run: python3 -m pip install "clang-format==11.0.1" ruff
@@ -29,7 +29,7 @@ jobs:
         run: ruff format --diff
 
   build-and-test:
-    name: 'Build and test'
+    name: "Build and test"
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +46,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
             libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo6 cmake \
-            libstdc++-12-dev
+            libstdc++-12-dev ninja-build
           echo "${PWD}/postgres/inst/bin:$PATH'" > $GITHUB_PATH
 
       - name: ccache
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
           path: duckdb
 
       - name: Checkout PostgreSQL code
@@ -96,14 +96,14 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Setup DuckDB build cache
         id: cache-duckdb-build
         uses: actions/cache@v4
         with:
           path: duckdb/third_party/duckdb/build/
-          key: duckdb-build-ubuntu-24.04-${{ steps.versions.outputs.duckdb_sha }}
+          key: duckdb-build-ubuntu-24.04-${{ steps.versions.outputs.duckdb_sha }}-ninja
 
       - name: Install pytest and other test requirements
         run: python3 -m pip install -r duckdb/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,15 @@ OBJS = $(subst .cpp,.o, $(SRCS))
 C_SRCS = $(wildcard src/*.c src/*/*.c)
 OBJS += $(subst .c,.o, $(C_SRCS))
 
+# set to `make` to disable ninja
+DUCKDB_GEN ?= ninja
+# used to know what version of extensions to download
+DUCKDB_VERSION = v1.1.1
+# duckdb build tweaks
+DUCKDB_CMAKE_VARS = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
+
 DUCKDB_BUILD_CXX_FLAGS=
 DUCKDB_BUILD_TYPE=
-
 ifeq ($(DUCKDB_BUILD), Debug)
 	DUCKDB_BUILD_CXX_FLAGS = -g -O0
 	DUCKDB_BUILD_TYPE = debug
@@ -68,9 +74,11 @@ third_party/duckdb/Makefile:
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE) \
+	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
+	GEN=$(DUCKDB_GEN) \
+	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)"
 	DISABLE_SANITIZER=1 \
-	ENABLE_UBSAN=0 \
-	BUILD_UNITTESTS=OFF \
+	DISABLE_UBSAN=1 \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake"
 
 install-duckdb: $(FULL_DUCKDB_LIB) $(shlib)

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ third_party/duckdb/Makefile:
 	git submodule update --init --recursive
 
 $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
-	$(MAKE) -C third_party/duckdb \
-	$(DUCKDB_BUILD_TYPE) \
 	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
 	GEN=$(DUCKDB_GEN) \
-	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)"
+	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)" \
 	DISABLE_SANITIZER=1 \
 	DISABLE_UBSAN=1 \
-	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake"
+	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake" \
+	$(MAKE) -C third_party/duckdb \
+	$(DUCKDB_BUILD_TYPE)
 
 install-duckdb: $(FULL_DUCKDB_LIB) $(shlib)
 	$(install_bin) -m 755 $(FULL_DUCKDB_LIB) $(DESTDIR)$(PG_LIB)


### PR DESCRIPTION
This re-applies #257 and fixes the issue from #260.

* was missing a backslash
* while some vars were being picked up as arguments, some were not. 
  We now instead set them as env vars when calling `make`.