### PR TITLE
ci: improve gha ccache caching key

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -54,7 +54,6 @@ jobs:
         with:
           key: ubuntu-24.04-${{ matrix.version }}
           create-symlink: true
-          append-timestamp: false
 
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -52,8 +52,9 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ubuntu-24.04
+          key: ubuntu-24.04-${{ matrix.version }}
           create-symlink: true
+          append-timestamp: false
 
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4


### PR DESCRIPTION
Separate the `ccache` cache into separate caches per job (i.e. PG version) to ensure the gha picks up the most recent cache for that version, rather than the overall most recent cache that was written.