### PR TITLE
Handle custom DateStyle correctly

### DIFF
--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -1,7 +1,9 @@
 #include "postgres.h"
+#include "nodes/parsenodes.h"
 
 char *pgduckdb_relation_name(Oid relid);
 char *pgduckdb_function_name(Oid function_oid);
+char *pgduckdb_get_querydef(Query *);
 char *pgduckdb_get_tabledef(Oid relation_id);
 List *pgduckdb_db_and_schema(const char *postgres_schema_name, bool is_duckdb_table);
 const char *pgduckdb_db_and_schema_string(const char *postgres_schema_name, bool is_duckdb_table);

--- a/include/pgduckdb/utility/rename_ruleutils.h
+++ b/include/pgduckdb/utility/rename_ruleutils.h
@@ -6,7 +6,7 @@
 #define pg_get_indexdef_string           pgduckdb_pg_get_indexdef_string
 #define pg_get_indexdef_columns          pgduckdb_pg_get_indexdef_columns
 #define pg_get_indexdef_columns_extended pgduckdb_pg_get_indexdef_columns_extended
-#define pg_get_querydef                  pgduckdb_pg_get_querydef
+#define pg_get_querydef                  pgduckdb_pg_get_querydef_internal
 #define pg_get_partkeydef_columns        pgduckdb_pg_get_partkeydef_columns
 #define pg_get_partconstrdef_string      pgduckdb_pg_get_partconstrdef_string
 #define pg_get_constraintdef_command     pgduckdb_pg_get_constraintdef_command

--- a/include/pgduckdb/vendor/pg_ruleutils.h
+++ b/include/pgduckdb/vendor/pg_ruleutils.h
@@ -28,7 +28,7 @@ extern char *pgduckdb_pg_get_indexdef_string(Oid indexrelid);
 extern char *pgduckdb_pg_get_indexdef_columns(Oid indexrelid, bool pretty);
 extern char *pgduckdb_pg_get_indexdef_columns_extended(Oid indexrelid,
 											  bits16 flags);
