### PR TITLE
Set a custom_user_agent value

### DIFF
--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -37,6 +37,7 @@ DuckDBManager::Initialize() {
 	elog(DEBUG2, "(PGDuckDB/DuckDBManager) Creating DuckDB instance");
 
 	duckdb::DBConfig config;
+	config.SetOptionByName("custom_user_agent", "pg_duckdb");
 	config.SetOptionByName("extension_directory", CreateOrGetDirectoryPath("duckdb_extensions"));
 	// Transforms VIEWs into their view definition
 	config.replacement_scans.emplace_back(pgduckdb::PostgresReplacementScan);


### PR DESCRIPTION
This is a DuckDB setting that controls the result of `PRAGMA user_agent`. It's additionally useful for MotherDuck because it allows us to understand that certain usage in our logs is coming from pg_duckdb.
