### PR TITLE
Remove Tx from TxManager  on rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ compile_commands.json
 *.o
 *.bc
 *.dylib
+*.pyc

--- a/include/pgduckdb/catalog/pgduckdb_table.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_table.hpp
@@ -26,7 +26,7 @@ public:
 
 public:
 	static ::Relation OpenRelation(Oid relid);
-	static bool SetTableInfo(CreateTableInfo &info, ::Relation rel);
+	static void SetTableInfo(CreateTableInfo &info, ::Relation rel);
 	static Cardinality GetTableCardinality(::Relation rel);
 
 protected:

--- a/include/pgduckdb/catalog/pgduckdb_transaction.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction.hpp
@@ -13,10 +13,11 @@ public:
 	SchemaItems(unique_ptr<PostgresSchema> &&schema, const string &name) : name(name), schema(std::move(schema)) {
 	}
 
-public:
 	optional_ptr<CatalogEntry> GetTable(const string &name);
 
-public:
+	optional_ptr<CatalogEntry> GetSchema() const;
+
+private:
 	string name;
 	unique_ptr<PostgresSchema> schema;
 	case_insensitive_map_t<unique_ptr<PostgresTable>> tables;
@@ -28,13 +29,11 @@ public:
 	                    Snapshot snapshot);
 	~PostgresTransaction() override;
 
-public:
 	optional_ptr<CatalogEntry> GetCatalogEntry(CatalogType type, const string &schema, const string &name);
 
 private:
 	optional_ptr<CatalogEntry> GetSchema(const string &name);
 
-private:
 	case_insensitive_map_t<SchemaItems> schemas;
 	PostgresCatalog &catalog;
 	Snapshot snapshot;

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -23,6 +23,10 @@ public:
 
 	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
 
+	void Reset() {
+		database.reset();
+	}
+
 private:
 	DuckDBManager();
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 addopts = ["--import-mode=prepend", "--showlocals", "--tb=short"]
 pythonpath = ['tests/pyduck']
 timeout = 30

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -248,6 +248,9 @@ CREATE EVENT TRIGGER duckdb_alter_table_trigger ON ddl_command_end
     WHEN tag IN ('ALTER TABLE')
     EXECUTE FUNCTION duckdb_alter_table_trigger();
 
+CREATE OR REPLACE FUNCTION recycle_ddb() RETURNS void
+    LANGUAGE C AS 'MODULE_PATHNAME', 'pgduckdb_recycle_ddb';
+
 DO $$
 BEGIN
     RAISE WARNING 'To actually execute queries using DuckDB you need to run "SET duckdb.execution TO true;"';

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -44,11 +44,11 @@ PostgresTable::OpenRelation(Oid relid) {
 	return pgduckdb::PostgresFunctionGuard<::Relation>(RelationIdGetRelation, relid);
 }
 