-extern char *pgduckdb_pg_get_querydef(Query *query, bool pretty);
+extern char *pgduckdb_pg_get_querydef_internal(Query *query, bool pretty);
 
 extern char *pgduckdb_pg_get_partkeydef_columns(Oid relid, bool pretty);
 extern char *pgduckdb_pg_get_partconstrdef_string(Oid partitionId, char *aliasname);

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -291,7 +291,7 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
 	pgduckdb::DuckDBQueryOrThrow(*connection, create_table_string);
 	if (ctas_query) {
 
-		const char *ctas_query_string = pgduckdb_pg_get_querydef(ctas_query, false);
+		const char *ctas_query_string = pgduckdb_get_querydef(ctas_query);
 
 		std::string insert_string =
 		    std::string("INSERT INTO ") + pgduckdb_relation_name(relid) + " " + ctas_query_string;

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -12,7 +12,7 @@ extern "C" {
 #include "utils/syscache.h"
 #include "utils/guc.h"
 
-#include "pgduckdb/vendor/pg_ruleutils.h"
+#include "pgduckdb/pgduckdb_ruleutils.h"
 }
 
 #include "pgduckdb/pgduckdb_duckdb.hpp"
@@ -34,7 +34,7 @@ DuckdbPrepare(const Query *query) {
 	PreventInTransactionBlock(true, "DuckDB queries");
 
 	Query *copied_query = (Query *)copyObjectImpl(query);
-	const char *query_string = pgduckdb_pg_get_querydef(copied_query, false);
+	const char *query_string = pgduckdb_get_querydef(copied_query);
 
 	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
 		if (duckdb_explain_analyze) {

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -14,7 +14,6 @@ extern "C" {
 #include "utils/rls.h"
 #include "tcop/tcopprot.h"
 
-#include "pgduckdb/vendor/pg_ruleutils.h"
 #include "pgduckdb/pgduckdb_ruleutils.h"
 }
 
@@ -197,8 +196,8 @@ DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment
 
 		rewritten = pg_analyze_and_rewrite_fixedparams(raw_stmt, query_string, NULL, 0, NULL);
 		query = linitial_node(Query, rewritten);
-		rewritten_query_string = duckdb::StringUtil::Format(
-		    "COPY (%s) TO %s %s", pgduckdb_pg_get_querydef(query, false), filename_quoted, options_string);
+		rewritten_query_string = duckdb::StringUtil::Format("COPY (%s) TO %s %s", pgduckdb_get_querydef(query),
+		                                                    filename_quoted, options_string);
 	} else {
 		bool copy_allowed = true;
 		ParseState *pstate = make_parsestate(NULL);

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -15,23 +15,19 @@ CREATE TEMP TABLE t(
     json_obj JSON,
     CHECK (i4 > i2)
 ) USING duckdb;
--- FIXME: This should not be necessary to make this test work, we should always
--- send ISO dates to duckdb or even better would be to make DuckDB respect
--- postgres its datestyle
-SET DateStyle = 'ISO, YMD';
 INSERT INTO t VALUES (true, 2, 4, 8, 4.0, 8.0, 't1', 't2', 't3', '2024-05-04', '2020-01-01T01:02:03', '{"a": 1}');
 SELECT * FROM t;
- bool | i2 | i4 | i8 | fl4 | fl8 | t1 | t2 | t3 |     d      |         ts          | json_obj 
-------+----+----+----+-----+-----+----+----+----+------------+---------------------+----------
- t    |  2 |  4 |  8 |   4 |   8 | t1 | t2 | t3 | 2024-05-04 | 2020-01-01 01:02:03 | {"a": 1}
+ bool | i2 | i4 | i8 | fl4 | fl8 | t1 | t2 | t3 |     d      |            ts            | json_obj 
+------+----+----+----+-----+-----+----+----+----+------------+--------------------------+----------
+ t    |  2 |  4 |  8 |   4 |   8 | t1 | t2 | t3 | 05-04-2024 | Wed Jan 01 01:02:03 2020 | {"a": 1}
 (1 row)
 
 CREATE TEMP TABLE t_heap (a int);
 INSERT INTO t_heap VALUES (2);
 SELECT * FROM t JOIN t_heap ON i2 = a;
- bool | i2 | i4 | i8 | fl4 | fl8 | t1 | t2 | t3 |     d      |         ts          | json_obj | a 
-------+----+----+----+-----+-----+----+----+----+------------+---------------------+----------+---
- t    |  2 |  4 |  8 |   4 |   8 | t1 | t2 | t3 | 2024-05-04 | 2020-01-01 01:02:03 | {"a": 1} | 2
+ bool | i2 | i4 | i8 | fl4 | fl8 | t1 | t2 | t3 |     d      |            ts            | json_obj | a 
+------+----+----+----+-----+-----+----+----+----+------------+--------------------------+----------+---
+ t    |  2 |  4 |  8 |   4 |   8 | t1 | t2 | t3 | 05-04-2024 | Wed Jan 01 01:02:03 2020 | {"a": 1} | 2
 (1 row)
 
 -- The default_table_access_method GUC should be honored.
@@ -211,8 +207,8 @@ CREATE TEMP TABLE webpages USING duckdb AS SELECT * FROM read_csv('../../data/we
 SELECT * FROM webpages ORDER BY column00 LIMIT 2;
  column00 |     column01     |  column02  
 ----------+------------------+------------
-        1 | AAAAAAAABAAAAAAA | 1997-09-03
-        2 | AAAAAAAACAAAAAAA | 1997-09-03
+        1 | AAAAAAAABAAAAAAA | 09-03-1997
+        2 | AAAAAAAACAAAAAAA | 09-03-1997
 (2 rows)
 
 CREATE TEMP TABLE t_heap(a int) USING heap;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -17,11 +17,6 @@ CREATE TEMP TABLE t(
 ) USING duckdb;
 
 
--- FIXME: This should not be necessary to make this test work, we should always
--- send ISO dates to duckdb or even better would be to make DuckDB respect
--- postgres its datestyle
-SET DateStyle = 'ISO, YMD';
-
 INSERT INTO t VALUES (true, 2, 4, 8, 4.0, 8.0, 't1', 't2', 't3', '2024-05-04', '2020-01-01T01:02:03', '{"a": 1}');
 SELECT * FROM t;
 


### PR DESCRIPTION
DuckDB only understands ISO dates when parsing dates. So we need to make sure that when we generate the DuckDB query, any date literals are formatted using ISO. We still want the final date output to be whatever the user requested though. We do this by temporarily changing the DateStyle to ISO when generating the DuckDB query.

Ideally we'd even want a TIMESTAMP casted explicitly to TEXT in DuckDB to be formatted using Postgres its DateStyle. But that seems a bridge to far for now. With this change at least queries are parseable by DuckDB when Postgres its DateStyle is set to anything other than ISO.
