### PR TITLE
Rename duckdb.execution to duckdb.force_execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Next, load the pg_duckdb extension:
 CREATE EXTENSION pg_duckdb;
 ```
 
-**IMPORTANT:** Once loaded you can use DuckDB execution by running `SET duckdb.execution TO true`. This is _opt-in_ to avoid breaking existing queries. To avoid doing that for every session, you can configure it for a certain user by doing `ALTER USER my_analytics_user SET duckdb.execution TO true`.
+**IMPORTANT:** DuckDB execution is usually enabled automatically when needed. It's enabled whenever you use DuckDB functions (such as `read_csv`), when you query DuckDB tables, and when running `COPY table TO 's3://...'`. However, if you want queries which only touch Postgres tables to use DuckDB execution you need to run `SET duckdb.force_execution TO true`'. This feature is _opt-in_ to avoid breaking existing queries. To avoid doing that for every session, you can configure it for a certain user by doing `ALTER USER my_analytics_user SET duckdb.force_execution TO true`.
 
 ## Features
 
-- `SELECT` queries executed by the DuckDB engine can directly read Postgres tables.
+- `SELECT` queries executed by the DuckDB engine can directly read Postgres tables. (If you only query Postgres tables you need to run `SET duckdb.force_execution TO true`, see the **IMPORTANT** section above for details)
 	- Able to read [data types](https://www.postgresql.org/docs/current/datatype.html) that exist in both Postgres and DuckDB. The following data types are supported: numeric, character, binary, date/time, boolean, uuid, json, and arrays.
 	- If DuckDB cannot support the query for any reason, execution falls back to Postgres.
 - Read parquet and CSV files from object storage (AWS S3, Cloudflare R2, or Google GCS).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ CREATE EXTENSION pg_duckdb;
 - Create indexes on Postgres tables to accelerate your DuckDB queries
 - Install DuckDB extensions using `SELECT duckdb.install_extension('extension_name');`
 - Toggle DuckDB execution on/off with a setting:
-	- `SET duckdb.execution = true|false`
+	- `SET duckdb.force_execution = true|false`
 - Cache remote object locally for faster execution using `SELECT duckdb.cache('path', 'type');` where
 	- 'path' is HTTPFS/S3/GCS/R2 remote object
 	- 'type' specify remote object type: 'parquet' or 'csv'

--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -8,7 +8,7 @@ typedef enum {
 } MotherDuckEnabled;
 
 // pgduckdb.c
-extern bool duckdb_execution;
+extern bool duckdb_force_execution;
 extern int duckdb_maximum_threads;
 extern char *duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -272,10 +272,4 @@ BEGIN
 END
 $$;
 
-DO $$
-BEGIN
-    RAISE WARNING 'To actually execute queries using DuckDB you need to run "SET duckdb.execution TO true;"';
-END
-$$;
-
 RESET search_path;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -12,7 +12,7 @@ extern "C" {
 
 static void DuckdbInitGUC(void);
 
-bool duckdb_execution = false;
+bool duckdb_force_execution = false;
 int duckdb_max_threads_per_query = 1;
 int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
@@ -113,7 +113,7 @@ static const struct config_enum_entry motherduck_enabled_options[] = {
 
 static void
 DuckdbInitGUC(void) {
-	DefineCustomVariable("duckdb.execution", "Is DuckDB query execution enabled.", &duckdb_execution);
+	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution);
 
 	DefineCustomVariable("duckdb.enable_external_access", "Allow the DuckDB to access external state.",
 	                     &duckdb_enable_external_access, PGC_SUSET);

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -157,12 +157,12 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
 	 * guidance on SECURITY DEFINER functions in postgres for details:
 	 * https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY
 	 *
-	 * We also temporarily force duckdb.execution to false, because
+	 * We also temporarily force duckdb.force_execution to false, because
 	 * pg_catalog.pg_event_trigger_ddl_commands does not exist in DuckDB.
 	 */
 	auto save_nestlevel = NewGUCNestLevel();
 	SetConfigOption("search_path", "", PGC_USERSET, PGC_S_SESSION);
-	SetConfigOption("duckdb.execution", "false", PGC_USERSET, PGC_S_SESSION);
+	SetConfigOption("duckdb.force_execution", "false", PGC_USERSET, PGC_S_SESSION);
 
 	int ret = SPI_exec(R"(
 		SELECT DISTINCT objid AS relid, pg_class.relpersistence = 't' AS is_temporary
@@ -340,12 +340,12 @@ duckdb_drop_trigger(PG_FUNCTION_ARGS) {
 	 * functions in postgres for details:
 	 * https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY
 	 *
-	 * We also temporarily force duckdb.execution to false, because
+	 * We also temporarily force duckdb.force_execution to false, because
 	 * pg_catalog.pg_event_trigger_dropped_objects does not exist in DuckDB.
 	 */
 	auto save_nestlevel = NewGUCNestLevel();
 	SetConfigOption("search_path", "", PGC_USERSET, PGC_S_SESSION);
-	SetConfigOption("duckdb.execution", "false", PGC_USERSET, PGC_S_SESSION);
+	SetConfigOption("duckdb.force_execution", "false", PGC_USERSET, PGC_S_SESSION);
 
 	if (!pgduckdb::doing_motherduck_sync) {
 		int ret = SPI_exec(R"(
@@ -516,9 +516,13 @@ duckdb_alter_table_trigger(PG_FUNCTION_ARGS) {
 	 * search_path confusion attacks. See guidance on SECURITY DEFINER
 	 * functions in postgres for details:
 	 * https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY
+	 *
+	 * We also temporarily force duckdb.force_execution to false, because
+	 * pg_catalog.pg_event_trigger_dropped_objects does not exist in DuckDB.
 	 */
 	auto save_nestlevel = NewGUCNestLevel();
 	SetConfigOption("search_path", "", PGC_USERSET, PGC_S_SESSION);
+	SetConfigOption("duckdb.force_execution", "false", PGC_USERSET, PGC_S_SESSION);
 	Oid saved_userid;
 	int sec_context;
 	GetUserIdAndSecContext(&saved_userid, &sec_context);

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -147,7 +147,7 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 
 	/*
 	 * We don't support multi-statement transactions yet, so don't try to
-	 * execute queries in them even if duckdb.execution is enabled.
+	 * execute queries in them even if duckdb.force_execution is enabled.
 	 */
 	if (IsInTransactionBlock(true)) {
 		if (throw_error) {

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -171,7 +171,7 @@ DuckdbPlannerHook(Query *parse, const char *query_string, int cursor_options, Pa
 			IsAllowedStatement(parse, true);
 
 			return DuckdbPlanNode(parse, cursor_options, true);
-		} else if (duckdb_execution && IsAllowedStatement(parse)) {
+		} else if (duckdb_force_execution && IsAllowedStatement(parse)) {
 			PlannedStmt *duckdbPlan = DuckdbPlanNode(parse, cursor_options, false);
 			if (duckdbPlan) {
 				return duckdbPlan;

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -592,7 +592,7 @@ class Postgres:
 
             # And finally, enable pg_duckdb
             pgconf.write("shared_preload_libraries = pg_duckdb\n")
-            pgconf.write("duckdb.execution = 'true'\n")
+            pgconf.write("duckdb.force_execution = 'true'\n")
 
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -45,7 +45,6 @@ DROP TABLE empty;
 -- Check that DROP / CREATE extension works
 DROP EXTENSION pg_duckdb;
 CREATE EXTENSION pg_duckdb;
-WARNING:  To actually execute queries using DuckDB you need to run "SET duckdb.execution TO true;"
 -- Verify that all pages that are fetched are closed before execution ends.
 -- Table with smaller number of tuples (if nothing is matched) will terminate execution
 -- before second table is read to the end.

--- a/test/regression/expected/concurrency.out
+++ b/test/regression/expected/concurrency.out
@@ -1,5 +1,5 @@
 SET duckdb.max_threads_per_query to 4;
-SET duckdb.execution = true;
+SET duckdb.force_execution = true;
 CREATE TABLE t(a INT, b VARCHAR);
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;

--- a/test/regression/expected/duckdb_only_functions.out
+++ b/test/regression/expected/duckdb_only_functions.out
@@ -1,6 +1,6 @@
--- We should be able to use duckdb-only functions even when duckdb.execution is
--- turned off
-SET duckdb.execution = false;
+-- We should be able to use duckdb-only functions even when
+-- duckdb.force_execution is turned off
+SET duckdb.force_execution = false;
 \getenv pwd PWD
 select * from read_parquet(:'pwd' || '/data/unsigned_types.parquet') as (usmallint int);
  usmallint 

--- a/test/regression/expected/duckdb_recycle.out
+++ b/test/regression/expected/duckdb_recycle.out
@@ -1,4 +1,4 @@
-SET duckdb.execution = true;
+SET duckdb.force_execution = true;
 CREATE TABLE ta(a INT);
 EXPLAIN SELECT count(*) FROM ta;
                          QUERY PLAN                         

--- a/test/regression/expected/secrets.out
+++ b/test/regression/expected/secrets.out
@@ -1,4 +1,4 @@
-SET duckdb.execution TO false;
+SET duckdb.force_execution TO false;
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 NOTICE:  result: name	
 VARCHAR	
@@ -78,4 +78,4 @@ pgduckb_secret_0
  
 (1 row)
 
-SET duckdb.execution TO true;
+SET duckdb.force_execution TO true;

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -1,5 +1,5 @@
--- All the queries below should work even if duckdb.execution is turned off.
-SET duckdb.execution = false;
+-- All the queries below should work even if duckdb.force_execution is turned off.
+SET duckdb.force_execution = false;
 CREATE TEMP TABLE t(
     bool BOOLEAN,
     i2 SMALLINT,
@@ -89,9 +89,9 @@ BEGIN;
 
     DROP TABLE t4;
 END;
--- Even if duckdb.execution is turned on
+-- Even if duckdb.force_execution is turned on
 BEGIN;
-    SET LOCAL duckdb.execution = true;
+    SET LOCAL duckdb.force_execution = true;
     CREATE TEMP TABLE t4(a int) USING heap;
     INSERT INTO t4 VALUES (1);
     SELECT * FROM t4;

--- a/test/regression/expected/transaction_errors.out
+++ b/test/regression/expected/transaction_errors.out
@@ -1,7 +1,7 @@
 CREATE TABLE foo AS SELECT 'bar' AS t;
-BEGIN; SET duckdb.execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
+BEGIN; SET duckdb.force_execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
 ERROR:  invalid input syntax for type integer: "bar"
-SET duckdb.execution = true;
+SET duckdb.force_execution = true;
 SELECT 1 FROM foo;
  ?column? 
 ----------

--- a/test/regression/regression.conf
+++ b/test/regression/regression.conf
@@ -1,5 +1,5 @@
 # Configuration
 
 shared_preload_libraries = 'pg_duckdb'
-duckdb.execution = true
+duckdb.force_execution = true
 log_temp_files = -1

--- a/test/regression/sql/concurrency.sql
+++ b/test/regression/sql/concurrency.sql
@@ -1,5 +1,5 @@
 SET duckdb.max_threads_per_query to 4;
-SET duckdb.execution = true;
+SET duckdb.force_execution = true;
 CREATE TABLE t(a INT, b VARCHAR);
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;

--- a/test/regression/sql/duckdb_only_functions.sql
+++ b/test/regression/sql/duckdb_only_functions.sql
@@ -1,6 +1,6 @@
--- We should be able to use duckdb-only functions even when duckdb.execution is
--- turned off
-SET duckdb.execution = false;
+-- We should be able to use duckdb-only functions even when
+-- duckdb.force_execution is turned off
+SET duckdb.force_execution = false;
 
 \getenv pwd PWD
 

--- a/test/regression/sql/duckdb_recycle.sql
+++ b/test/regression/sql/duckdb_recycle.sql
@@ -1,4 +1,4 @@
-SET duckdb.execution = true;
+SET duckdb.force_execution = true;
 CREATE TABLE ta(a INT);
 EXPLAIN SELECT count(*) FROM ta;
 SELECT duckdb.recycle_ddb();

--- a/test/regression/sql/secrets.sql
+++ b/test/regression/sql/secrets.sql
@@ -1,5 +1,5 @@
 
-SET duckdb.execution TO false;
+SET duckdb.force_execution TO false;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
@@ -28,4 +28,4 @@ SELECT last_value FROM duckdb.secrets_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
 
-SET duckdb.execution TO true;
+SET duckdb.force_execution TO true;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -1,5 +1,5 @@
--- All the queries below should work even if duckdb.execution is turned off.
-SET duckdb.execution = false;
+-- All the queries below should work even if duckdb.force_execution is turned off.
+SET duckdb.force_execution = false;
 CREATE TEMP TABLE t(
     bool BOOLEAN,
     i2 SMALLINT,
@@ -62,9 +62,9 @@ BEGIN;
     DROP TABLE t4;
 END;
 
--- Even if duckdb.execution is turned on
+-- Even if duckdb.force_execution is turned on
 BEGIN;
-    SET LOCAL duckdb.execution = true;
+    SET LOCAL duckdb.force_execution = true;
     CREATE TEMP TABLE t4(a int) USING heap;
     INSERT INTO t4 VALUES (1);
     SELECT * FROM t4;

--- a/test/regression/sql/transaction_errors.sql
+++ b/test/regression/sql/transaction_errors.sql
@@ -1,4 +1,4 @@
 CREATE TABLE foo AS SELECT 'bar' AS t;
-BEGIN; SET duckdb.execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
-SET duckdb.execution = true;
+BEGIN; SET duckdb.force_execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
+SET duckdb.force_execution = true;
 SELECT 1 FROM foo;


### PR DESCRIPTION
Many people won't need to turn this setting on anymore now that we automatically upgrade to DuckDB execution in many cases. So this changes the name of `duckdb.execution` to `duckdb.force_execution` to make that obvious. It also removes the WARNING during installation and updates the relevant section of the README.

Fixes #312 