### PR TITLE
Add MotherDuck support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ DUCKDB_GEN ?= ninja
 DUCKDB_VERSION = v1.1.1
 # duckdb build tweaks
 DUCKDB_CMAKE_VARS = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
+# set to 1 to disable asserts in DuckDB. This is particularly useful in combinition with MotherDuck.
+# When asserts are enabled the released motherduck extension will fail some of
+# those asserts. By disabling asserts it's possible to run a debug build of
+# DuckDB agains the release build of MotherDuck.
+DUCKDB_DISABLE_ASSERTIONS ?= 0
 
 DUCKDB_BUILD_CXX_FLAGS=
 DUCKDB_BUILD_TYPE=
@@ -76,6 +81,7 @@ $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	GEN=$(DUCKDB_GEN) \
 	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)" \
 	DISABLE_SANITIZER=1 \
+	DISABLE_ASSERTIONS=$(DUCKDB_DISABLE_ASSERTIONS) \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake" \
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE)

--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -3,6 +3,9 @@
 // pgduckdb.c
 extern bool duckdb_execution;
 extern int duckdb_max_threads_per_query;
+extern char *duckdb_background_worker_db;
+extern char *duckdb_motherduck_token;
+extern char *duckdb_motherduck_postgres_user;
 extern "C" void _PG_init(void);
 
 // pgduckdb_hooks.c

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/parser/column_definition.hpp"
+#include "duckdb/parser/constraint.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/catalog/catalog_entry/column_dependency_manager.hpp"
+#include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+
+void DuckdbInitBackgroundWorker(void);
+
+namespace pgduckdb {
+
+void SyncMotherDuckCatalogsWithPg(bool drop_with_cascade);
+extern bool doing_motherduck_sync;
+
+} // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -11,11 +11,17 @@
 #include "duckdb/parser/column_list.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 
+extern "C" {
+#include "postgres.h"
+}
+
 void DuckdbInitBackgroundWorker(void);
 
 namespace pgduckdb {
 
 void SyncMotherDuckCatalogsWithPg(bool drop_with_cascade);
 extern bool doing_motherduck_sync;
+extern char *current_motherduck_database_name;
+extern char *current_motherduck_catalog_version;
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -21,7 +21,7 @@ namespace pgduckdb {
 
 void SyncMotherDuckCatalogsWithPg(bool drop_with_cascade);
 extern bool doing_motherduck_sync;
-extern char *current_motherduck_database_name;
+extern char *current_duckdb_database_name;
 extern char *current_motherduck_catalog_version;
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -42,7 +42,7 @@ private:
 
 	int secret_table_num_rows;
 	int secret_table_current_seq;
-	duckdb::unique_ptr<duckdb::DuckDB> database;
+	duckdb::DuckDB *database;
 	std::string default_dbname;
 };
 

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -23,6 +23,11 @@ public:
 
 	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
 
+	inline const std::string &
+	GetDefaultDBName() const {
+		return default_dbname;
+	}
+
 private:
 	DuckDBManager();
 
@@ -38,6 +43,7 @@ private:
 	int secret_table_num_rows;
 	int secret_table_current_seq;
 	duckdb::unique_ptr<duckdb::DuckDB> database;
+	std::string default_dbname;
 };
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -48,6 +48,17 @@ private:
 
 	int secret_table_num_rows;
 	int secret_table_current_seq;
+	/*
+	 * FIXME: Use a unique_ptr instead of a raw pointer. For now this is not
+	 * possible though, as the MotherDuck extension causes an ABORT when the
+	 * DuckDB database its destructor is run at the exit of the process.  This
+	 * then in turn crashes Postgres, which we obviously dont't want. Not
+	 * running the destructor also doesn't really have any downsides, as the
+	 * process is going to die anyway. It's probably even a tiny bit more
+	 * efficient not to run the destructor at all. But we should still fix
+	 * this, because running the destructor is a good way to find bugs (such
+	 * as the one reported in #279).
+	 */
 	duckdb::DuckDB *database;
 	std::string default_dbname;
 };

--- a/include/pgduckdb/pgduckdb_metadata_cache.hpp
+++ b/include/pgduckdb/pgduckdb_metadata_cache.hpp
@@ -1,9 +1,18 @@
 extern "C" {
 #include "postgres.h"
+#include "utils/rel.h"
 }
 
 namespace pgduckdb {
 bool IsExtensionRegistered();
 bool IsDuckdbOnlyFunction(Oid function_oid);
+uint64 CacheVersion();
+Oid ExtensionOid();
 Oid DuckdbTableAmOid();
+bool IsMotherDuckEnabled();
+Oid MotherDuckPostgresUser();
+Oid IsDuckdbTable(Form_pg_class relation);
+Oid IsDuckdbTable(Relation relation);
+Oid IsMotherDuckTable(Form_pg_class relation);
+Oid IsMotherDuckTable(Relation relation);
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -3,3 +3,4 @@
 char *pgduckdb_relation_name(Oid relid);
 char *pgduckdb_function_name(Oid function_oid);
 char *pgduckdb_get_tabledef(Oid relation_id);
+const char *pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table);

--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -3,4 +3,5 @@
 char *pgduckdb_relation_name(Oid relid);
 char *pgduckdb_function_name(Oid function_oid);
 char *pgduckdb_get_tabledef(Oid relation_id);
-const char *pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table);
+List *pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table);
+const char *pgduckdb_db_and_schema_string(const char *postgres_schema_name, bool is_duckdb_table);

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -19,6 +19,7 @@ constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET = INT64CONST(10957) * USECS_PER
 
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(duckdb::LogicalType type);
+int32 GetPostgresDuckDBTypemod(duckdb::LogicalType type);
 duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type);
 void ConvertPostgresToDuckValue(Datum value, duckdb::Vector &result, idx_t offset);
 bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -181,11 +181,11 @@ CREATE ACCESS METHOD duckdb
     TYPE TABLE
     HANDLER duckdb_am_handler;
 
-CREATE FUNCTION duckdb_drop_table_trigger() RETURNS event_trigger
+CREATE FUNCTION duckdb_drop_trigger() RETURNS event_trigger
     AS 'MODULE_PATHNAME' LANGUAGE C;
 
