### PR TITLE
Only load pg_duckdb extension if set in shared_preload_variables

### DIFF
--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -1,5 +1,6 @@
 extern "C" {
 #include "postgres.h"
+#include "miscadmin.h"
 #include "utils/guc.h"
 }
 
@@ -16,11 +17,15 @@ PG_MODULE_MAGIC;
 
 void
 _PG_init(void) {
+	if (!process_shared_preload_libraries_in_progress) {
+		ereport(ERROR, (errmsg("pg_duckdb needs to be loaded via shared_preload_libraries"),
+		                errhint("Add pg_duckdb to shared_preload_libraries.")));
+	}
 	DuckdbInitGUC();
 	DuckdbInitHooks();
 	DuckdbInitNode();
 }
-}
+} // extern "C"
 
 /* clang-format off */
 static void


### PR DESCRIPTION
As I described in #200 it's probably possible with some effort to not require
`pg_duckdb` in `shared_preload_variables`, but for now we have not done this work
yet. So to not confuse users, let's error out if `pg_duckdb` is not in
`shared_preload_libraries`.
