### PR TITLE
Factorize simple DuckDB queries

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -15,13 +15,19 @@ public:
 	static inline DuckDBManager &
 	Get() {
 		static DuckDBManager instance;
+		if (!instance.database) {
+			instance.Initialize();
+		}
 		return instance;
 	}
 
-	duckdb::unique_ptr<duckdb::Connection> GetConnection();
+	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
 
 private:
 	DuckDBManager();
+
+	void Initialize();
+
 	void InitializeDatabase();
 	bool CheckSecretsSeq();
 	void LoadSecrets(duckdb::ClientContext &);

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/error_data.hpp"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+
 extern "C" {
 #include "postgres.h"
 }
-
-#include "duckdb/common/exception.hpp"
-#include "duckdb/common/error_data.hpp"
 
 #include <vector>
 #include <string>
@@ -102,5 +103,11 @@ DuckDBFunctionGuard(FuncType duckdb_function, const char* function_name, FuncArg
 }
 
 std::string CreateOrGetDirectoryPath(std::string directory_name);
+
+duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query);
+
+duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(duckdb::Connection &connection, const std::string &query);
+
+duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(const std::string &query);
 
 } // namespace pgduckdb

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "utils/regproc.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
+#include "utils/relcache.h"
 #include "access/htup_details.h"
 #include "parser/parsetree.h"
 }
@@ -40,8 +41,7 @@ PostgresTable::~PostgresTable() {
 ::Relation
 PostgresTable::OpenRelation(Oid relid) {
 	std::lock_guard<std::mutex> lock(pgduckdb::DuckdbProcessLock::GetLock());
-	auto rel = pgduckdb::PostgresFunctionGuard<::Relation>(RelationIdGetRelation, relid);
-	return rel;
+	return pgduckdb::PostgresFunctionGuard<::Relation>(RelationIdGetRelation, relid);
 }
 
 bool

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -42,6 +42,7 @@ SchemaItems::GetTable(const string &entry_name) {
 	if (it != tables.end()) {
 		return it->second.get();
 	}
+
 	auto snapshot = schema->snapshot;
 	auto &catalog = schema->catalog;
 
@@ -71,6 +72,7 @@ SchemaItems::GetTable(const string &entry_name) {
 		// will get bound again and hit a PostgresIndexTable / PostgresHeapTable.
 		return nullptr;
 	}
+
 	ReleaseSysCache(tuple);
 
 	::Relation rel = PostgresTable::OpenRelation(rel_oid);

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -46,9 +46,8 @@ DuckdbPrepare(const Query *query) {
 
 	elog(DEBUG2, "(PGDuckDB/DuckdbPrepare) Preparing: %s", query_string);
 
-	auto duckdb_connection = pgduckdb::DuckDBManager::Get().GetConnection();
-	auto context = duckdb_connection->context;
-	auto prepared_query = context->Prepare(query_string);
+	auto duckdb_connection = pgduckdb::DuckDBManager::CreateConnection();
+	auto prepared_query = duckdb_connection->context->Prepare(query_string);
 	return {std::move(prepared_query), std::move(duckdb_connection)};
 }
 
@@ -108,7 +107,7 @@ CreatePlan(Query *query) {
 PlannedStmt *
 DuckdbPlanNode(Query *parse, int cursor_options) {
 	/* We need to check can we DuckDB create plan */
-	Plan *plan = pgduckdb::DuckDBFunctionGuard<Plan*>(CreatePlan, "CreatePlan", parse);
+	Plan *plan = pgduckdb::DuckDBFunctionGuard<Plan *>(CreatePlan, "CreatePlan", parse);
 	Plan *duckdb_plan = (Plan *)castNode(CustomScan, plan);
 
 	if (!duckdb_plan) {

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -1,3 +1,4 @@
+#include "pgduckdb/pgduckdb_utils.hpp"
 
 extern "C" {
 #include "postgres.h"
@@ -59,6 +60,26 @@ CreateOrGetDirectoryPath(std::string directory_name) {
 	std::string directory(duckdb_data_directory->data);
 	pfree(duckdb_data_directory->data);
 	return directory;
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
+	auto res = context.Query(query, false);
+	if (res->HasError()) {
+		res->ThrowError();
+	}
+	return res;
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+DuckDBQueryOrThrow(duckdb::Connection &connection, const std::string &query) {
+	return DuckDBQueryOrThrow(*connection.context, query);
+}
+
+duckdb::unique_ptr<duckdb::QueryResult>
+DuckDBQueryOrThrow(const std::string &query) {
+	auto connection = pgduckdb::DuckDBManager::CreateConnection();
+	return DuckDBQueryOrThrow(*connection, query);
 }
 
 } // namespace pgduckdb

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -64,11 +64,21 @@ CreateOrGetDirectoryPath(std::string directory_name) {
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
-	auto res = context.Query(query, false);
-	if (res->HasError()) {
-		res->ThrowError();
+	const char *error_message = nullptr;
+	{
+		auto res = context.Query(query, false);
+		if (!res->HasError()) {
+			return res;
+		}
+
+		error_message = pstrdup(res->GetError().c_str());
 	}
-	return res;
+
+	if (error_message) {
+		elog(ERROR, "(PGDuckDB/DuckDBQuery) %s", error_message);
+	}
+
+	return nullptr; // unreachable
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>


### PR DESCRIPTION
* change `DuckDBManager::GetConnection()` member into a static `CreateConnection()`
* introduce 3 flavor of `DuckDBQueryOrThrow` to simplify recurring pattern