### PR TITLE
Synchronise extensions before reconnect

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -41,14 +41,35 @@ private:
 	void Initialize();
 
 	void InitializeDatabase();
-	bool CheckSecretsSeq();
+
 	void LoadSecrets(duckdb::ClientContext &);
 	void DropSecrets(duckdb::ClientContext &);
 	void LoadExtensions(duckdb::ClientContext &);
 	void LoadFunctions(duckdb::ClientContext &);
 
+	inline bool
+	IsSecretSeqLessThan(int64 seq) const {
+		return secret_table_current_seq < seq;
+	}
+
+	inline bool
+	IsExtensionsSeqLessThan(int64 seq) const {
+		return extensions_table_current_seq < seq;
+	}
+
+	inline void
+	UpdateSecretSeq(int64 seq) {
+		secret_table_current_seq = seq;
+	}
+
+	inline void
+	UpdateExtensionsSeq(int64 seq) {
+		extensions_table_current_seq = seq;
+	}
+
 	int secret_table_num_rows;
-	int secret_table_current_seq;
+	int64 secret_table_current_seq;
+	int64 extensions_table_current_seq;
 	/*
 	 * FIXME: Use a unique_ptr instead of a raw pointer. For now this is not
 	 * possible though, as the MotherDuck extension causes an ABORT when the

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -197,10 +197,27 @@ $$ LANGUAGE PLpgSQL;
 CREATE TRIGGER duckdb_secret_r2_tr BEFORE INSERT OR UPDATE ON secrets
 FOR EACH ROW EXECUTE PROCEDURE duckdb_secret_r2_check();
 
+-- Extensions
+
+CREATE SEQUENCE extensions_table_seq START WITH 1 INCREMENT BY 1;
+SELECT setval('extensions_table_seq', 1);
+
 CREATE TABLE extensions (
     name TEXT NOT NULL PRIMARY KEY,
     enabled BOOL DEFAULT TRUE
 );
+
+CREATE OR REPLACE FUNCTION duckdb_update_extensions_table_seq()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    PERFORM nextval('duckdb.extensions_table_seq');
+    RETURN NEW;
+END;
+$$ LANGUAGE PLpgSQL;
+
+CREATE TRIGGER extensions_table_seq_tr AFTER INSERT OR UPDATE OR DELETE ON extensions
+EXECUTE FUNCTION duckdb_update_extensions_table_seq();
 
 -- The following might seem unnecesasry, but it's needed to know if a dropped
 -- table was a DuckDB table or not. See the comments and code in

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -168,7 +168,7 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 
 void
 DuckDBManager::DropSecrets(duckdb::ClientContext &context) {
-	for (auto secret_id = 0; secret_id < secret_table_num_rows; ++secret_id) {
+	for (auto secret_id = 0; secret_id < secret_table_num_rows; secret_id++) {
 		auto drop_secret_cmd = duckdb::StringUtil::Format("DROP SECRET pgduckb_secret_%d;", secret_id);
 		pgduckdb::DuckDBQueryOrThrow(context, drop_secret_cmd);
 	}

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -161,10 +161,9 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 		DuckDBQueryOrThrow(context, secret_key->data);
 
 		pfree(secret_key->data);
-		++secret_id;
+		secret_id++;
 		secret_table_num_rows = secret_id;
 	}
-
 }
 
 void

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -162,9 +162,9 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 
 		pfree(secret_key->data);
 		++secret_id;
+		secret_table_num_rows = secret_id;
 	}
 
-	secret_table_num_rows = secret_id;
 }
 
 void

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -171,7 +171,7 @@ void
 DuckDBManager::DropSecrets(duckdb::ClientContext &context) {
 	for (auto secret_id = 0; secret_id < secret_table_num_rows; ++secret_id) {
 		auto drop_secret_cmd = duckdb::StringUtil::Format("DROP SECRET pgduckb_secret_%d;", secret_id);
-		pgduckdb::DuckDBQueryOrThrow(drop_secret_cmd);
+		pgduckdb::DuckDBQueryOrThrow(context, drop_secret_cmd);
 	}
 
 	secret_table_num_rows = 0;

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -209,7 +209,8 @@ PG_FUNCTION_INFO_V1(pgduckdb_raw_query);
 Datum
 pgduckdb_raw_query(PG_FUNCTION_ARGS) {
 	const char *query = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	auto result = pgduckdb::DuckDBQueryOrThrow(query);
+	typedef duckdb::unique_ptr<duckdb::QueryResult> (*DuckDBQueryOrThrow)(const std::string &);
+	auto result = pgduckdb::DuckDBFunctionGuard<duckdb::unique_ptr<duckdb::QueryResult>, DuckDBQueryOrThrow>(pgduckdb::DuckDBQueryOrThrow, "pgduckdb_raw_query", query);
 	elog(NOTICE, "result: %s", result->ToString().c_str());
 	PG_RETURN_BOOL(true);
 }

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -1,0 +1,97 @@
+SET duckdb.execution TO false;
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+NOTICE:  result: extension_name	loaded	installed	
+VARCHAR	BOOLEAN	BOOLEAN	
+[ Rows: 4]
+cached_httpfs	true	true
+json	true	true
+parquet	true	true
+pgduckdb	true	false
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          1
+(1 row)
+
+-- INSERT SHOULD TRIGGER UPDATE OF EXTENSIONS
+INSERT INTO duckdb.extensions (name, enabled) VALUES ('icu', TRUE);
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          2
+(1 row)
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+NOTICE:  result: extension_name	loaded	installed	
+VARCHAR	BOOLEAN	BOOLEAN	
+[ Rows: 5]
+cached_httpfs	true	true
+icu	true	true
+json	true	true
+parquet	true	true
+pgduckdb	true	false
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+INSERT INTO duckdb.extensions (name, enabled) VALUES ('aws', TRUE);
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          3
+(1 row)
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+NOTICE:  result: extension_name	loaded	installed	
+VARCHAR	BOOLEAN	BOOLEAN	
+[ Rows: 6]
+aws	true	true
+cached_httpfs	true	true
+icu	true	true
+json	true	true
+parquet	true	true
+pgduckdb	true	false
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+-- DELETE SHOULD TRIGGER UPDATE OF EXTENSIONS
+-- But we do not unload for now (would require a restart of DuckDB)
+DELETE FROM duckdb.extensions WHERE name = 'aws';
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          4
+(1 row)
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+NOTICE:  result: extension_name	loaded	installed	
+VARCHAR	BOOLEAN	BOOLEAN	
+[ Rows: 6]
+aws	true	true
+cached_httpfs	true	true
+icu	true	true
+json	true	true
+parquet	true	true
+pgduckdb	true	false
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+SET duckdb.execution TO true;

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -1,4 +1,4 @@
-SET duckdb.execution TO false;
+SET duckdb.force_execution TO false;
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 NOTICE:  result: extension_name	loaded	installed	
 VARCHAR	BOOLEAN	BOOLEAN	
@@ -94,4 +94,3 @@ pgduckdb	true	false
  
 (1 row)
 
-SET duckdb.execution TO true;

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -1,5 +1,5 @@
 SET duckdb.execution TO false;
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 NOTICE:  result: extension_name	loaded	installed	
 VARCHAR	BOOLEAN	BOOLEAN	
 [ Rows: 4]
@@ -28,7 +28,7 @@ SELECT last_value FROM duckdb.extensions_table_seq;
           2
 (1 row)
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 NOTICE:  result: extension_name	loaded	installed	
 VARCHAR	BOOLEAN	BOOLEAN	
 [ Rows: 5]
@@ -51,7 +51,7 @@ SELECT last_value FROM duckdb.extensions_table_seq;
           3
 (1 row)
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 NOTICE:  result: extension_name	loaded	installed	
 VARCHAR	BOOLEAN	BOOLEAN	
 [ Rows: 6]
@@ -77,7 +77,7 @@ SELECT last_value FROM duckdb.extensions_table_seq;
           4
 (1 row)
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 NOTICE:  result: extension_name	loaded	installed	
 VARCHAR	BOOLEAN	BOOLEAN	
 [ Rows: 6]

--- a/test/regression/expected/secrets.out
+++ b/test/regression/expected/secrets.out
@@ -78,4 +78,3 @@ pgduckb_secret_0
  
 (1 row)
 
-SET duckdb.force_execution TO true;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -2,6 +2,7 @@ test: basic
 test: concurrency
 test: search_path
 test: execution_error
+test: extensions
 test: type_support
 test: array_type_support
 test: views

--- a/test/regression/sql/extensions.sql
+++ b/test/regression/sql/extensions.sql
@@ -1,0 +1,30 @@
+
+SET duckdb.execution TO false;
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+
+-- INSERT SHOULD TRIGGER UPDATE OF EXTENSIONS
+
+INSERT INTO duckdb.extensions (name, enabled) VALUES ('icu', TRUE);
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+
+INSERT INTO duckdb.extensions (name, enabled) VALUES ('aws', TRUE);
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+
+-- DELETE SHOULD TRIGGER UPDATE OF EXTENSIONS
+-- But we do not unload for now (would require a restart of DuckDB)
+DELETE FROM duckdb.extensions WHERE name = 'aws';
+
+SELECT last_value FROM duckdb.extensions_table_seq;
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+
+SET duckdb.execution TO true;

--- a/test/regression/sql/extensions.sql
+++ b/test/regression/sql/extensions.sql
@@ -1,7 +1,7 @@
 
 SET duckdb.execution TO false;
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
 SELECT last_value FROM duckdb.extensions_table_seq;
 
@@ -11,13 +11,13 @@ INSERT INTO duckdb.extensions (name, enabled) VALUES ('icu', TRUE);
 
 SELECT last_value FROM duckdb.extensions_table_seq;
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
 INSERT INTO duckdb.extensions (name, enabled) VALUES ('aws', TRUE);
 
 SELECT last_value FROM duckdb.extensions_table_seq;
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
 -- DELETE SHOULD TRIGGER UPDATE OF EXTENSIONS
 -- But we do not unload for now (would require a restart of DuckDB)
@@ -25,6 +25,6 @@ DELETE FROM duckdb.extensions WHERE name = 'aws';
 
 SELECT last_value FROM duckdb.extensions_table_seq;
 
-SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded $$);
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
 SET duckdb.execution TO true;

--- a/test/regression/sql/extensions.sql
+++ b/test/regression/sql/extensions.sql
@@ -1,5 +1,5 @@
 
-SET duckdb.execution TO false;
+SET duckdb.force_execution TO false;
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
@@ -26,5 +26,3 @@ DELETE FROM duckdb.extensions WHERE name = 'aws';
 SELECT last_value FROM duckdb.extensions_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
-
-SET duckdb.execution TO true;

--- a/test/regression/sql/secrets.sql
+++ b/test/regression/sql/secrets.sql
@@ -27,5 +27,3 @@ DELETE FROM duckdb.secrets WHERE key_id = 'access_key_id_1';
 SELECT last_value FROM duckdb.secrets_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT name FROM duckdb_secrets() $$);
-
-SET duckdb.force_execution TO true;


### PR DESCRIPTION
If duckdb.extensions table is inserted, updated or deleted in same connection we would not sync changes for next query. Introduce sequence that keeps track of each change so we can compare with and sync if required.

Inspired from https://github.com/duckdb/pg_duckdb/pull/253

Fixes https://github.com/duckdb/pg_duckdb/issues/278