### PR TITLE
Rename duckdb.max_threads_per_query to duckdb.max_threads_per_postgres_scan

### DIFF
--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -14,7 +14,7 @@ extern char *duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;
 extern bool duckdb_enable_external_access;
 extern bool duckdb_allow_unsigned_extensions;
-extern int duckdb_max_threads_per_query;
+extern int duckdb_max_threads_per_postgres_scan;
 extern char *duckdb_motherduck_postgres_database;
 extern int duckdb_motherduck_enabled;
 extern char *duckdb_motherduck_token;

--- a/include/pgduckdb/scan/postgres_seq_scan.hpp
+++ b/include/pgduckdb/scan/postgres_seq_scan.hpp
@@ -25,7 +25,7 @@ struct PostgresSeqScanGlobalState : public duckdb::GlobalTableFunctionState {
 	~PostgresSeqScanGlobalState();
 	idx_t
 	MaxThreads() const override {
-		return duckdb_max_threads_per_query;
+		return duckdb_max_threads_per_postgres_scan;
 	}
 
 public:

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -13,7 +13,7 @@ extern "C" {
 static void DuckdbInitGUC(void);
 
 bool duckdb_force_execution = false;
-int duckdb_max_threads_per_query = 1;
+int duckdb_max_threads_per_postgres_scan = 1;
 int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
 char *duckdb_motherduck_postgres_database = strdup("postgres");
@@ -138,9 +138,9 @@ DuckdbInitGUC(void) {
 	                     "Maximum number of DuckDB threads per Postgres backend, alias for duckdb.threads",
 	                     &duckdb_maximum_threads, -1, 1024, PGC_SUSET);
 
-	DefineCustomVariable("duckdb.max_threads_per_query",
+	DefineCustomVariable("duckdb.max_threads_per_postgres_scan",
 	                     "Maximum number of DuckDB threads used for a single Postgres scan",
-	                     &duckdb_max_threads_per_query, 1, 64);
+	                     &duckdb_max_threads_per_postgres_scan, 1, 64);
 
 	DefineCustomVariable("duckdb.motherduck_enabled",
 	                     "If motherduck support should enabled. 'auto' means enabled if motherduck_token is set",

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -15,7 +15,7 @@ SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
  9 |   100
 (4 rows)
 
-SET duckdb.max_threads_per_query to 4;
+SET duckdb.max_threads_per_postgres_scan to 4;
 SELECT COUNT(*) FROM t;
  count 
 -------
@@ -38,7 +38,7 @@ SELECT COUNT(*) FROM empty;
      0
 (1 row)
 
-SET duckdb.max_threads_per_query TO default;
+SET duckdb.max_threads_per_postgres_scan TO default;
 SET client_min_messages TO default;
 DROP TABLE t;
 DROP TABLE empty;

--- a/test/regression/expected/concurrency.out
+++ b/test/regression/expected/concurrency.out
@@ -1,4 +1,4 @@
-SET duckdb.max_threads_per_query to 4;
+SET duckdb.max_threads_per_postgres_scan to 4;
 SET duckdb.force_execution = true;
 CREATE TABLE t(a INT, b VARCHAR);
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;

--- a/test/regression/sql/basic.sql
+++ b/test/regression/sql/basic.sql
@@ -5,7 +5,7 @@ INSERT INTO t SELECT g % 10 from generate_series(1,1000) g;
 SELECT COUNT(*) FROM t;
 SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
 
-SET duckdb.max_threads_per_query to 4;
+SET duckdb.max_threads_per_postgres_scan to 4;
 
 SELECT COUNT(*) FROM t;
 SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
@@ -13,7 +13,7 @@ SELECT a, COUNT(*) FROM t WHERE a > 5 GROUP BY a ORDER BY a;
 CREATE TABLE empty(a INT);
 SELECT COUNT(*) FROM empty;
 
-SET duckdb.max_threads_per_query TO default;
+SET duckdb.max_threads_per_postgres_scan TO default;
 SET client_min_messages TO default;
 
 DROP TABLE t;

--- a/test/regression/sql/concurrency.sql
+++ b/test/regression/sql/concurrency.sql
@@ -1,4 +1,4 @@
-SET duckdb.max_threads_per_query to 4;
+SET duckdb.max_threads_per_postgres_scan to 4;
 SET duckdb.force_execution = true;
 CREATE TABLE t(a INT, b VARCHAR);
 INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;


### PR DESCRIPTION
The name didn't reflect what it was actually doing.
