### PR TITLE
Update default settings

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -67,6 +67,7 @@ private:
 		extensions_table_current_seq = seq;
 	}
 
+	bool disabled_filesystems_is_set;
 	int secret_table_num_rows;
 	int64 secret_table_current_seq;
 	int64 extensions_table_current_seq;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -20,8 +20,8 @@ char *duckdb_motherduck_postgres_database = strdup("postgres");
 char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;
-char *duckdb_maximum_memory = NULL;
-char *duckdb_disabled_filesystems = NULL;
+char *duckdb_maximum_memory = strdup("4GB");
+char *duckdb_disabled_filesystems = strdup("LocalFileSystem");
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_unsigned_extensions = false;
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -224,7 +224,7 @@ DuckDBManager::CreateConnection() {
 	    duckdb::StringUtil::Format("SET http_file_cache_dir TO '%s';", CreateOrGetDirectoryPath("duckdb_cache"));
 	context.Query(http_file_cache_set_dir_query, false);
 
-	if (!superuser() && duckdb_disabled_filesystems != NULL) {
+	if (duckdb_disabled_filesystems != NULL && !superuser()) {
 		/*
 		 * DuckDB does not allow us to disable this setting on the
 		 * database after the DuckDB connection is created for a non

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -86,11 +86,6 @@ DuckDBManager::Initialize() {
 
 	auto &context = *connection->context;
 
-	if (duckdb_disabled_filesystems != NULL) {
-		pgduckdb::DuckDBQueryOrThrow(context,
-		                             "SET disabled_filesystems='" + std::string(duckdb_disabled_filesystems) + "'");
-	}
-
 	auto &db_manager = duckdb::DatabaseManager::Get(context);
 	default_dbname = db_manager.GetDefaultDatabase(context);
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
@@ -109,6 +104,11 @@ DuckDBManager::Initialize() {
 
 	LoadFunctions(context);
 	LoadExtensions(context);
+
+	if (duckdb_disabled_filesystems != NULL) {
+		pgduckdb::DuckDBQueryOrThrow(context,
+		                             "SET disabled_filesystems='" + std::string(duckdb_disabled_filesystems) + "'");
+	}
 }
 
 void

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -129,6 +129,7 @@ DuckdbInstallExtension(Datum name_datum) {
 	auto ret = SPI_execute_with_args(R"(
 		INSERT INTO duckdb.extensions (name, enabled)
 		VALUES ($1, true)
+		ON CONFLICT (name) DO UPDATE SET enabled = true
 		)",
 	                                 lengthof(arg_types), arg_types, values, NULL, false, 0);
 	if (ret != SPI_OK_INSERT)

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -21,7 +21,14 @@ SELECT last_value FROM duckdb.extensions_table_seq;
 (1 row)
 
 -- INSERT SHOULD TRIGGER UPDATE OF EXTENSIONS
-INSERT INTO duckdb.extensions (name, enabled) VALUES ('icu', TRUE);
+SELECT duckdb.install_extension('icu');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
 ------------
@@ -44,7 +51,12 @@ pgduckdb	true	false
  
 (1 row)
 
-INSERT INTO duckdb.extensions (name, enabled) VALUES ('aws', TRUE);
+SELECT duckdb.install_extension('aws');
+ install_extension 
+-------------------
+ t
+(1 row)
+
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
 ------------

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -32,7 +32,38 @@ SELECT duckdb.install_extension('icu');
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
 ------------
-          2
+          3
+(1 row)
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+NOTICE:  result: extension_name	loaded	installed	
+VARCHAR	BOOLEAN	BOOLEAN	
+[ Rows: 5]
+cached_httpfs	true	true
+icu	true	true
+json	true	true
+parquet	true	true
+pgduckdb	true	false
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
+-- Check that we can rerun this without issues
+SELECT duckdb.install_extension('icu');
+ install_extension 
+-------------------
+ t
+(1 row)
+
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
+SELECT last_value FROM duckdb.extensions_table_seq;
+ last_value 
+------------
+          5
 (1 row)
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
@@ -60,7 +91,7 @@ SELECT duckdb.install_extension('aws');
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
 ------------
-          3
+          7
 (1 row)
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
@@ -86,7 +117,7 @@ DELETE FROM duckdb.extensions WHERE name = 'aws';
 SELECT last_value FROM duckdb.extensions_table_seq;
  last_value 
 ------------
-          4
+          8
 (1 row)
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -32,6 +32,9 @@ ERROR:  permission denied for function install_extension
 SELECT * FROM duckdb.cache('some hacky sql', 'some more hacky sql');
 ERROR:  permission denied for function cache
 SET duckdb.force_execution = true;
+-- read_csv from the local filesystem should be disallowed
+SELECT count("sepal.length") FROM read_csv('../../data/iris.csv') AS ("sepal.length" FLOAT);
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Permission Error: File system LocalFileSystem has been disabled by configuration
 -- Should fail because DuckDB execution is not allowed for this user
 SET ROLE user3;
 SELECT * FROM t;

--- a/test/regression/sql/extensions.sql
+++ b/test/regression/sql/extensions.sql
@@ -15,6 +15,16 @@ SELECT last_value FROM duckdb.extensions_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
+-- Check that we can rerun this without issues
+SELECT duckdb.install_extension('icu');
+
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
+SELECT last_value FROM duckdb.extensions_table_seq;
+
+SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
+
+
 SELECT duckdb.install_extension('aws');
 
 SELECT last_value FROM duckdb.extensions_table_seq;

--- a/test/regression/sql/extensions.sql
+++ b/test/regression/sql/extensions.sql
@@ -7,13 +7,15 @@ SELECT last_value FROM duckdb.extensions_table_seq;
 
 -- INSERT SHOULD TRIGGER UPDATE OF EXTENSIONS
 
-INSERT INTO duckdb.extensions (name, enabled) VALUES ('icu', TRUE);
+SELECT duckdb.install_extension('icu');
 
+-- Increases the sequence twice because we use ON CONFLICT DO UPDATE. So
+-- the trigger fires for both INSERT and UPDATE internally.
 SELECT last_value FROM duckdb.extensions_table_seq;
 
 SELECT * FROM duckdb.raw_query($$ SELECT extension_name, loaded, installed FROM duckdb_extensions() WHERE loaded and extension_name != 'jemalloc' $$);
 
-INSERT INTO duckdb.extensions (name, enabled) VALUES ('aws', TRUE);
+SELECT duckdb.install_extension('aws');
 
 SELECT last_value FROM duckdb.extensions_table_seq;
 

--- a/test/regression/sql/non_superuser.sql
+++ b/test/regression/sql/non_superuser.sql
@@ -24,6 +24,8 @@ SELECT * FROM duckdb.install_extension('some hacky sql');
 SELECT * FROM duckdb.cache('some hacky sql', 'some more hacky sql');
 SET duckdb.force_execution = true;
 
+-- read_csv from the local filesystem should be disallowed
+SELECT count("sepal.length") FROM read_csv('../../data/iris.csv') AS ("sepal.length" FLOAT);
 -- Should fail because DuckDB execution is not allowed for this user
 SET ROLE user3;
 SELECT * FROM t;


### PR DESCRIPTION
Fixes #217 

This changes the defaults for `duckdb.max_memory` and `duckdb.disabled_filesystems` to the agreed upon settings. While doing that I found two issues that this also fixes:
1. `duckdb.disabled_filesystems = 'LocalFilesystem'` was basically a way to make DuckDB execution unusable, due to us doing file system access when initializing the database/connection. So now we enable the setting later. Also we now don't call `INSTALL {extension}` during connection initialization anymore.
2. #316 didn't fix the loading of extensions when `duckdb.install_extension()` was called. Only for direct inserts to the `duckdb.extensions` table. That's fixed by not using the low-level `CatalogTupleInsert`, and instead switching to SPI.
3. Postgres superusers should not be restricted by `duckdb.disabled_filesystems`, they should be able to do whatever they want. So now this setting is not actually configured for superusers anymore.