### PR TITLE
Close heap buffer is execution is terminated

### DIFF
--- a/src/scan/heap_reader.cpp
+++ b/src/scan/heap_reader.cpp
@@ -51,6 +51,12 @@ HeapReader::HeapReader(Relation rel, duckdb::shared_ptr<HeapReaderGlobalState> h
 }
 
 HeapReader::~HeapReader() {
+	/* If execution is interrupted and buffer is still opened close it now */
+	if (m_buffer != InvalidBuffer) {
+		DuckdbProcessLock::GetLock().lock();
+		UnlockReleaseBuffer(m_buffer);
+		DuckdbProcessLock::GetLock().unlock();
+	}
 }
 
 Page

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -46,3 +46,17 @@ DROP TABLE empty;
 DROP EXTENSION pg_duckdb;
 CREATE EXTENSION pg_duckdb;
 WARNING:  To actually execute queries using DuckDB you need to run "SET duckdb.execution TO true;"
+-- Verify that all pages that are fetched are closed before execution ends.
+-- Table with smaller number of tuples (if nothing is matched) will terminate execution
+-- before second table is read to the end.
+CREATE TABLE rt(a INT);
+CREATE TABLE lt(a INT);
+INSERT INTO rt SELECT g FROM generate_series(1,100) g;
+INSERT INTO lt SELECT g % 10 FROM generate_series(1,100000) g;
+SELECT lt.a * rt.a FROM lt, rt WHERE lt.a % 2 = 0 AND rt.a = 0;
+ ?column? 
+----------
+(0 rows)
+
+DROP TABLE lt;
+DROP TABLE rt;

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -1,9 +1,10 @@
-create table int_as_varchar(a varchar);
-insert into int_as_varchar SELECT * from (
+CREATE TABLE int_as_varchar(a varchar);
+INSERT INTO int_as_varchar SELECT * from (
 	VALUES
 		('abc')
 ) t(a);
-select a::INTEGER from int_as_varchar;
+SELECT a::INTEGER FROM int_as_varchar;
 ERROR:  (PGDuckDB/ExecuteQuery) Conversion Error: Could not convert string 'abc' to INT32
 LINE 1: SELECT (a)::integer AS a FROM pgduckdb.public.int...
                   ^
+DROP TABLE int_as_varchar;

--- a/test/regression/sql/basic.sql
+++ b/test/regression/sql/basic.sql
@@ -23,3 +23,16 @@ DROP TABLE empty;
 
 DROP EXTENSION pg_duckdb;
 CREATE EXTENSION pg_duckdb;
+
+
+-- Verify that all pages that are fetched are closed before execution ends.
+-- Table with smaller number of tuples (if nothing is matched) will terminate execution
+-- before second table is read to the end.
+
+CREATE TABLE rt(a INT);
+CREATE TABLE lt(a INT);
+INSERT INTO rt SELECT g FROM generate_series(1,100) g;
+INSERT INTO lt SELECT g % 10 FROM generate_series(1,100000) g;
+SELECT lt.a * rt.a FROM lt, rt WHERE lt.a % 2 = 0 AND rt.a = 0;
+DROP TABLE lt;
+DROP TABLE rt;

--- a/test/regression/sql/execution_error.sql
+++ b/test/regression/sql/execution_error.sql
@@ -1,7 +1,8 @@
-create table int_as_varchar(a varchar);
-insert into int_as_varchar SELECT * from (
+CREATE TABLE int_as_varchar(a varchar);
+INSERT INTO int_as_varchar SELECT * from (
 	VALUES
 		('abc')
 ) t(a);
 
-select a::INTEGER from int_as_varchar;
+SELECT a::INTEGER FROM int_as_varchar;
+DROP TABLE int_as_varchar;


### PR DESCRIPTION
If heap reader execution is terminated before we close current buffer we would leak that resource. Check if buffer is opened and close it in destructor.