### PR TITLE
Rework PG function guard

### DIFF
--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -41,7 +41,7 @@ PostgresTable::~PostgresTable() {
 ::Relation
 PostgresTable::OpenRelation(Oid relid) {
 	std::lock_guard<std::mutex> lock(pgduckdb::DuckdbProcessLock::GetLock());
-	return pgduckdb::PostgresFunctionGuard<::Relation>(RelationIdGetRelation, relid);
+	return PostgresFunctionGuard(::RelationIdGetRelation, relid);
 }
 
 void

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -45,7 +45,7 @@ static bool ctas_skip_data = false;
  */
 void
 DuckdbTruncateTable(Oid relation_oid) {
-	auto name = pgduckdb::PostgresFunctionGuard<char *>(pgduckdb_relation_name, relation_oid);
+	auto name = PostgresFunctionGuard(pgduckdb_relation_name, relation_oid);
 	pgduckdb::DuckDBQueryOrThrow(std::string("TRUNCATE ") + name);
 }
 

--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -119,7 +119,7 @@ ToastFetchDatum(struct varlena *attr) {
 
 	std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());
 
-	toast_rel = PostgresFunctionGuard<Relation>(try_table_open, toast_pointer.va_toastrelid, AccessShareLock);
+	toast_rel = PostgresFunctionGuard(try_table_open, toast_pointer.va_toastrelid, AccessShareLock);
 
 	if (toast_rel == NULL) {
 		throw duckdb::InternalException("(PGDuckDB/ToastFetchDatum) Error toast relation is NULL");

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -123,7 +123,7 @@ int64
 GetSeqLastValue(const char *seq_name) {
 	Oid duckdb_namespace = get_namespace_oid("duckdb", false);
 	Oid table_seq_oid = get_relname_relid(seq_name, duckdb_namespace);
-	return PostgresFunctionGuard<int64>(DirectFunctionCall1Coll, pg_sequence_last_value, InvalidOid, table_seq_oid);
+	return PostgresFunctionGuard(DirectFunctionCall1Coll, pg_sequence_last_value, InvalidOid, table_seq_oid);
 }
 
 void

--- a/src/scan/heap_reader.cpp
+++ b/src/scan/heap_reader.cpp
@@ -100,8 +100,8 @@ HeapReader::ReadPageTuples(duckdb::DataChunk &output) {
 			std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());
 			block = m_block_number;
 
-			m_buffer = PostgresFunctionGuard<Buffer>(ReadBufferExtended, m_rel, MAIN_FORKNUM, block, RBM_NORMAL,
-			                                        m_buffer_access_strategy);
+			m_buffer = PostgresFunctionGuard(ReadBufferExtended, m_rel, MAIN_FORKNUM, block, RBM_NORMAL,
+			                                 m_buffer_access_strategy);
 
 			PostgresFunctionGuard(LockBuffer, m_buffer, BUFFER_LOCK_SHARE);
 


### PR DESCRIPTION
Forked off https://github.com/duckdb/pg_duckdb/pull/254

Rework the way we wrap calls to PG functions:
* merge both flavor of `PostgresFunctionGuard` (returning void or not) into a single macro
* drop the need for explicit template instantiation
* automatically capture function name for better tracing

This PR doesn't systematically review all calls to PG functions, this will be addressed in a following one.