-CREATE EVENT TRIGGER duckdb_drop_table_trigger ON sql_drop
-    EXECUTE FUNCTION duckdb_drop_table_trigger();
+CREATE EVENT TRIGGER duckdb_drop_trigger ON sql_drop
+    EXECUTE FUNCTION duckdb_drop_trigger();
 
 CREATE FUNCTION duckdb_create_table_trigger() RETURNS event_trigger
     AS 'MODULE_PATHNAME' LANGUAGE C;
@@ -200,6 +200,24 @@ CREATE FUNCTION duckdb_alter_table_trigger() RETURNS event_trigger
 CREATE EVENT TRIGGER duckdb_alter_table_trigger ON ddl_command_end
     WHEN tag IN ('ALTER TABLE')
     EXECUTE FUNCTION duckdb_alter_table_trigger();
+
+CREATE FUNCTION duckdb_grant_trigger() RETURNS event_trigger
+    AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE EVENT TRIGGER duckdb_grant_trigger ON ddl_command_end
+    WHEN tag IN ('GRANT')
+    EXECUTE FUNCTION duckdb_grant_trigger();
+
+CREATE OR REPLACE PROCEDURE force_motherduck_sync(drop_with_cascade BOOLEAN DEFAULT false)
+    LANGUAGE C AS 'MODULE_PATHNAME';
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname LIKE 'ddb$%') THEN
+        RAISE 'pg_duckdb can only be installed if there are no schemas with a ddb$ prefix';
+    END IF;
+END
+$$;
 
 DO $$
 BEGIN

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -159,7 +159,7 @@ CREATE TABLE extensions (
 -- duckdb_drop_table_trigger for details.
 CREATE TABLE tables (
     relid regclass PRIMARY KEY,
-    motherduck_database_name TEXT,
+    duckdb_db TEXT NOT NULL,
     motherduck_catalog_version TEXT
 );
 

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -158,7 +158,9 @@ CREATE TABLE extensions (
 -- table was a DuckDB table or not. See the comments and code in
 -- duckdb_drop_table_trigger for details.
 CREATE TABLE tables (
-    relid regclass PRIMARY KEY
+    relid regclass PRIMARY KEY,
+    motherduck_database_name TEXT,
+    motherduck_catalog_version TEXT
 );
 
 REVOKE ALL ON tables FROM PUBLIC;

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -1,0 +1,449 @@
+#include "duckdb.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/parser/column_definition.hpp"
+#include "duckdb/parser/constraint.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/catalog/catalog_entry/column_dependency_manager.hpp"
+#include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/storage/table_storage_info.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "pgduckdb/pgduckdb_types.hpp"
+#include <string>
+#include <unordered_map>
+
+extern "C" {
+#include "postgres.h"
+#include "fmgr.h"
+#include "access/xact.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "executor/spi.h"
+#include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "tcop/tcopprot.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+#include "utils/builtins.h"
+#include "catalog/dependency.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_extension.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
+#include "utils/syscache.h"
+#include "catalog/objectaddress.h"
+}
+
+#include "pgduckdb/pgduckdb.h"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+#include "pgduckdb/pgduckdb_background_worker.hpp"
+#include "pgduckdb/pgduckdb_metadata_cache.hpp"
+
+static bool is_background_worker = false;
+static std::unordered_map<std::string, std::string> last_known_motherduck_catalog_versions;
+static uint64 initial_cache_version = 0;
+
+extern "C" {
+PGDLLEXPORT void
+pgduckdb_background_worker_main(Datum main_arg) {
+	elog(LOG, "started pgduckdb background worker");
+	// Set up a signal handler for SIGTERM
+	pqsignal(SIGTERM, die);
+	BackgroundWorkerUnblockSignals();
+
+	BackgroundWorkerInitializeConnection(duckdb_background_worker_db, NULL, 0);
+
+	pgduckdb::doing_motherduck_sync = true;
+	is_background_worker = true;
+
+	while (true) {
+		// Initialize SPI (Server Programming Interface) and connect to the database
+		SetCurrentStatementStartTimestamp();
+		StartTransactionCommand();
+		SPI_connect();
+		PushActiveSnapshot(GetTransactionSnapshot());
+
+		if (pgduckdb::IsExtensionRegistered()) {
+			/*
+			 * If the extension is not registerid this loop is a no-op, which
+			 * means we essentially keep polling until the extension is
+			 * installed
+			 */
+			elog(LOG, "Syncing MotherDuck catalogs with Postgres");
+			pgduckdb::SyncMotherDuckCatalogsWithPg(false);
+		}
+
+		// Commit the transaction
+		PopActiveSnapshot();
+		SPI_finish();
+		CommitTransactionCommand();
+		pgstat_report_stat(false);
+		pgstat_report_activity(STATE_IDLE, NULL);
+
+		// Wait for a second or until the latch is set
+		WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L, PG_WAIT_EXTENSION);
+		CHECK_FOR_INTERRUPTS();
+		ResetLatch(MyLatch);
+	}
+
+	proc_exit(0);
+}
+
+PG_FUNCTION_INFO_V1(force_motherduck_sync);
+Datum
+force_motherduck_sync(PG_FUNCTION_ARGS) {
+	Datum drop_with_cascade = PG_GETARG_BOOL(0);
+	/* clear the cache of known catalog versions to force a full sync */
+	last_known_motherduck_catalog_versions.clear();
+	SPI_connect_ext(SPI_OPT_NONATOMIC);
+	PG_TRY();
+	{
+		pgduckdb::doing_motherduck_sync = true;
+		pgduckdb::SyncMotherDuckCatalogsWithPg(drop_with_cascade);
+	}
+	PG_FINALLY();
+	{ pgduckdb::doing_motherduck_sync = false; }
+	PG_END_TRY();
+	SPI_finish();
+	PG_RETURN_VOID();
+}
+}
+
+void
+DuckdbInitBackgroundWorker(void) {
+	if (!pgduckdb::IsMotherDuckEnabled()) {
+		return;
+	}
+
+	BackgroundWorker worker;
+	// Set up the worker struct
+	MemSet(&worker, 0, sizeof(BackgroundWorker));
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+	snprintf(worker.bgw_library_name, BGW_MAXLEN, "pg_duckdb");
+	snprintf(worker.bgw_function_name, BGW_MAXLEN, "pgduckdb_background_worker_main");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_duckdb sync worker");
+	worker.bgw_restart_time = 1;
+	worker.bgw_main_arg = (Datum)0;
+
+	// Register the worker
+	RegisterBackgroundWorker(&worker);
+}
+
+namespace pgduckdb {
+bool doing_motherduck_sync;
+
+static std::string
+PgSchemaName(std::string db_name, std::string schema_name, bool is_default_db) {
+	if (is_default_db) {
+		return schema_name;
+	}
+	std::string escaped_db_name = duckdb::KeywordHelper::EscapeQuotes(db_name, '$');
+	if (schema_name == "main") {
+		return "ddb$" + escaped_db_name;
+	}
+	return "ddb$" + escaped_db_name + "$" + duckdb::KeywordHelper::EscapeQuotes(schema_name, '$');
+}
+
+static std::string
+DropPgTableString(const char *postgres_schema_name, const char *table_name, bool with_cascade) {
+	std::string ret = "";
+	ret += "DROP TABLE ";
+	ret += duckdb::KeywordHelper::WriteQuoted(postgres_schema_name, '"');
+	ret += ".";
+	ret += duckdb::KeywordHelper::WriteQuoted(table_name, '"');
+	ret += with_cascade ? " CASCADE; " : "; ";
+	return ret;
+}
+
+static std::string
+CreatePgTableString(duckdb::CreateTableInfo &info, bool is_default_db) {
+	std::string ret = "";
+
+	ret += "CREATE TABLE ";
+	std::string schema_name = PgSchemaName(info.catalog, info.schema, is_default_db);
+	ret += duckdb::KeywordHelper::WriteQuoted(schema_name, '"');
+	ret += ".";
+	ret += duckdb::KeywordHelper::WriteQuoted(info.table, '"');
+	ret += "(";
+
+	bool first = true;
+	for (auto &column : info.columns.Logical()) {
+		if (!first) {
+			ret += ", ";
+		}
+		ret += duckdb::KeywordHelper::WriteQuoted(column.Name(), '"');
+		ret += " ";
+		Oid postgres_type = GetPostgresDuckDBType(column.Type());
+		if (postgres_type == InvalidOid) {
+			elog(WARNING, "Skipping table %s.%s.%s due to unsupported type", info.catalog.c_str(), info.schema.c_str(),
+			     info.table.c_str());
+
+			return "";
+		}
+		int32 typemod = GetPostgresDuckDBTypemod(column.Type());
+		ret += format_type_with_typemod(postgres_type, typemod);
+		first = false;
+	}
+	ret += ") USING duckdb;";
+	return ret;
+}
+
+static std::string
+CreatePgSchemaString(std::string postgres_schema_name) {
+	return "CREATE SCHEMA " + duckdb::KeywordHelper::WriteQuoted(postgres_schema_name, '"') + ";";
+}
+
+/*
+ * This function is a workaround for the fact that SPI_commit() does not work
+ * well in background workers. You get weird errors like:
+ * ERROR: portal snapshots (0) did not account for all active snapshots (1)
+ *
+ * Luckily we don't really care, all we really care about is that we quickly
+ * release the heavy locks we hold on tables after dropping/creating them. And
+ * this can easily be done by simply finishing the transaction and opening a
+ * new one.
+ *
+ * This workaround is only necessary in background workers, in normal sessions
+ * where people call force_motherduck_sync wo still want to use SPI_commit().
+ *
+ * See the following thread for details:
+ * https://www.postgresql.org/message-id/flat/CAFcNs%2Bp%2BfD5HEXEiZMZC1COnXkJCMnUK0%3Dr4agmZP%3D9Hi%2BYcJA%40mail.gmail.com
+ */
+void
+SPI_commit_that_works_in_bgworker() {
+	if (is_background_worker) {
+		SPI_finish();
+		PopActiveSnapshot();
+		CommitTransactionCommand();
+		StartTransactionCommand();
+		SPI_connect();
+		PushActiveSnapshot(GetTransactionSnapshot());
+	} else {
+		SPI_commit();
+	}
+	if (initial_cache_version != pgduckdb::CacheVersion()) {
+		if (is_background_worker) {
+			elog(ERROR, "DuckDB cache version changed during sync, aborting sync, background worker will restart "
+			            "automatically");
+		} else {
+			elog(ERROR, "DuckDB cache version changed during sync, aborting sync, please try again");
+		}
+	}
+}
+
+static bool
+CreateTable(const char *postgres_schema_name, const char *table_name, std::string create_table_query,
+            bool drop_with_cascade) {
+	/*
+	 * We need to fetch this over-and-over again, because we commit the
+	 * transaction and thus release locks. So in theory the schema could be
+	 * deleted/renamed etc.
+	 */
+	Oid schema_oid = get_namespace_oid(postgres_schema_name, false);
+	HeapTuple tuple = SearchSysCache2(RELNAMENSP, CStringGetDatum(table_name), ObjectIdGetDatum(schema_oid));
+	if (HeapTupleIsValid(tuple)) {
+		Form_pg_class postgres_relation = (Form_pg_class)GETSTRUCT(tuple);
+		/* The table already exists in Postgres, so we cannot simply create it. */
+
+		if (!IsMotherDuckTable(postgres_relation)) {
+			/*
+			 * Oops, we have a conflict. Let's notify the user, and
+			 * not do anything else
+			 */
+			elog(WARNING,
+			     "Skipping sync of MotherDuck table %s.%s because its name conflicts with an "
+			     "already existing table/view/index in Postgres",
+			     postgres_schema_name, table_name);
+			ReleaseSysCache(tuple);
+			return false;
+		}
+		ReleaseSysCache(tuple);
+
+		/*
+		 * It's an old version of this DuckDB table, we can safely
+		 * drop it and recreate it.
+		 */
+		auto drop_query = DropPgTableString(postgres_schema_name, table_name, drop_with_cascade);
+		create_table_query = drop_query + create_table_query;
+	}
+
+	MemoryContext old_context = MemoryContextSwitchTo(CurrentMemoryContext);
+	int ret;
+
+	/*
+	 * We create a subtransaction to be able to cleanly roll back in case of
+	 * any errors.
+	 */
+	BeginInternalSubTransaction(NULL);
+	PG_TRY();
+	{ ret = SPI_exec(create_table_query.c_str(), 0); }
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(old_context);
+		ErrorData *edata = CopyErrorData();
+		ereport(WARNING, (errmsg("Failed to sync MotherDuck table %s.%s", postgres_schema_name, table_name),
+
+		                  errdetail("While executing command: %s", create_table_query.c_str()),
+		                  errhint("See next WARNING for details")));
+		edata->elevel = WARNING;
+		ThrowErrorData(edata);
+		FreeErrorData(edata);
+		FlushErrorState();
+		RollbackAndReleaseCurrentSubTransaction();
+		return false;
+	}
+	PG_END_TRY();
+
+	if (ret != SPI_OK_UTILITY) {
+		elog(WARNING, "SPI_execute failed: error code %d", ret);
+		RollbackAndReleaseCurrentSubTransaction();
+		return false;
+	}
+	/* Success, so we commit the subtransaction */
+	ReleaseCurrentSubTransaction();
+	/* And then we also commit the actual transaction to release any locks that
+	 * were necessary to execute it. */
+	SPI_commit_that_works_in_bgworker();
+	return true;
+}
+
+static bool
+CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
+	Oid schema_oid = get_namespace_oid(postgres_schema_name, true);
+	if (schema_oid != InvalidOid) {
+		return true;
+	}
+
+	std::string create_schema_query = CreatePgSchemaString(postgres_schema_name);
+
+	MemoryContext old_context = MemoryContextSwitchTo(CurrentMemoryContext);
+	int ret;
+
+	/*
+	 * We create a subtransaction to be able to cleanly roll back in case of
+	 * any errors.
+	 */
+	BeginInternalSubTransaction(NULL);
+	PG_TRY();
+	{ ret = SPI_exec(create_schema_query.c_str(), 0); }
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(old_context);
+		ErrorData *edata = CopyErrorData();
+		ereport(WARNING, (errmsg("Failed to sync MotherDuck schema %s", postgres_schema_name),
+		                  errdetail("While executing command: %s", create_schema_query.c_str()),
+		                  errhint("See next WARNING for details")));
+		edata->elevel = WARNING;
+		ThrowErrorData(edata);
+		FreeErrorData(edata);
+		FlushErrorState();
+		RollbackAndReleaseCurrentSubTransaction();
+		return false;
+	}
+	PG_END_TRY();
+
+	if (ret != SPI_OK_UTILITY) {
+		elog(WARNING, "SPI_execute failed: error code %d", ret);
+		RollbackAndReleaseCurrentSubTransaction();
+		return false;
+	}
+	/* Success, so we commit the subtransaction */
+	ReleaseCurrentSubTransaction();
+
+	if (!is_default_db) {
+		/*
+		 * For ddb$ schemas we need to record a dependency between the schema
+		 * and the extension, so that DROP EXTENSION also drops these schemas.
+		 */
+		schema_oid = get_namespace_oid(postgres_schema_name, false);
+		ObjectAddress schema_address = {
+		    .classId = NamespaceRelationId,
+		    .objectId = schema_oid,
+		};
+		ObjectAddress extension_address = {
+		    .classId = ExtensionRelationId,
+		    .objectId = pgduckdb::ExtensionOid(),
+		};
+		recordDependencyOn(&schema_address, &extension_address, DEPENDENCY_NORMAL);
+	}
+
+	/* And then we also commit the actual transaction to release any locks that
+	 * were necessary to execute it. */
+	SPI_commit_that_works_in_bgworker();
+	return true;
+}
+
+void
+SyncMotherDuckCatalogsWithPg(bool drop_with_cascade) {
+	initial_cache_version = pgduckdb::CacheVersion();
+
+	auto connection = pgduckdb::DuckDBManager::Get().CreateConnection();
+	auto &context = *connection->context;
+	if (!pgduckdb::IsMotherDuckEnabled()) {
+		elog(ERROR, "MotherDuck support is not enabled");
+	}
+
+	auto &db_manager = duckdb::DatabaseManager::Get(context);
+	auto default_db = db_manager.GetDefaultDatabase(context);
+	auto result =
+	    context.Query("SELECT alias, server_catalog_version::text FROM __md_local_databases_metadata()", false);
+	if (result->HasError()) {
+		elog(WARNING, "Failed to fetch MotherDuck database metadata: %s", result->GetError().c_str());
+		return;
+	}
+	context.transaction.BeginTransaction();
+	for (auto &row : *result) {
+		auto motherduck_db = row.GetValue<std::string>(0);
+		auto catalog_version = row.GetValue<std::string>(1);
+		if (last_known_motherduck_catalog_versions[motherduck_db] == catalog_version) {
+			/* The catalog version has not changed, we can skip this database */
+			continue;
+		}
+		/* The catalog version has changed, we need to sync the catalog */
+		last_known_motherduck_catalog_versions[motherduck_db] = catalog_version;
+		auto schemas = duckdb::Catalog::GetSchemas(context, motherduck_db);
+		bool is_default_db = motherduck_db == default_db;
+		for (duckdb::SchemaCatalogEntry &schema : schemas) {
+			if (schema.name == "information_schema" || schema.name == "pg_catalog") {
+				continue;
+			}
+
+			std::string postgres_schema_name = PgSchemaName(motherduck_db, schema.name, is_default_db);
+
+			CreateSchemaIfNotExists(postgres_schema_name.c_str(), is_default_db);
+
+			schema.Scan(context, duckdb::CatalogType::TABLE_ENTRY, [&](duckdb::CatalogEntry &entry) {
+				if (entry.type != duckdb::CatalogType::TABLE_ENTRY) {
+					return;
+				}
+				auto &table = entry.Cast<duckdb::TableCatalogEntry>();
+				auto storage_info = table.GetStorageInfo(context);
+
+				auto table_info = duckdb::unique_ptr_cast<duckdb::CreateInfo, duckdb::CreateTableInfo>(table.GetInfo());
+				table_info->schema = table.schema.name;
+				table_info->catalog = motherduck_db;
+
+				auto create_query = CreatePgTableString(*table_info, is_default_db);
+				if (create_query.empty()) {
+					return;
+				}
+
+				if (!CreateTable(postgres_schema_name.c_str(), table.name.c_str(), create_query.c_str(),
+				                 drop_with_cascade)) {
+					return;
+				}
+			});
+		}
+	}
+	context.transaction.Commit();
+}
+} // namespace pgduckdb

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -145,7 +145,7 @@ bool doing_motherduck_sync;
 char *current_motherduck_catalog_version;
 
 static std::string
