### PR TITLE
Small improvements to secret and extension management

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The best way to get started is to connect Postgres to a new or existing object s
 	```sql
 	-- Session Token is Optional
 	INSERT INTO duckdb.secrets
-	(type, id, secret, session_token, region)
+	(type, key_id, secret, session_token, region)
 	VALUES ('S3', 'access_key_id', 'secret_access_key', 'session_token', 'us-east-1');
 	```
 

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -8,25 +8,27 @@
 namespace pgduckdb {
 
 /* constants for duckdb.secrets */
-#define Natts_duckdb_secret              8
-#define Anum_duckdb_secret_type          1
-#define Anum_duckdb_secret_id            2
-#define Anum_duckdb_secret_secret        3
-#define Anum_duckdb_secret_region        4
-#define Anum_duckdb_secret_session_token 5
-#define Anum_duckdb_secret_endpoint      6
-#define Anum_duckdb_secret_r2_account_id 7
-#define Anum_duckdb_secret_use_ssl       8
+#define Natts_duckdb_secret              9
+#define Anum_duckdb_secret_name          1
+#define Anum_duckdb_secret_type          2
+#define Anum_duckdb_secret_key_id        3
+#define Anum_duckdb_secret_secret        4
+#define Anum_duckdb_secret_region        5
+#define Anum_duckdb_secret_session_token 6
+#define Anum_duckdb_secret_endpoint      7
+#define Anum_duckdb_secret_r2_account_id 8
+#define Anum_duckdb_secret_use_ssl       9
 
 typedef struct DuckdbSecret {
+	std::string name;
 	std::string type;
-	std::string id;
+	std::string key_id;
 	std::string secret;
 	std::string region;
 	std::string session_token;
 	std::string endpoint;
 	std::string r2_account_id;
-	bool		use_ssl;
+	bool use_ssl;
 } DuckdbSecret;
 
 extern std::vector<DuckdbSecret> ReadDuckdbSecrets();

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -159,8 +159,9 @@ CREATE SEQUENCE secrets_table_seq START WITH 1 INCREMENT BY 1;
 SELECT setval('secrets_table_seq', 1);
 
 CREATE TABLE secrets (
+    name TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
     type TEXT NOT NULL,
-    id TEXT NOT NULL,
+    key_id TEXT NOT NULL,
     secret TEXT NOT NULL,
     region TEXT,
     session_token TEXT,
@@ -197,7 +198,7 @@ CREATE TRIGGER duckdb_secret_r2_tr BEFORE INSERT OR UPDATE ON secrets
 FOR EACH ROW EXECUTE PROCEDURE duckdb_secret_r2_check();
 
 CREATE TABLE extensions (
-    name TEXT NOT NULL,
+    name TEXT NOT NULL PRIMARY KEY,
     enabled BOOL DEFAULT TRUE
 );
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -108,7 +108,7 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 		StringInfo secret_key = makeStringInfo();
 		bool is_r2_cloud_secret = (secret.type.rfind("R2", 0) == 0);
 		appendStringInfo(secret_key, "CREATE SECRET pgduckb_secret_%d ", secret_id);
-		appendStringInfo(secret_key, "(TYPE %s, KEY_ID '%s', SECRET '%s'", secret.type.c_str(), secret.id.c_str(),
+		appendStringInfo(secret_key, "(TYPE %s, KEY_ID '%s', SECRET '%s'", secret.type.c_str(), secret.key_id.c_str(),
 		                 secret.secret.c_str());
 		if (secret.region.length() && !is_r2_cloud_secret) {
 			appendStringInfo(secret_key, ", REGION '%s'", secret.region.c_str());
@@ -130,9 +130,8 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 
 		pfree(secret_key->data);
 		secret_id++;
+		secret_table_num_rows = secret_id;
 	}
-
-	secret_table_num_rows = secret_id;
 }
 
 void

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -61,7 +61,7 @@ ReadDuckdbSecrets() {
 		DuckdbSecret secret;
 
 		secret.type = DatumToString(datum_array[Anum_duckdb_secret_type - 1]);
-		secret.id = DatumToString(datum_array[Anum_duckdb_secret_id - 1]);
+		secret.key_id = DatumToString(datum_array[Anum_duckdb_secret_key_id - 1]);
 		secret.secret = DatumToString(datum_array[Anum_duckdb_secret_secret - 1]);
 
 		if (!is_null_array[Anum_duckdb_secret_region - 1])

--- a/test/regression/expected/secrets.out
+++ b/test/regression/expected/secrets.out
@@ -17,7 +17,7 @@ SELECT last_value FROM duckdb.secrets_table_seq;
 (1 row)
 
 -- INSERT SHOULD TRIGGER UPDATE OF SECRETS
-INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+INSERT INTO duckdb.secrets (type, key_id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
 SELECT last_value FROM duckdb.secrets_table_seq;
  last_value 
@@ -37,7 +37,7 @@ pgduckb_secret_0
  
 (1 row)
 
-INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+INSERT INTO duckdb.secrets (type, key_id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
 SELECT last_value FROM duckdb.secrets_table_seq;
  last_value 
@@ -59,7 +59,7 @@ pgduckb_secret_1
 (1 row)
 
 -- DELETE SHOULD TRIGGER UPDATE OF SECRETS
-DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+DELETE FROM duckdb.secrets WHERE key_id = 'access_key_id_1';
 SELECT last_value FROM duckdb.secrets_table_seq;
  last_value 
 ------------

--- a/test/regression/sql/secrets.sql
+++ b/test/regression/sql/secrets.sql
@@ -7,14 +7,14 @@ SELECT last_value FROM duckdb.secrets_table_seq;
 
 -- INSERT SHOULD TRIGGER UPDATE OF SECRETS
 
-INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+INSERT INTO duckdb.secrets (type, key_id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_1', 'secret_access_key', 'session_token', 'us-east-1');
 
 SELECT last_value FROM duckdb.secrets_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
-INSERT INTO duckdb.secrets (type, id, secret, session_token, region)
+INSERT INTO duckdb.secrets (type, key_id, secret, session_token, region)
 VALUES ('S3', 'access_key_id_2', 'secret_access_key', 'session_token', 'us-east-1');
 
 SELECT last_value FROM duckdb.secrets_table_seq;
@@ -22,7 +22,7 @@ SELECT last_value FROM duckdb.secrets_table_seq;
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
 -- DELETE SHOULD TRIGGER UPDATE OF SECRETS
-DELETE FROM duckdb.secrets WHERE id = 'access_key_id_1';
+DELETE FROM duckdb.secrets WHERE key_id = 'access_key_id_1';
 
 SELECT last_value FROM duckdb.secrets_table_seq;
 


### PR DESCRIPTION
1. Add a unique name column to the secrets table, so people can reference a unique identifier. Defaults to a random uuid. This makes it easy to delete/update/reference a secret.
2. Rename `id` column in secrets to `key_id` to align with DuckDB naming.
3. Correctly track count `secret_table_num_rows` in case of partial failure.
4. Add a primary key to `duckdb.extensions`, you cannot install the same extension multiple times. Let's enforce that.

Fixes #289 