### PR TITLE
README: Add shared_preload_libraries requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ To build and install, run:
 make install
 ```
 
-Next, load the pg_duckdb extension:
+Add `pg_duckdb` to the `shared_preload_libraries` in your `postgresql.conf` file:
+
+```ini
+shared_preload_libraries = 'pg_duckdb'
+```
+
+Next, create the `pg_duckdb` extension:
 
 ```sql
 CREATE EXTENSION pg_duckdb;


### PR DESCRIPTION
We were missing this in the installation steps.

Fixes #318
Related #287
Related #274
