### PR TITLE
Custom vector allocator

### DIFF
--- a/include/pgduckdb/utility/allocator.hpp
+++ b/include/pgduckdb/utility/allocator.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace pgduckdb {
+
+template <class T>
+struct DuckDBMallocator {
+	typedef T value_type;
+
+	DuckDBMallocator() = default;
+
+    template<class U>
+    constexpr DuckDBMallocator(const DuckDBMallocator <U>&) noexcept {}
+
+	[[nodiscard]] T *
+	allocate(std::size_t n) {
+		if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) {
+			throw std::bad_array_new_length();
+		}
+
+		auto p = static_cast<T *>(duckdb_malloc(n * sizeof(T)));
+		if (p == nullptr) {
+			throw std::bad_alloc();
+		}
+
+		return p;
+	}
+
+	void
+	deallocate(T *p, std::size_t n) noexcept {
+		duckdb_free(p);
+	}
+};
+
+template<class T, class U>
+bool operator==(const DuckDBMallocator <T>&, const DuckDBMallocator <U>&) { return true; }
+
+template<class T, class U>
+bool operator!=(const DuckDBMallocator <T>&, const DuckDBMallocator <U>&) { return false; }
+
+} // namespace pgduckdb

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -52,7 +52,6 @@ PostgresScanGlobalState::InitGlobalState(duckdb::TableFunctionInitInput &input) 
 	for (auto const &[attr_id, column_idx] : ordered_input_columns) {
 		m_input_columns.emplace_back(attr_id, column_idx);
 
-		duckdb::TableFilter *column_filter = nullptr;
 		if (!table_filters) {
 			continue;
 		}


### PR DESCRIPTION
Introduces a custom DuckDB allocator to avoid using `duckdb_malloc` and `duckdb_free` which might lead to memory leaks.