### PR TITLE
Heap reading optimization and fixes

### DIFF
--- a/include/pgduckdb/scan/heap_reader.hpp
+++ b/include/pgduckdb/scan/heap_reader.hpp
@@ -58,6 +58,7 @@ private:
 	OffsetNumber m_current_tuple_index;
 	int m_page_tuples_left;
 	HeapTupleData m_tuple;
+	BufferAccessStrategy m_buffer_access_strategy;
 };
 
 } // namespace pgduckdb


### PR DESCRIPTION
PR contains two commits that are supposed to be committed separately.

First commit improves performances of reading heap tuples and writing them back to duckdb output vector by converting map lookups into vector structures that are read sequentially for each row.

Second commit addresses problem of creating BufferAccessStrategy for each page read and creates single object for complete duration of scan execution.