### PR TITLE
Add `disabled_filesystems` support

### DIFF
--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -4,6 +4,7 @@
 extern bool duckdb_execution;
 extern int duckdb_maximum_threads;
 extern char *duckdb_maximum_memory;
+extern char *duckdb_disabled_filesystems;
 extern bool duckdb_enable_external_access;
 extern bool duckdb_allow_unsigned_extensions;
 extern int duckdb_max_threads_per_query;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -20,6 +20,7 @@ char *duckdb_motherduck_postgres_user = strdup("");
 
 int duckdb_maximum_threads = -1;
 char *duckdb_maximum_memory = NULL;
+char *duckdb_disabled_filesystems = NULL;
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_unsigned_extensions = false;
 
@@ -94,6 +95,10 @@ DuckdbInitGUC(void) {
 	                     &duckdb_allow_unsigned_extensions);
 
 	DefineCustomVariable("duckdb.max_memory", "The maximum memory DuckDB can use (e.g., 1GB)", &duckdb_maximum_memory);
+
+	DefineCustomVariable("duckdb.disabled_filesystems",
+	                     "Disable specific file systems preventing access (e.g., LocalFileSystem)",
+	                     &duckdb_disabled_filesystems);
 
 	DefineCustomVariable("duckdb.threads", "Maximum number of DuckDB threads per Postgres backend.",
 	                     &duckdb_maximum_threads, -1, 1024);

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -88,20 +88,21 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.execution", "Is DuckDB query execution enabled.", &duckdb_execution);
 
 	DefineCustomVariable("duckdb.enable_external_access", "Allow the DuckDB to access external state.",
-	                     &duckdb_enable_external_access);
+	                     &duckdb_enable_external_access, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.allow_unsigned_extensions",
 	                     "Allow DuckDB to load extensions with invalid or missing signatures",
-	                     &duckdb_allow_unsigned_extensions);
+	                     &duckdb_allow_unsigned_extensions, PGC_SUSET);
 
-	DefineCustomVariable("duckdb.max_memory", "The maximum memory DuckDB can use (e.g., 1GB)", &duckdb_maximum_memory);
+	DefineCustomVariable("duckdb.max_memory", "The maximum memory DuckDB can use (e.g., 1GB)", &duckdb_maximum_memory,
+	                     PGC_SUSET);
 
 	DefineCustomVariable("duckdb.disabled_filesystems",
 	                     "Disable specific file systems preventing access (e.g., LocalFileSystem)",
-	                     &duckdb_disabled_filesystems);
+	                     &duckdb_disabled_filesystems, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.threads", "Maximum number of DuckDB threads per Postgres backend.",
-	                     &duckdb_maximum_threads, -1, 1024);
+	                     &duckdb_maximum_threads, -1, 1024, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.max_threads_per_query",
 	                     "Maximum number of DuckDB threads used for a single Postgres scan",


### PR DESCRIPTION
cf. https://duckdb.org/docs/configuration/overview.html
Adds support for DuckDB's `disabled_filesystems` option

Fixes #105 

Also set `enable_external_access`, `allow_unsigned_extensions`, `max_threads` and `max_memory` as only modifiable by a super user.

