### PR TITLE
Capture exceptions thrown in Catalog Synchronization BGW

### DIFF
--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -74,7 +74,7 @@ DuckDBManager::Initialize() {
 		}
 	}
 
-	database = duckdb::make_uniq<duckdb::DuckDB>(connection_string, &config).release();
+	database = new duckdb::DuckDB(connection_string, &config);
 
 	auto &dbconfig = duckdb::DBConfig::GetConfig(*database->instance);
 	dbconfig.storage_extensions["pgduckdb"] = duckdb::make_uniq<duckdb::PostgresStorageExtension>();


### PR DESCRIPTION
If an error was to happen during the BGW initialization (or runtime) it would badly crash Postgres with things like:

```
libc++abi: terminating due to uncaught exception of type duckdb::InvalidInputException: ...
```

This PR makes sure we catch exception and throw it the "PG way".