### PR TITLE
Add missing iceberg_* functions with parameters

### DIFF
--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -97,7 +97,7 @@ BEGIN
 END;
 $func$;
 
--- Iceberg* functions optional parameters are extract from source code;
+-- iceberg_* functions optional parameters are extract from source code;
 -- https://github.com/duckdb/duckdb_iceberg/tree/main/src/iceberg_functions
 
 CREATE OR REPLACE FUNCTION iceberg_scan(path text, allow_moved_paths BOOLEAN DEFAULT FALSE,
@@ -115,7 +115,7 @@ $func$;
 
 CREATE TYPE iceberg_metadata_record AS (
   manifest_path TEXT,
-  manifest_sequence_number BIGINT,
+  manifest_sequence_number NUMERIC,
   manifest_content  TEXT,
   status TEXT,
   content TEXT,

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -97,6 +97,9 @@ BEGIN
 END;
 $func$;
 
+-- Iceberg* functions optional parameters are extract from source code;
+-- https://github.com/duckdb/duckdb_iceberg/tree/main/src/iceberg_functions
+
 CREATE OR REPLACE FUNCTION iceberg_scan(path text, allow_moved_paths BOOLEAN DEFAULT FALSE,
                                                    mode TEXT DEFAULT '',
                                                    metadata_compression_codec TEXT DEFAULT 'none',
@@ -110,23 +113,39 @@ BEGIN
 END;
 $func$;
 
+CREATE TYPE iceberg_metadata_record AS (
+  manifest_path TEXT,
+  manifest_sequence_number BIGINT,
+  manifest_content  TEXT,
+  status TEXT,
+  content TEXT,
+  file_path TEXT
+);
+
 CREATE OR REPLACE FUNCTION iceberg_metadata(path text, allow_moved_paths BOOLEAN DEFAULT FALSE,
                                                        metadata_compression_codec TEXT DEFAULT 'none',
                                                        skip_schema_inference BOOLEAN DEFAULT FALSE,
                                                        version TEXT DEFAULT 'version-hint.text',
                                                        version_name_format TEXT DEFAULT 'v%s%s.metadata.json,%s%s.metadata.json')
-RETURNS SETOF record LANGUAGE 'plpgsql' AS
+RETURNS SETOF iceberg_metadata_record LANGUAGE 'plpgsql' AS
 $func$
 BEGIN
     RAISE EXCEPTION 'Function `iceberg_metadata(TEXT)` only works with Duckdb execution.';
 END;
 $func$;
 
+CREATE TYPE iceberg_snapshots_record AS (
+  sequence_number BIGINT,
+  snapshot_id BIGINT,
+  timestamp_ms TIMESTAMP,
+  manifest_list TEXT
+);
+
 CREATE OR REPLACE FUNCTION iceberg_snapshots(path text, metadata_compression_codec TEXT DEFAULT 'none',
                                                         skip_schema_inference BOOLEAN DEFAULT FALSE,
                                                         version TEXT DEFAULT 'version-hint.text',
                                                         version_name_format TEXT DEFAULT 'v%s%s.metadata.json,%s%s.metadata.json')
-RETURNS SETOF record LANGUAGE 'plpgsql' AS
+RETURNS SETOF iceberg_snapshots_record LANGUAGE 'plpgsql' AS
 $func$
 BEGIN
     RAISE EXCEPTION 'Function `iceberg_snapshots(TEXT)` only works with Duckdb execution.';

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -97,11 +97,39 @@ BEGIN
 END;
 $func$;
 
-CREATE OR REPLACE FUNCTION iceberg_scan(path text)
+CREATE OR REPLACE FUNCTION iceberg_scan(path text, allow_moved_paths BOOLEAN DEFAULT FALSE,
+                                                   mode TEXT DEFAULT '',
+                                                   metadata_compression_codec TEXT DEFAULT 'none',
+                                                   skip_schema_inference BOOLEAN DEFAULT FALSE,
+                                                   version TEXT DEFAULT 'version-hint.text',
+                                                   version_name_format TEXT DEFAULT 'v%s%s.metadata.json,%s%s.metadata.json')
 RETURNS SETOF record LANGUAGE 'plpgsql' AS
 $func$
 BEGIN
     RAISE EXCEPTION 'Function `iceberg_scan(TEXT)` only works with Duckdb execution.';
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION iceberg_metadata(path text, allow_moved_paths BOOLEAN DEFAULT FALSE,
+                                                       metadata_compression_codec TEXT DEFAULT 'none',
+                                                       skip_schema_inference BOOLEAN DEFAULT FALSE,
+                                                       version TEXT DEFAULT 'version-hint.text',
+                                                       version_name_format TEXT DEFAULT 'v%s%s.metadata.json,%s%s.metadata.json')
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+    RAISE EXCEPTION 'Function `iceberg_metadata(TEXT)` only works with Duckdb execution.';
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION iceberg_snapshots(path text, metadata_compression_codec TEXT DEFAULT 'none',
+                                                        skip_schema_inference BOOLEAN DEFAULT FALSE,
+                                                        version TEXT DEFAULT 'version-hint.text',
+                                                        version_name_format TEXT DEFAULT 'v%s%s.metadata.json,%s%s.metadata.json')
+RETURNS SETOF record LANGUAGE 'plpgsql' AS
+$func$
+BEGIN
+    RAISE EXCEPTION 'Function `iceberg_snapshots(TEXT)` only works with Duckdb execution.';
 END;
 $func$;
 

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -90,7 +90,7 @@ BuildDuckdbOnlyFunctions() {
 	 * each of the found functions is actually part of our extension before
 	 * caching its OID as a DuckDB-only function.
 	 */
-	const char *function_names[] = {"read_parquet", "read_csv", "iceberg_scan"};
+	const char *function_names[] = {"read_parquet", "read_csv", "iceberg_scan", "iceberg_metadata", "iceberg_snapshots"};
 
 	for (int i = 0; i < lengthof(function_names); i++) {
 		CatCList *catlist = SearchSysCacheList1(PROCNAMEARGSNSP, CStringGetDatum(function_names[i]));

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -571,6 +571,7 @@ GetPostgresDuckDBType(duckdb::LogicalType type) {
 	case duckdb::LogicalTypeId::INTEGER:
 		return INT4OID;
 	case duckdb::LogicalTypeId::BIGINT:
+	case duckdb::LogicalTypeId::UBIGINT:
 		return INT8OID;
 	case duckdb::LogicalTypeId::HUGEINT:
 		return NUMERICOID;

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -404,7 +404,8 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 		}
 		NumericVar numeric_var;
 		D_ASSERT(value.type().id() == duckdb::LogicalTypeId::DECIMAL ||
-		         value.type().id() == duckdb::LogicalTypeId::HUGEINT);
+		         value.type().id() == duckdb::LogicalTypeId::HUGEINT ||
+				 value.type().id() == duckdb::LogicalTypeId::UBIGINT);
 		auto physical_type = value.type().InternalType();
 		const bool is_decimal = value.type().id() == duckdb::LogicalTypeId::DECIMAL;
 		uint8_t scale = is_decimal ? duckdb::DecimalType::GetScale(value.type()) : 0;
@@ -420,6 +421,10 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 		}
 		case duckdb::PhysicalType::INT64: {
 			numeric_var = ConvertNumeric<int64_t>(value.GetValueUnsafe<int64_t>(), scale);
+			break;
+		}
+		case duckdb::PhysicalType::UINT64: {
+			numeric_var = ConvertNumeric<uint64_t>(value.GetValueUnsafe<uint64_t>(), scale);
 			break;
 		}
 		case duckdb::PhysicalType::INT128: {
@@ -571,8 +576,8 @@ GetPostgresDuckDBType(duckdb::LogicalType type) {
 	case duckdb::LogicalTypeId::INTEGER:
 		return INT4OID;
 	case duckdb::LogicalTypeId::BIGINT:
-	case duckdb::LogicalTypeId::UBIGINT:
 		return INT8OID;
+	case duckdb::LogicalTypeId::UBIGINT:
 	case duckdb::LogicalTypeId::HUGEINT:
 		return NUMERICOID;
 	case duckdb::LogicalTypeId::UTINYINT:


### PR DESCRIPTION
This also adds support for conversion to UBIGINT because one of the Iceberg functions return that type.