### PR TITLE
Make duckdb.install_extension('httpfs') not break the installation

### DIFF
--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -186,9 +186,23 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 	auto duckdb_extensions = ReadDuckdbExtensions();
 
 	for (auto &extension : duckdb_extensions) {
-		if (extension.enabled) {
-			DuckDBQueryOrThrow(context, "LOAD " + extension.name);
+		if (!extension.enabled) {
+			continue;
 		}
+
+		/*
+		 * Skip the httpfs extension. It conflicts with our cached_httpfs
+		 * extension which is loaded by default, but people might still try to
+		 * install it manually. We could also throw an error by doing so, but
+		 * it seems nicer to just skip it, because it is clear what they meant
+		 * to do and this way we don't need to educate people about the
+		 * existence of our cached_httpfs extension (which might be removed in
+		 * the near future anyway).
+		 */
+		if (extension.name == "httpfs") {
+			continue;
+		}
+		DuckDBQueryOrThrow(context, "LOAD " + extension.name);
 	}
 }
 


### PR DESCRIPTION
Running the following (and then reconnecting because of #278)

```sql
SELECT duckdb.install_extension('httpfs');
```

Would completely break DuckDB functionality. You would always get the following error:

```
ERROR:  XX000: (PGDuckDB/DuckDBQuery) Invalid Input Error: Initialization function "httpfs_init" from file "/home/jelte/.pgenv/pgsql/data/duckdb_extensions/v1.1.1/linux_amd64/httpfs.duckdb_extension" threw an exception: "Attempted to register an already registered secret type: 's3'"
```

This fixes that by essentially making `duckdb.install_extension('httpfs')` a no-op.
