### PR TITLE
Resolve security issues reported by pgspot

### DIFF
--- a/pg_duckdb.control
+++ b/pg_duckdb.control
@@ -2,3 +2,4 @@ comment = 'DuckDB Embedded in Postgres'
 default_version = '0.0.1'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false
+schema = public

--- a/sql/pg_duckdb--0.0.1.sql
+++ b/sql/pg_duckdb--0.0.1.sql
@@ -336,9 +336,9 @@ CREATE EVENT TRIGGER duckdb_alter_table_trigger ON ddl_command_end
     WHEN tag IN ('ALTER TABLE')
     EXECUTE FUNCTION duckdb_alter_table_trigger();
 
--- We explicitely don't set the search_path here in the functinon definitian.
+-- We explicitly don't set the search_path here in the function definition.
 -- Because we actually need the original search_path that was active during the
--- GRANT to reslove the RangeVar using RangeVarGetRelid. We don't need this for
+-- GRANT to resolve the RangeVar using RangeVarGetRelid. We don't need this for
 -- any of the other triggers since those don't manually resolve RangeVars, at
 -- least not yet. So for those we might as well err on the side of caution and
 -- force a safe search_path.


### PR DESCRIPTION
It's really easy to make critical security mistakes in the SQL scripts of an extension. Luckily [pgspot][1] can help finding those. There were a few false positives because the tool did not realize that the search_path `duckdb, pg_catalog, pg_temp` was also safe. I'll probably make a PR to pgspot to allow specifying additional safe schemas. For now I just followed its advice to get to 0 errors, and I think the script is still pretty readable.

I also changed the script to use `@extschema@` whenever we were previously storing a function in the `public` schema. This way we can more easily choose to make the extension relocatable in the future. Or at least allow people to store the these objects in a schema of their choice by doing `CREATE EXTENSION pg_duckdb WITH SCHEMA some_other_schema`. For now I forced the schema to `public` in the control file. Because we don't have tests for this multi schema stuff and we might not think its worth the effort in the long run.

[1]: https://github.com/timescale/pgspot

Fixes #250