-bool
+void
 PostgresTable::SetTableInfo(CreateTableInfo &info, ::Relation rel) {
 	auto tupleDesc = RelationGetDescr(rel);
 
-	for (int i = 0; i < tupleDesc->natts; i++) {
+	for (int i = 0; i < tupleDesc->natts; ++i) {
 		Form_pg_attribute attr = &tupleDesc->attrs[i];
 		auto col_name = duckdb::string(NameStr(attr->attname));
 		auto duck_type = pgduckdb::ConvertPostgresToDuckColumnType(attr);
@@ -57,8 +57,6 @@ PostgresTable::SetTableInfo(CreateTableInfo &info, ::Relation rel) {
 		elog(DEBUG2, "(DuckDB/SetTableInfo) Column name: %s, Type: %s --", col_name.c_str(),
 		     duck_type.ToString().c_str());
 	}
-
-	return true;
 }
 
 Cardinality

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -82,8 +82,10 @@ SchemaItems::GetTable(const string &entry_name) {
 	info.table = entry_name;
 	Cardinality cardinality = 1;
 	if (!PostgresTable::SetTableInfo(info, rel)) {
+		RelationClose(rel);
 		return nullptr;
 	}
+
 	cardinality = PostgresTable::GetTableCardinality(rel);
 	table = make_uniq<PostgresHeapTable>(catalog, *schema, info, rel, cardinality, snapshot);
 	tables[entry_name] = std::move(table);

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -90,18 +90,22 @@ SchemaItems::GetTable(const string &entry_name) {
 	return tables[entry_name].get();
 }
 
+optional_ptr<CatalogEntry> SchemaItems::GetSchema() const {
+	return schema.get();
+}
+
 optional_ptr<CatalogEntry>
 PostgresTransaction::GetSchema(const string &name) {
 	auto it = schemas.find(name);
 	if (it != schemas.end()) {
-		return it->second.schema.get();
+		return it->second.GetSchema();
 	}
 
 	CreateSchemaInfo create_schema;
 	create_schema.schema = name;
 	auto pg_schema = make_uniq<PostgresSchema>(catalog, create_schema, snapshot);
 	schemas.emplace(std::make_pair(name, SchemaItems(std::move(pg_schema), name)));
-	return schemas.at(name).schema.get();
+	return schemas.at(name).GetSchema();
 }
 
 optional_ptr<CatalogEntry>

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -77,17 +77,12 @@ SchemaItems::GetTable(const string &entry_name) {
 
 	::Relation rel = PostgresTable::OpenRelation(rel_oid);
 
-	unique_ptr<PostgresTable> table;
 	CreateTableInfo info;
 	info.table = entry_name;
-	Cardinality cardinality = 1;
-	if (!PostgresTable::SetTableInfo(info, rel)) {
-		RelationClose(rel);
-		return nullptr;
-	}
+	PostgresTable::SetTableInfo(info, rel);
 
-	cardinality = PostgresTable::GetTableCardinality(rel);
-	table = make_uniq<PostgresHeapTable>(catalog, *schema, info, rel, cardinality, snapshot);
+	auto cardinality = PostgresTable::GetTableCardinality(rel);
+	auto table = make_uniq<PostgresHeapTable>(catalog, *schema, info, rel, cardinality, snapshot);
 	tables[entry_name] = std::move(table);
 	return tables[entry_name].get();
 }
@@ -118,6 +113,7 @@ PostgresTransaction::GetCatalogEntry(CatalogType type, const string &schema, con
 		if (it == schemas.end()) {
 			return nullptr;
 		}
+
 		auto &schema_entry = it->second;
 		return schema_entry.GetTable(name);
 	}

--- a/src/catalog/pgduckdb_transaction_manager.cpp
+++ b/src/catalog/pgduckdb_transaction_manager.cpp
@@ -26,7 +26,8 @@ PostgresTransactionManager::CommitTransaction(ClientContext &context, Transactio
 
 void
 PostgresTransactionManager::RollbackTransaction(Transaction &transaction) {
-	return;
+	lock_guard<mutex> l(transaction_lock);
+	transactions.erase(transaction);
 }
 
 void

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -37,14 +37,14 @@ IsCatalogTable(List *tables) {
 				return true;
 			}
 		}
+
 		if (table->relid) {
 			auto rel = RelationIdGetRelation(table->relid);
 			auto namespace_oid = RelationGetNamespace(rel);
+			RelationClose(rel);
 			if (namespace_oid == PG_CATALOG_NAMESPACE || namespace_oid == PG_TOAST_NAMESPACE) {
-				RelationClose(rel);
 				return true;
 			}
-			RelationClose(rel);
 		}
 	}
 	return false;
@@ -55,6 +55,7 @@ IsDuckdbTable(Oid relid) {
 	if (relid == InvalidOid) {
 		return false;
 	}
+
 	auto rel = RelationIdGetRelation(relid);
 	bool result = pgduckdb::IsDuckdbTableAm(rel->rd_tableam);
 	RelationClose(rel);

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -226,10 +226,17 @@ Duckdb_ExplainCustomScan(CustomScanState *node, List *ancestors, ExplainState *e
 	if (!chunk || chunk->size() == 0) {
 		return;
 	}
+
 	/* Is it safe to hardcode this as result of DuckDB explain? */
-	auto value = chunk->GetValue(1, 0);
+	auto value = chunk->GetValue(1, 0).GetValue<duckdb::string>();
+
+	/* Fully consume the stream */
+	do {
+		chunk = duckdb_scan_state->query_results->Fetch();
+	} while (chunk && chunk->size() > 0);
+
 	std::string explain_output = "\n\n";
-	explain_output += value.GetValue<duckdb::string>();
+	explain_output += value;
 	explain_output += "\n";
 	ExplainPropertyText("DuckDB Execution Plan", explain_output.c_str(), es);
 }

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -223,4 +223,11 @@ cache(PG_FUNCTION_ARGS) {
 	PG_RETURN_BOOL(result);
 }
 
+PG_FUNCTION_INFO_V1(pgduckdb_recycle_ddb);
+Datum
+pgduckdb_recycle_ddb(PG_FUNCTION_ARGS) {
+	pgduckdb::DuckDBManager::Get().Reset();
+	PG_RETURN_BOOL(true);
+}
+
 } // extern "C"

--- a/test/regression/expected/duckdb_recycle.out
+++ b/test/regression/expected/duckdb_recycle.out
@@ -1,0 +1,57 @@
+SET duckdb.execution = true;
+CREATE TABLE ta(a INT);
+EXPLAIN SELECT count(*) FROM ta;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │    UNGROUPED_AGGREGATE    │
+ │    ────────────────────   │
+ │        Aggregates:        │
+ │        count_star()       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │     POSTGRES_SEQ_SCAN     │
+ │    ────────────────────   │
+ │         Function:         │
+ │     POSTGRES_SEQ_SCAN     │
+ │                           │
+ │         ~2550 Rows        │
+ └───────────────────────────┘
+ 
+ 
+(19 rows)
+
+SELECT duckdb.recycle_ddb();
+ recycle_ddb 
+-------------
+ 
+(1 row)
+
+EXPLAIN SELECT count(*) FROM ta;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │    UNGROUPED_AGGREGATE    │
+ │    ────────────────────   │
+ │        Aggregates:        │
+ │        count_star()       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │     POSTGRES_SEQ_SCAN     │
+ │    ────────────────────   │
+ │         Function:         │
+ │     POSTGRES_SEQ_SCAN     │
+ │                           │
+ │         ~2550 Rows        │
+ └───────────────────────────┘
+ 
+ 
+(19 rows)
+
+DROP TABLE ta;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -9,6 +9,7 @@ test: materialized_view
 test: hugeint_conversion
 test: read_functions
 test: duckdb_only_functions
+test: duckdb_recycle
 test: cte
 test: create_table_as
 test: standard_conforming_strings

--- a/test/regression/sql/duckdb_recycle.sql
+++ b/test/regression/sql/duckdb_recycle.sql
@@ -1,0 +1,6 @@
+SET duckdb.execution = true;
+CREATE TABLE ta(a INT);
+EXPLAIN SELECT count(*) FROM ta;
+SELECT duckdb.recycle_ddb();
+EXPLAIN SELECT count(*) FROM ta;
+DROP TABLE ta;


### PR DESCRIPTION
Fixes https://github.com/duckdb/pg_duckdb/issues/279

Also adds a test that removes `DuckDB` singleton and re-creates it: this is when the crash was happening.

And fully consume the explain output stream from DuckDB