### PR TITLE
GetConnection should check secret table changes

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -18,18 +18,7 @@ public:
 		return instance;
 	}
 
-	inline duckdb::DuckDB &
-	GetDatabase() {
-		if(CheckSecretsSeq()) {
-			auto connection = duckdb::make_uniq<duckdb::Connection>(*database);
-			auto &context = *connection->context;
-			DropSecrets(context);
-			LoadSecrets(context);
-		}
-		return *database;
-	}
-
-	duckdb::unique_ptr<duckdb::Connection> GetConnection() const;
+	duckdb::unique_ptr<duckdb::Connection> GetConnection();
 
 private:
 	DuckDBManager();

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -199,8 +199,14 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 }
 
 duckdb::unique_ptr<duckdb::Connection>
-DuckDBManager::GetConnection() const {
-	return duckdb::make_uniq<duckdb::Connection>(*database);
+DuckDBManager::GetConnection() {
+	auto connection = duckdb::make_uniq<duckdb::Connection>(*database);
+	if (CheckSecretsSeq()) {
+		auto &context = *connection->context;
+		DropSecrets(context);
+		LoadSecrets(context);
+	}
+	return connection;
 }
 
 } // namespace pgduckdb


### PR DESCRIPTION
We don't need use anymore `GetDatabase()` which contained logic to update secrets based on sequence number. Move thisi logic now in `GetConnection` which is currently used in code.