### PR TITLE
Revert "Allocate buffer once per local state (#324)"

### DIFF
--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -33,33 +33,12 @@ public:
 
 class PostgresScanLocalState {
 public:
-	PostgresScanLocalState(const PostgresScanGlobalState *psgs) : m_output_vector_size(0), m_exhausted_scan(false) {
-		if (psgs->m_count_tuples_only) {
-			values = nullptr;
-			nulls = nullptr;
-		} else {
-			/* FIXME: all calls to duckdb_malloc/duckdb_free should be changed in future */
-			const auto s = psgs->m_output_columns_ids.size();
-			values = (Datum *)duckdb_malloc(sizeof(Datum) * s);
-			nulls = (bool *)duckdb_malloc(sizeof(bool) * s);
-		}
+	PostgresScanLocalState() : m_output_vector_size(0), m_exhausted_scan(false) {
 	}
-
 	~PostgresScanLocalState() {
-		if (values) {
-			duckdb_free(values);
-			values = nullptr;
-		}
-		if (nulls) {
-			duckdb_free(nulls);
-			nulls = nullptr;
-		}
 	}
-
 	int m_output_vector_size;
 	bool m_exhausted_scan;
-	Datum *values;
-	bool *nulls;
 };
 
 duckdb::unique_ptr<duckdb::TableRef> PostgresReplacementScan(duckdb::ClientContext &context,

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1079,10 +1079,11 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanG
 		return;
 	}
 
-	bool valid_tuple = true;
+	/* FIXME: all calls to duckdb_malloc/duckdb_free should be changed in future */
+	Datum *values = (Datum *)duckdb_malloc(sizeof(Datum) * scan_global_state->m_read_columns_ids.size());
+	bool *nulls = (bool *)duckdb_malloc(sizeof(bool) * scan_global_state->m_read_columns_ids.size());
 
-	auto values = scan_local_state->values;
-	auto nulls = scan_local_state->nulls;
+	bool valid_tuple = true;
 
 	/* First we are fetching all required columns ordered by column id
 	 * and than we need to write this tuple into output vector. Output column id list
@@ -1135,6 +1136,9 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanG
 		scan_local_state->m_output_vector_size++;
 		scan_global_state->m_total_row_count++;
 	}
+
+	duckdb_free(values);
+	duckdb_free(nulls);
 }
 
 } // namespace pgduckdb

--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -28,8 +28,8 @@ PostgresSeqScanGlobalState::~PostgresSeqScanGlobalState() {
 
 PostgresSeqScanLocalState::PostgresSeqScanLocalState(Relation rel,
                                                      duckdb::shared_ptr<HeapReaderGlobalState> heap_reder_global_state,
-                                                     duckdb::shared_ptr<PostgresScanGlobalState> global_state) {
-	m_local_state = duckdb::make_shared_ptr<PostgresScanLocalState>(global_state.get());
+                                                     duckdb::shared_ptr<PostgresScanGlobalState> global_state)
+    : m_local_state(duckdb::make_shared_ptr<PostgresScanLocalState>()) {
 	m_heap_table_reader = duckdb::make_uniq<HeapReader>(rel, heap_reder_global_state, global_state, m_local_state);
 }
 


### PR DESCRIPTION
PR #324 seemed to cause some flaky crash, reverting while we investigate.
This reverts commit 511c6187cc6e0f15c479ced15fd1b28c7e764e58.