### PR TITLE
Convert BPCHAR type to DuckDB VARCHAR without padding

### DIFF
--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -21,7 +21,7 @@ duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute
 Oid GetPostgresDuckDBType(duckdb::LogicalType type);
 int32 GetPostgresDuckDBTypemod(duckdb::LogicalType type);
 duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type);
-void ConvertPostgresToDuckValue(Datum value, duckdb::Vector &result, idx_t offset);
+void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, idx_t offset);
 bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);
 void InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanGlobalState> scan_global_state,
                           duckdb::shared_ptr<PostgresScanLocalState> scan_local_state, HeapTupleData *tuple);

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -671,6 +671,7 @@ Append(duckdb::Vector &result, T value, idx_t offset) {
 static void
 AppendString(duckdb::Vector &result, Datum value, idx_t offset, bool is_bpchar) {
 	const char *text = VARDATA_ANY(value);
+	/* Remove the padding of a BPCHAR type. DuckDB expects unpadded value. */
 	auto len = is_bpchar ? bpchartruelen(VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value)) : VARSIZE_ANY_EXHDR(value);
 	duckdb::string_t str(text, len);
 

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -57,17 +57,17 @@ SELECT * FROM bool_tbl;
 CREATE TABLE bpchar_tbl(a CHAR(25) NOT NULL);
 INSERT INTO bpchar_tbl SELECT CAST(a AS VARCHAR) from (VALUES (''), ('test'), ('this is a long string')) t(a);
 SELECT * FROM bpchar_tbl;
-             a             
----------------------------
-                          
- test                     
- this is a long string    
+           a           
+-----------------------
+ 
+ test
+ this is a long string
 (3 rows)
 
 SELECT * FROM bpchar_tbl WHERE a = 'test';
-             a             
----------------------------
- test                     
+  a   
+------
+ test
 (1 row)
 
 --- VARCHAR


### PR DESCRIPTION
When conversion from BPCHAR to DuckDB VARCHAR type needs to be done we need to strip extra padding form postgres value.