### PR TITLE
Lookup is_null correctly in case of pushed down filters

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1110,12 +1110,11 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanG
 	/* Write tuple columns in output vector. */
 	for (idx_t idx = 0; valid_tuple && idx < scan_global_state->m_output_columns_ids.size(); idx++) {
 		auto &result = output.data[idx];
-		if (nulls[idx]) {
+		idx_t output_column_idx = scan_global_state->m_read_columns_ids[scan_global_state->m_output_columns_ids[idx]];
+		if (nulls[output_column_idx]) {
 			auto &array_mask = duckdb::FlatVector::Validity(result);
 			array_mask.SetInvalid(scan_local_state->m_output_vector_size);
 		} else {
-			idx_t output_column_idx =
-			    scan_global_state->m_read_columns_ids[scan_global_state->m_output_columns_ids[idx]];
 			auto attr = scan_global_state->m_tuple_desc->attrs[scan_global_state->m_output_columns_ids[idx]];
 			if (attr.attlen == -1) {
 				bool should_free = false;

--- a/test/regression/expected/correct_null_conversions.out
+++ b/test/regression/expected/correct_null_conversions.out
@@ -1,0 +1,9 @@
+create table t(a int, b numeric(8, 3));
+insert into t values (5, NULL);
+select b from t where a > 3;
+ b 
+---
+  
+(1 row)
+
+drop table t;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -1,5 +1,6 @@
 test: basic
 test: concurrency
+test: correct_null_conversions
 test: search_path
 test: execution_error
 test: type_support

--- a/test/regression/sql/correct_null_conversions.sql
+++ b/test/regression/sql/correct_null_conversions.sql
@@ -1,0 +1,4 @@
+create table t(a int, b numeric(8, 3));
+insert into t values (5, NULL);
+select b from t where a > 3;
+drop table t;


### PR DESCRIPTION
While running TPCDS queries a few of them crashed Postgres when using `duckdb.force_execution = true`. It turns out that happened because it would look at the NULL value for the wrong field. This fixes that as well as including a minimal reproducing test of the issue. It took me quite a while to figure out what was going on because the lookup code is pretty complex. I'll open another issue to refactor/comment it a bit because I have some ideas on how to improve it, but I'll postpone doing that until after 0.1.0
