### PR TITLE
Better MotherDuck configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,49 @@ The best way to get started is to connect Postgres to a new or existing object s
 	LIMIT 100;
 	```
 
+### Connect with MotherDuck
+
+pg_duckdb also integrates with [MotherDuck][md]. To enable this support you first need to [generate an access token][md-access-token] and then add the following line to your `postgresql.conf` file:
+
+```ini
+duckdb.motherduck_token = 'your_access_token';
+```
+
+NOTE: If you don't want to store the token in your `postgresql.conf`file can also store the token in the `motherduck_token` environment variable and then explicitly enable MotherDuck support in your `postgresql.conf` file:
+
+```ini
+duckdb.motherduck_enabled = true;
+```
+
+If you installed `pg_duckdb` in a different Postgres database than the default one named `postgres`, then you also need to add the following line to your `postgresql.conf` file:
+
+```ini
+duckdb.motherduck_postgres_database = 'your_database_name';
+```
+
+After doing this (and possibly restarting Postgres). You can then you create tables in the MotherDuck database by using the `duckdb` [Table Access Method][tam] like this:
+```sql
+CREATE TABLE orders(id bigint, item text, price NUMERIC(10, 2)) USING duckdb;
+CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
+```
+
+[tam]: https://www.postgresql.org/docs/current/tableam.html
+
+
+Any tables that you already had in MotherDuck are automatically available in Postgres. Since MotherDuck allows creating multiple databases these databases are. The tables stored in the `my_db` are stored together in schemas together with your Postgres tables. Tables in other databases can be accessed using dedicated schemas which are prefixed with `ddb$`.
+
+```sql
+INSERT INTO main.my_table VALUES (1, 'abc'); -- inserts into my_db.main.my_table
+SELECT COUNT(*) FROM ddb$my_shared_db.aggregated_order_data; -- reads from my_shared_db.main.aggregated_order_data
+SELECT COUNT(*) FROM ddb$sample_data$hn.hacker_news; -- reads from sample_data.hn.hacker_news
+```
+
+[md]: https://motherduck.com/
+[md-access-token]: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-an-access-token
+
 ## Roadmap
 
 Please see the [project roadmap][roadmap] for upcoming planned tasks and features.
-
-### Connect with MotherDuck
-
-pg_duckdb integration with MotherDuck will enable dual execution with Differential Storage.
-
-* Zero-copy snapshots and forks
-* Time travel
-* Data tiering
-* Improved concurrency and cacheability
 
 ## Contributing
 

--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/* Values for the backslash_quote GUC */
+typedef enum {
+	MOTHERDUCK_OFF,
+	MOTHERDUCK_ON,
+	MOTHERDUCK_AUTO,
+} MotherDuckEnabled;
+
 // pgduckdb.c
 extern bool duckdb_execution;
 extern int duckdb_maximum_threads;
@@ -8,7 +15,8 @@ extern char *duckdb_disabled_filesystems;
 extern bool duckdb_enable_external_access;
 extern bool duckdb_allow_unsigned_extensions;
 extern int duckdb_max_threads_per_query;
-extern char *duckdb_background_worker_db;
+extern char *duckdb_motherduck_postgres_database;
+extern int duckdb_motherduck_enabled;
 extern char *duckdb_motherduck_token;
 extern char *duckdb_motherduck_postgres_user;
 extern "C" void _PG_init(void);

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -7,6 +7,7 @@ extern "C" {
 #include "nodes/pg_list.h"
 #include "optimizer/optimizer.h"
 }
+#include "pgduckdb/pgduckdb_utils.hpp"
 
 namespace pgduckdb {
 

--- a/include/pgduckdb/pgduckdb_metadata_cache.hpp
+++ b/include/pgduckdb/pgduckdb_metadata_cache.hpp
@@ -10,6 +10,8 @@ uint64 CacheVersion();
 Oid ExtensionOid();
 Oid DuckdbTableAmOid();
 bool IsMotherDuckEnabled();
+bool IsMotherDuckEnabledAnywhere();
+bool IsMotherDuckPostgresDatabase();
 Oid MotherDuckPostgresUser();
 Oid IsDuckdbTable(Form_pg_class relation);
 Oid IsDuckdbTable(Relation relation);

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -55,12 +55,12 @@ static uint64 initial_cache_version = 0;
 extern "C" {
 PGDLLEXPORT void
 pgduckdb_background_worker_main(Datum main_arg) {
-	elog(LOG, "started pgduckdb background worker");
+	elog(LOG, "started pg_duckdb background worker");
 	// Set up a signal handler for SIGTERM
 	pqsignal(SIGTERM, die);
 	BackgroundWorkerUnblockSignals();
 
-	BackgroundWorkerInitializeConnection(duckdb_background_worker_db, NULL, 0);
+	BackgroundWorkerInitializeConnection(duckdb_motherduck_postgres_database, NULL, 0);
 
 	pgduckdb::doing_motherduck_sync = true;
 	is_background_worker = true;
@@ -119,7 +119,7 @@ force_motherduck_sync(PG_FUNCTION_ARGS) {
 
 void
 DuckdbInitBackgroundWorker(void) {
-	if (!pgduckdb::IsMotherDuckEnabled()) {
+	if (!pgduckdb::IsMotherDuckEnabledAnywhere()) {
 		return;
 	}
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -59,7 +59,19 @@ DuckDBManager::Initialize() {
 	 * its default database will be set to the default MotherDuck database.
 	 */
 	if (pgduckdb::IsMotherDuckEnabled()) {
-		connection_string = psprintf("md:?motherduck_token=%s", duckdb_motherduck_token);
+		/*
+		 * Disable web login for MotherDuck. Having support for web login could
+		 * be nice for demos, but because the received token is not shared
+		 * between backends you will get browser windows popped up. Sharing the
+		 * token across backends could be made to work but the implementing it
+		 * is not trivial, so for now we simply disable the web login.
+		 */
+		setenv("motherduck_disable_web_login", "1", 1);
+		if (duckdb_motherduck_token[0] == '\0') {
+			connection_string = "md:";
+		} else {
+			connection_string = psprintf("md:?motherduck_token=%s", duckdb_motherduck_token);
+		}
 	}
 
 	database = duckdb::make_uniq<duckdb::DuckDB>(connection_string, &config).release();


### PR DESCRIPTION
1. Allow taking the `motherduck_token` from an environment variable by setting `duckdb.motherduck_enabled = true`.
2. Include instructions for MotherDuck in README
3. Rename `duckdb.background_worker_db` to `duckdb.motherduck_postgres_datase` and check this GUC before connecting to MotherDuck.
4. Allow dropping orphaned MotherDuck shell tables if MotherDuck is not enabled.