-PgSchemaName(std::string db_name, std::string schema_name, bool is_default_db) {
+PgSchemaName(const std::string &db_name, const std::string &schema_name, bool is_default_db) {
 	if (is_default_db) {
 		return schema_name;
 	}

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -77,7 +77,6 @@ pgduckdb_background_worker_main(Datum main_arg) {
 			 * means we essentially keep polling until the extension is
 			 * installed
 			 */
-			elog(LOG, "Syncing MotherDuck catalogs with Postgres");
 			pgduckdb::SyncMotherDuckCatalogsWithPg(false);
 		}
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -343,9 +343,10 @@ DropTable(const char *fully_qualified_table, bool drop_with_cascade) {
 	const char *query = psprintf("DROP TABLE %s%s", fully_qualified_table, drop_with_cascade ? " CASCADE" : "");
 
 	if (!SPI_run_utility_command(query)) {
-		ereport(WARNING, (errmsg("Failed to drop deleted MotherDuck table %s", fully_qualified_table),
+		ereport(WARNING,
+		        (errmsg("Failed to drop deleted MotherDuck table %s", fully_qualified_table),
 
-		                  errdetail("While executing command: %s", query), errhint("See next WARNING for details")));
+		         errdetail("While executing command: %s", query), errhint("See previous WARNING for details")));
 		return false;
 	}
 	/*
@@ -370,7 +371,7 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 	if (!SPI_run_utility_command(create_schema_query.c_str())) {
 		ereport(WARNING, (errmsg("Failed to sync MotherDuck schema %s", postgres_schema_name),
 		                  errdetail("While executing command: %s", create_schema_query.c_str()),
-		                  errhint("See next WARNING for details")));
+		                  errhint("See previous WARNING for details")));
 		return false;
 	}
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -485,10 +485,10 @@ SyncMotherDuckCatalogsWithPg(bool drop_with_cascade) {
 			 * up. Otherwise we might accidentally cleanup a table that is
 			 * still there, but which failed to be updated for some reason.
 			 *
-			 * We
-			 * rely on the database operator to fix the syncing problem, and
-			 * after that's done we'll clean up the tables
-			 * We could do something smarter here, but for now this is okay.
+			 * We rely on the database operator to fix the syncing problem, and
+			 * after that's done we'll clean up the tables during that first
+			 * working sync. We could do something smarter here, but for now
+			 * this is okay.
 			 */
 			continue;
 		}

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -487,8 +487,8 @@ SyncMotherDuckCatalogsWithPg(bool drop_with_cascade) {
 			 *
 			 * We rely on the database operator to fix the syncing problem, and
 			 * after that's done we'll clean up the tables during that first
-			 * working sync. We could do something smarter here, but for now
-			 * this is okay.
+			 * working sync. We could probably do something smarter here, but
+			 * for now this is okay.
 			 */
 			continue;
 		}

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -191,6 +191,7 @@ CreatePgTableString(duckdb::CreateTableInfo &info, bool is_default_db) {
 			ret += ", ";
 		}
 		first = false;
+
 		ret += duckdb::KeywordHelper::WriteQuoted(column.Name(), '"');
 		ret += " ";
 		int32 typemod = GetPostgresDuckDBTypemod(column.Type());

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -284,7 +284,7 @@ SPI_run_utility_command(const char *query) {
 }
 
 static bool
-CreateTable(const char *postgres_schema_name, const char *table_name, std::string create_table_query,
+CreateTable(const char *postgres_schema_name, const char *table_name, const char *create_table_query,
             bool drop_with_cascade) {
 	/*
 	 * We need to fetch this over-and-over again, because we commit the
@@ -316,13 +316,13 @@ CreateTable(const char *postgres_schema_name, const char *table_name, std::strin
 		 * drop it and recreate it.
 		 */
 		auto drop_query = DropPgTableString(postgres_schema_name, table_name, drop_with_cascade);
-		create_table_query = drop_query + create_table_query;
+		create_table_query = psprintf("%s %s", drop_query.c_str(), create_table_query);
 	}
 
-	if (!SPI_run_utility_command(create_table_query.c_str())) {
+	if (!SPI_run_utility_command(create_table_query)) {
 		ereport(WARNING, (errmsg("Failed to sync MotherDuck table %s.%s", postgres_schema_name, table_name),
 
-		                  errdetail("While executing command: %s", create_table_query.c_str()),
+		                  errdetail("While executing command: %s", create_table_query),
 		                  errhint("See previous WARNING for details")));
 		return false;
 	}

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -137,6 +137,14 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
+	if (!pgduckdb::IsExtensionRegistered()) {
+		/*
+		 * We're not installed, so don't mess with the query. Normally this
+		 * shouldn't happen, but better safe than sorry.
+		 */
+		PG_RETURN_NULL();
+	}
+
 	EventTriggerData *trigger_data = (EventTriggerData *)fcinfo->context;
 	Node *parsetree = trigger_data->parsetree;
 
@@ -315,6 +323,14 @@ duckdb_drop_trigger(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
+	if (!pgduckdb::IsExtensionRegistered()) {
+		/*
+		 * We're not installed, so don't mess with the query. Normally this
+		 * shouldn't happen, but better safe than sorry.
+		 */
+		PG_RETURN_NULL();
+	}
+
 	SPI_connect();
 
 	/*
@@ -469,6 +485,14 @@ duckdb_alter_table_trigger(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
+	if (!pgduckdb::IsExtensionRegistered()) {
+		/*
+		 * We're not installed, so don't mess with the query. Normally this
+		 * shouldn't happen, but better safe than sorry.
+		 */
+		PG_RETURN_NULL();
+	}
+
 	SPI_connect();
 
 	/*
@@ -566,6 +590,15 @@ Datum
 duckdb_grant_trigger(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
+
+	if (!pgduckdb::IsExtensionRegistered()) {
+		/*
+		 * We're not installed, so don't mess with the query. Normally this
+		 * shouldn't happen, but better safe than sorry.
+		 */
+		PG_RETURN_NULL();
+	}
+
 	EventTriggerData *trigdata = (EventTriggerData *)fcinfo->context;
 	Node *parsetree = trigdata->parsetree;
 	if (!IsA(parsetree, GrantStmt)) {

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -14,6 +14,7 @@ extern "C" {
 
 #include "pgduckdb/pgduckdb_options.hpp"
 #include "pgduckdb/pgduckdb_duckdb.hpp"
+#include "pgduckdb/pgduckdb_metadata_cache.hpp"
 #include "pgduckdb/scan/postgres_scan.hpp"
 #include "pgduckdb/scan/postgres_seq_scan.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
@@ -33,7 +34,17 @@ DuckDBManager::Initialize() {
 	// Transforms VIEWs into their view definition
 	config.replacement_scans.emplace_back(pgduckdb::PostgresReplacementScan);
 
-	database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+	const char *connection_string = nullptr;
+
+	/*
+	 * If MotherDuck is enabled, use it to connect to DuckDB. That way DuckDB
+	 * its default database will be set to the default MotherDuck database.
+	 */
+	if (pgduckdb::IsMotherDuckEnabled()) {
+
+		connection_string = psprintf("md:?motherduck_token=%s", duckdb_motherduck_token);
+	}
+	database = duckdb::make_uniq<duckdb::DuckDB>(connection_string, &config);
 	duckdb::DBConfig::GetConfig(*database->instance).storage_extensions["pgduckdb"] =
 	    duckdb::make_uniq<duckdb::PostgresStorageExtension>();
 	duckdb::ExtensionInstallInfo extension_install_info;
@@ -42,7 +53,13 @@ DuckDBManager::Initialize() {
 	auto connection = duckdb::make_uniq<duckdb::Connection>(*database);
 
 	auto &context = *connection->context;
+	auto &db_manager = duckdb::DatabaseManager::Get(context);
+	default_dbname = db_manager.GetDefaultDatabase(context);
 	context.Query("ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)", false);
+	auto result = context.Query("ATTACH DATABASE ':memory:' AS pg_temp;", false);
+	if (result->HasError()) {
+		elog(ERROR, "(PGDuckDB/DuckDBManager) could not attach pg_temp: %s", result->GetError().c_str());
+	}
 
 	LoadFunctions(context);
 	LoadExtensions(context);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -44,7 +44,7 @@ DuckDBManager::Initialize() {
 
 		connection_string = psprintf("md:?motherduck_token=%s", duckdb_motherduck_token);
 	}
-	database = duckdb::make_uniq<duckdb::DuckDB>(connection_string, &config);
+	database = duckdb::make_uniq<duckdb::DuckDB>(connection_string, &config).release();
 	duckdb::DBConfig::GetConfig(*database->instance).storage_extensions["pgduckdb"] =
 	    duckdb::make_uniq<duckdb::PostgresStorageExtension>();
 	duckdb::ExtensionInstallInfo extension_install_info;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -58,6 +58,17 @@ DuckDBManager::Initialize() {
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 
+	if (pgduckdb::IsMotherDuckEnabled()) {
+		/*
+		 * Workaround for MotherDuck catalog sync that turns off automatically,
+		 * in case of no queries being sent to MotherDuck. Since the background
+		 * worker never sends any query to MotherDuck we need to turn this off.
+		 * So we set the timeout to an arbitrary very large value.
+		 */
+		pgduckdb::DuckDBQueryOrThrow(context,
+		                             "SET motherduck_background_catalog_refresh_inactivity_timeout='99 years'");
+	}
+
 	LoadFunctions(context);
 	LoadExtensions(context);
 }

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -55,11 +55,8 @@ DuckDBManager::Initialize() {
 	auto &context = *connection->context;
 	auto &db_manager = duckdb::DatabaseManager::Get(context);
 	default_dbname = db_manager.GetDefaultDatabase(context);
-	context.Query("ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)", false);
-	auto result = context.Query("ATTACH DATABASE ':memory:' AS pg_temp;", false);
-	if (result->HasError()) {
-		elog(ERROR, "(PGDuckDB/DuckDBManager) could not attach pg_temp: %s", result->GetError().c_str());
-	}
+	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
+	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 
 	LoadFunctions(context);
 	LoadExtensions(context);

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -1,3 +1,4 @@
+#include "duckdb.hpp"
 extern "C" {
 #include "postgres.h"
 
@@ -16,7 +17,9 @@ extern "C" {
 #include "pgduckdb/vendor/pg_ruleutils.h"
 }
 
+#include "pgduckdb/pgduckdb.h"
 #include "pgduckdb/pgduckdb_table_am.hpp"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
 #include "pgduckdb/pgduckdb_metadata_cache.hpp"
 
 extern "C" {
@@ -27,6 +30,73 @@ pgduckdb_function_name(Oid function_oid) {
 	}
 	auto func_name = get_func_name(function_oid);
 	return psprintf("system.main.%s", quote_identifier(func_name));
+}
+
+static List *
+GetDuckdbCatalogAndSchema(const char *postgres_schema_name) {
+	if (strncmp("ddb$", postgres_schema_name, 4) != 0) {
+		auto dbname = pgduckdb::DuckDBManager::Get().GetDefaultDBName().c_str();
+		return list_make2((void *)dbname, (void *)postgres_schema_name);
+	}
+	StringInfoData db_name;
+	StringInfoData schema_name;
+	initStringInfo(&db_name);
+	initStringInfo(&schema_name);
+	const char *saveptr = &postgres_schema_name[4];
+	const char *dollar;
+
+	while ((dollar = strchr(saveptr, '$'))) {
+		appendBinaryStringInfo(&db_name, saveptr, dollar - saveptr);
+		saveptr = dollar + 1;
+		if (saveptr[0] == '\0') {
+			elog(ERROR, "Schema name is invalid");
+		}
+
+		if (saveptr[0] == '$') {
+			appendStringInfoChar(&db_name, '$');
+		} else {
+			break;
+		}
+	}
+
+	if (!dollar) {
+		appendStringInfoString(&db_name, saveptr);
+		return list_make2((void *)db_name.data, (char *)"main");
+	}
+
+	while ((dollar = strchr(saveptr, '$'))) {
+		appendBinaryStringInfo(&schema_name, saveptr, dollar - saveptr);
+		saveptr = dollar + 1;
+
+		if (saveptr[0] == '$') {
+			appendStringInfoChar(&schema_name, '$');
+		} else {
+			break;
+		}
+	}
+	appendStringInfoString(&schema_name, saveptr);
+
+	return list_make2(db_name.data, schema_name.data);
+}
+
+static const char *
+DuckdbCatalogAndSchemaString(Form_pg_class relation) {
+	if (relation->relam == pgduckdb::DuckdbTableAmOid() && relation->relpersistence == RELPERSISTENCE_TEMP) {
+		return "pg_temp.main";
+	}
+
+	const char *postgres_schema_name = get_namespace_name_or_temp(relation->relnamespace);
+	const char *db_name;
+	const char *schema_name;
+	if (relation->relam == pgduckdb::DuckdbTableAmOid()) {
+		List *db_and_schema = GetDuckdbCatalogAndSchema(postgres_schema_name);
+		db_name = (const char *)linitial(db_and_schema);
+		schema_name = (const char *)lsecond(db_and_schema);
+	} else {
+		db_name = "pgduckdb";
+		schema_name = postgres_schema_name;
+	}
+	return psprintf("%s.%s", quote_identifier(db_name), quote_identifier(schema_name));
 }
 
 /*
@@ -42,21 +112,9 @@ pgduckdb_relation_name(Oid relation_oid) {
 		elog(ERROR, "cache lookup failed for relation %u", relation_oid);
 	Form_pg_class relation = (Form_pg_class)GETSTRUCT(tp);
 	const char *relname = NameStr(relation->relname);
-	/*
-	 * XXX: Should this be using get_namespace_name instead, the difference is
-	 * that it will store temp tables in the pg_temp_123 style schemas instead
-	 * of plain pg_temp. I don't think this really matters.
-	 */
-	const char *nspname = get_namespace_name_or_temp(relation->relnamespace);
-	const char *dbname;
+	const char *db_and_schema = DuckdbCatalogAndSchemaString(relation);
 
-	if (relation->relam == pgduckdb::DuckdbTableAmOid()) {
-		dbname = "memory";
-	} else {
-		dbname = "pgduckdb";
-	}
-
-	char *result = psprintf("%s.%s.%s", quote_identifier(dbname), quote_identifier(nspname), quote_identifier(relname));
+	char *result = psprintf("%s.%s", db_and_schema, quote_identifier(relname));
 
 	ReleaseSysCache(tp);
 
@@ -79,7 +137,7 @@ char *
 pgduckdb_get_tabledef(Oid relation_oid) {
 	Relation relation = relation_open(relation_oid, AccessShareLock);
 	const char *relation_name = pgduckdb_relation_name(relation_oid);
-	const char *schema_name = get_namespace_name_or_temp(relation->rd_rel->relnamespace);
+	const char *db_and_schema = DuckdbCatalogAndSchemaString(relation->rd_rel);
 
 	StringInfoData buffer;
 	initStringInfo(&buffer);
@@ -88,12 +146,21 @@ pgduckdb_get_tabledef(Oid relation_oid) {
 		elog(ERROR, "Only regular tables are supported in DuckDB");
 	}
 
-	appendStringInfo(&buffer, "CREATE SCHEMA IF NOT EXISTS %s; ", quote_identifier(schema_name));
+	appendStringInfo(&buffer, "CREATE SCHEMA IF NOT EXISTS %s; ", db_and_schema);
 
 	appendStringInfoString(&buffer, "CREATE ");
 
-	if (relation->rd_rel->relpersistence != RELPERSISTENCE_TEMP) {
-		elog(ERROR, "Only TEMP tables are supported in DuckDB");
+	if (relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP) {
+		// allowed
+	} else if (!pgduckdb::IsMotherDuckEnabled()) {
+		elog(ERROR, "Only TEMP tables are supported in DuckDB if MotherDuck support is not enabled");
+	} else if (relation->rd_rel->relpersistence != RELPERSISTENCE_PERMANENT) {
+		elog(ERROR, "Only TEMP and non-UNLOGGED tables are supported in DuckDB");
+	} else if (relation->rd_rel->relowner != pgduckdb::MotherDuckPostgresUser()) {
+		elog(ERROR, "MotherDuck tables must be created by the duckb.motherduck_postgres_user");
+	}
+
+	if (relation->rd_rel->relpersistence != RELPERSISTENCE_PERMANENT) {
 	}
 
 	appendStringInfo(&buffer, "TABLE %s (", relation_name);

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -38,7 +38,15 @@ pgduckdb_function_name(Oid function_oid) {
  * are not escaped yet.
  */
 List *
-GetDuckdbCatalogAndSchema(const char *postgres_schema_name) {
+pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table) {
+	if (!is_duckdb_table) {
+		return list_make2((void *)"pgduckdb", (void *)postgres_schema_name);
+	}
+
+	if (strcmp("pg_temp", postgres_schema_name) == 0) {
+		return list_make2((void *)"pg_temp", (void *)"main");
+	}
+
 	if (strncmp("ddb$", postgres_schema_name, 4) != 0) {
 		auto dbname = pgduckdb::DuckDBManager::Get().GetDefaultDBName().c_str();
 		return list_make2((void *)dbname, (void *)postgres_schema_name);
@@ -89,21 +97,11 @@ GetDuckdbCatalogAndSchema(const char *postgres_schema_name) {
  * database are quoted if necessary.
  */
 const char *
-pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table) {
-	if (is_duckdb_table && strcmp("pg_temp", postgres_schema_name) == 0) {
-		return "pg_temp.main";
-	}
-	const char *db_name;
-	const char *schema_name;
-	if (is_duckdb_table) {
-		List *db_and_schema = GetDuckdbCatalogAndSchema(postgres_schema_name);
-		db_name = (const char *)linitial(db_and_schema);
-		schema_name = (const char *)lsecond(db_and_schema);
-		return psprintf("%s.%s", quote_identifier(db_name), quote_identifier(schema_name));
-	} else {
-		db_name = "pgduckdb";
-		schema_name = postgres_schema_name;
-	}
+pgduckdb_db_and_schema_string(const char *postgres_schema_name, bool is_duckdb_table) {
+	List *db_and_schema = pgduckdb_db_and_schema(postgres_schema_name, is_duckdb_table);
+	const char *db_name = (const char *)linitial(db_and_schema);
+	const char *schema_name = (const char *)lsecond(db_and_schema);
+	return psprintf("%s.%s", quote_identifier(db_name), quote_identifier(schema_name));
 	return psprintf("%s.%s", quote_identifier(db_name), quote_identifier(schema_name));
 }
 
@@ -121,7 +119,7 @@ pgduckdb_relation_name(Oid relation_oid) {
 	Form_pg_class relation = (Form_pg_class)GETSTRUCT(tp);
 	const char *relname = NameStr(relation->relname);
 	const char *postgres_schema_name = get_namespace_name_or_temp(relation->relnamespace);
-	const char *db_and_schema = pgduckdb_db_and_schema(postgres_schema_name, pgduckdb::IsDuckdbTable(relation));
+	const char *db_and_schema = pgduckdb_db_and_schema_string(postgres_schema_name, pgduckdb::IsDuckdbTable(relation));
 
 	char *result = psprintf("%s.%s", db_and_schema, quote_identifier(relname));
 
@@ -147,7 +145,7 @@ pgduckdb_get_tabledef(Oid relation_oid) {
 	Relation relation = relation_open(relation_oid, AccessShareLock);
 	const char *relation_name = pgduckdb_relation_name(relation_oid);
 	const char *postgres_schema_name = get_namespace_name_or_temp(relation->rd_rel->relnamespace);
-	const char *db_and_schema = pgduckdb_db_and_schema(postgres_schema_name, pgduckdb::IsDuckdbTable(relation));
+	const char *db_and_schema = pgduckdb_db_and_schema_string(postgres_schema_name, pgduckdb::IsDuckdbTable(relation));
 
 	StringInfoData buffer;
 	initStringInfo(&buffer);

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -237,8 +237,8 @@ SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_ta
 NOTICE:  result: database_name	schema_name	sql	
 VARCHAR	VARCHAR	VARCHAR	
 [ Rows: 2]
-memory	pg_temp	CREATE TABLE pg_temp.t(b INTEGER);
-memory	pg_temp	CREATE TABLE pg_temp.webpages(column00 INTEGER, column01 VARCHAR, column02 DATE);
+pg_temp	main	CREATE TABLE t(b INTEGER);
+pg_temp	main	CREATE TABLE webpages(column00 INTEGER, column01 VARCHAR, column02 DATE);
 
 
  raw_query 

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -110,8 +110,8 @@ SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_ta
 NOTICE:  result: database_name	schema_name	sql	
 VARCHAR	VARCHAR	VARCHAR	
 [ Rows: 2]
-memory	pg_temp	CREATE TABLE pg_temp.t(bool BOOLEAN, i2 SMALLINT, i4 INTEGER DEFAULT(1), i8 BIGINT NOT NULL, fl4 FLOAT DEFAULT((random() + CAST(1 AS DOUBLE))), fl8 DOUBLE, t1 VARCHAR, t2 VARCHAR, t3 VARCHAR, d DATE, ts TIMESTAMP, json_obj JSON, CHECK((i4 > i2)), CHECK((fl8 > CAST(0 AS DOUBLE))));
-memory	pg_temp	CREATE TABLE pg_temp.t2(a INTEGER);
+pg_temp	main	CREATE TABLE t(bool BOOLEAN, i2 SMALLINT, i4 INTEGER DEFAULT(1), i8 BIGINT NOT NULL, fl4 FLOAT DEFAULT((random() + CAST(1 AS DOUBLE))), fl8 DOUBLE, t1 VARCHAR, t2 VARCHAR, t3 VARCHAR, d DATE, ts TIMESTAMP, json_obj JSON, CHECK((i4 > i2)), CHECK((fl8 > CAST(0 AS DOUBLE))));
+pg_temp	main	CREATE TABLE t2(a INTEGER);
 
 
  raw_query 
@@ -132,7 +132,7 @@ VARCHAR	VARCHAR	VARCHAR
 (1 row)
 
 CREATE TABLE t(a int);
-ERROR:  Only TEMP tables are supported in DuckDB
+ERROR:  Only TEMP tables are supported in DuckDB if MotherDuck support is not enabled
 -- XXX: A better error message would be nice here, but for now this is acceptable.
 CREATE TEMP TABLE t(a int PRIMARY KEY);
 ERROR:  duckdb does not implement duckdb_index_build_range_scan


### PR DESCRIPTION
This adds initial MotherDuck support. It supports syncing of table and schema metadata from MotherDuck to Postgres. Every second a background worker will check if a MotherDuck catalog has changed to a new version. If there was a catalog version update, then the changes are synced to Postgres by dropping and recreating all MotherDuck shell tables related to that MotherDuck catalog.

The schemas from the default MotherDuck database is merged with schemas with the same name from Postgres. Schemas from other databases are encoded in this way:
1. If the db is `awesomedb` schema is `main`, then the postgres schema name is `ddb$awesomedb`
2. If the db is `awesomedb` schema is `some_other_schema`, then the postgres schema name is `ddb$awesomedb$some_other_schema`  

To enable MotherDuck support all that's needed is adding the following to your Postgres config:
```
shared_preload_libraries = 'pg_duckdb'
duckdb.background_worker_db = '<the db in which you do CREATE EXTENSION>'
duckdb.motherduck_token = '<your token>`
```

This also fixes a problem with temporary duckdb tables that were not explicitely dropped before the backend was terminated. The oids of those tables would stay in the `duckdb.tables` table indefinitely. To fix that this now tracks temporary table oids in backend-local in-memory set. 

TODO:
- [x] Check MotherDuck catalog version to see if Postgres catalog needs to be updated, and do nothing if version is the same.
- [ ] ~~Only update tables that have changed since the last sync (optional?)~~ (creating separate issue for 0.2.0 for this)
- [ ] ~~Create the tables as the duckdb.motherduck_postgres_user~~ (I'm going to make a separate PR for this)
- [x] Change to use eager committing of transactions, so Postgres locks are not held for long periods of time.
- [x] Disallow GRANT on table
- [x] Disallow creation of `ddb$` schemas
- [x] Check that no `ddb$` schemas exist in extension creation script
- [x] Automatically drop all `ddb$` schemas when dropping the extension
- [x] Make the background worker handle create+drop extension sensibly
