### PR TITLE
Disable SANITIZER and UBSAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ $(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
 	GEN=$(DUCKDB_GEN) \
 	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)" \
 	DISABLE_SANITIZER=1 \
-	DISABLE_UBSAN=1 \
 	EXTENSION_CONFIGS="../pg_duckdb_extensions.cmake" \
 	$(MAKE) -C third_party/duckdb \
 	$(DUCKDB_BUILD_TYPE)


### PR DESCRIPTION
Setting DISABLE_UBSAN after DISABLE_SANITIZER will override DISABLE_SANITIZER_FLAG. Only use DISABLE_SANITIZER for building project.