### PR TITLE
Don't get page if buffer was released

### DIFF
--- a/src/scan/heap_reader.cpp
+++ b/src/scan/heap_reader.cpp
@@ -85,7 +85,7 @@ HeapReader::ReadPageTuples(duckdb::DataChunk &output) {
 		m_read_next_page = true;
 	} else {
 		block = m_block_number;
-		if (block != InvalidBlockNumber) {
+		if(!m_read_next_page) {
 			page = BufferGetPage(m_buffer);
 		}
 	}

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -59,3 +59,16 @@ SELECT lt.a * rt.a FROM lt, rt WHERE lt.a % 2 = 0 AND rt.a = 0;
 
 DROP TABLE lt;
 DROP TABLE rt;
+---- Regression for gh#347
+CREATE TABLE t(a INT, b VARCHAR);
+INSERT INTO t SELECT g from generate_series(1,10) g;
+INSERT INTO t SELECT g % 10 from generate_series(1,1000) g;
+INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
+INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
+SELECT COUNT(b) FROM t WHERE a > 3;
+ count 
+-------
+  1920
+(1 row)
+
+DROP TABLE t;

--- a/test/regression/sql/basic.sql
+++ b/test/regression/sql/basic.sql
@@ -36,3 +36,14 @@ INSERT INTO lt SELECT g % 10 FROM generate_series(1,100000) g;
 SELECT lt.a * rt.a FROM lt, rt WHERE lt.a % 2 = 0 AND rt.a = 0;
 DROP TABLE lt;
 DROP TABLE rt;
+
+
+---- Regression for gh#347
+
+CREATE TABLE t(a INT, b VARCHAR);
+INSERT INTO t SELECT g from generate_series(1,10) g;
+INSERT INTO t SELECT g % 10 from generate_series(1,1000) g;
+INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
+INSERT INTO t SELECT g % 100, MD5(g::VARCHAR) FROM generate_series(1,1000) g;
+SELECT COUNT(b) FROM t WHERE a > 3;
+DROP TABLE t;


### PR DESCRIPTION
There is edge case when we relase buffer and also have complete output vector filled. In that case we would call `BufferGetPage` with InvalidBuffer as parameter. Current check is only to check block which can be valid. We should check do we need to read next buffer or not instead.