### PR TITLE
Improve C++ exception handling

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -89,7 +89,8 @@ __CPPFunctionGuard__(const char *func_name, FuncArgs... args) {
 	Datum func_name##_cpp(PG_FUNCTION_ARGS);                                                                           \
 	Datum func_name(PG_FUNCTION_ARGS) {                                                                                \
 		return InvokeCPPFunc(func_name##_cpp, fcinfo);                                                                 \
-	}
+	} \
+	Datum func_name##_cpp(PG_FUNCTION_ARGS)
 
 
 std::string CreateOrGetDirectoryPath(const char* directory_name);

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -58,12 +58,12 @@ __PostgresFunctionGuard__(const char *func_name, FuncArgs... args) {
 #define PostgresFunctionGuard(FUNC, ...)                                                                               \
 	pgduckdb::__PostgresFunctionGuard__<decltype(&FUNC), &FUNC>("##FUNC##", __VA_ARGS__)
 
-template <typename FuncRetT, typename FuncType, typename... FuncArgs>
-FuncRetT
-DuckDBFunctionGuard(FuncType duckdb_function, const char* function_name, FuncArgs... args) {
+template <typename Func, Func func, typename... FuncArgs>
+typename std::invoke_result<Func, FuncArgs...>::type
+__CPPFunctionGuard__(const char *func_name, FuncArgs... args) {
 	const char *error_message = nullptr;
 	try {
-		return duckdb_function(args...);
+		return func(args...);
 	} catch (duckdb::Exception &ex) {
 		duckdb::ErrorData edata(ex.what());
 		error_message = pstrdup(edata.Message().c_str());
@@ -77,14 +77,22 @@ DuckDBFunctionGuard(FuncType duckdb_function, const char* function_name, FuncArg
 		}
 	}
 
-	if (error_message) {
-		elog(ERROR, "(PGDuckDB/%s) %s", function_name, error_message);
-	}
-
-	std::abort(); // Cannot reach.
+	elog(ERROR, "(PGDuckDB/%s) %s", func_name, error_message);
 }
 
-std::string CreateOrGetDirectoryPath(std::string directory_name);
+#define InvokeCPPFunc(FUNC, ...) pgduckdb::__CPPFunctionGuard__<decltype(&FUNC), &FUNC>(__FUNCTION__, __VA_ARGS__)
+
+// Wrappers
+
+#define DECLARE_PG_FUNCTION(func_name)                                                                                 \
+	PG_FUNCTION_INFO_V1(func_name);                                                                                    \
+	Datum func_name##_cpp(PG_FUNCTION_ARGS);                                                                           \
+	Datum func_name(PG_FUNCTION_ARGS) {                                                                                \
+		return InvokeCPPFunc(func_name##_cpp, fcinfo);                                                                 \
+	}
+
+
+std::string CreateOrGetDirectoryPath(const char* directory_name);
 
 duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query);
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -538,16 +538,15 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 	return true;
 }
 
-void SyncMotherDuckCatalogsWithPg_Unsafe(bool drop_with_cascade);
+void SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade);
 
 void
 SyncMotherDuckCatalogsWithPg(bool drop_with_cascade) {
-	pgduckdb::DuckDBFunctionGuard<void>(SyncMotherDuckCatalogsWithPg_Unsafe, "SyncMotherDuckCatalogsWithPg",
-	                                    drop_with_cascade);
+	InvokeCPPFunc(SyncMotherDuckCatalogsWithPg_Cpp, drop_with_cascade);
 }
 
 void
-SyncMotherDuckCatalogsWithPg_Unsafe(bool drop_with_cascade) {
+SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 	if (!pgduckdb::IsMotherDuckEnabled()) {
 		throw std::runtime_error("MotherDuck support is not enabled");
 	}

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -131,9 +131,13 @@ extern "C" {
  */
 static std::unordered_set<Oid> temporary_duckdb_tables;
 
-PG_FUNCTION_INFO_V1(duckdb_create_table_trigger);
+DECLARE_PG_FUNCTION(duckdb_create_table_trigger);
+DECLARE_PG_FUNCTION(duckdb_drop_trigger);
+DECLARE_PG_FUNCTION(duckdb_alter_table_trigger);
+DECLARE_PG_FUNCTION(duckdb_grant_trigger);
+
 Datum
-duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
+duckdb_create_table_trigger_cpp(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -196,6 +200,7 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
 	if (isnull) {
 		elog(ERROR, "Expected relid to be returned, but found NULL");
 	}
+
 	Datum is_temporary_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
 	if (isnull) {
 		elog(ERROR, "Expected temporary boolean to be returned, but found NULL");
@@ -317,9 +322,8 @@ duckdb_create_table_trigger(PG_FUNCTION_ARGS) {
  * dropped table was a DuckDB table or not (because we cannot check its access
  * method anymore).
  */
-PG_FUNCTION_INFO_V1(duckdb_drop_trigger);
 Datum
-duckdb_drop_trigger(PG_FUNCTION_ARGS) {
+duckdb_drop_trigger_cpp(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -494,9 +498,8 @@ duckdb_drop_trigger(PG_FUNCTION_ARGS) {
 	PG_RETURN_NULL();
 }
 
-PG_FUNCTION_INFO_V1(duckdb_alter_table_trigger);
 Datum
-duckdb_alter_table_trigger(PG_FUNCTION_ARGS) {
+duckdb_alter_table_trigger_cpp(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -596,17 +599,14 @@ duckdb_alter_table_trigger(PG_FUNCTION_ARGS) {
 	}
 
 	elog(ERROR, "DuckDB does not support ALTER TABLE yet");
-
-	PG_RETURN_NULL();
 }
 
 /*
  * This event trigger is called when a GRANT statement is executed. We use it to
  * block GRANTs on DuckDB tables. We allow grants on schemas though.
  */
-PG_FUNCTION_INFO_V1(duckdb_grant_trigger);
 Datum
-duckdb_grant_trigger(PG_FUNCTION_ARGS) {
+duckdb_grant_trigger_cpp(PG_FUNCTION_ARGS) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -131,13 +131,7 @@ extern "C" {
  */
 static std::unordered_set<Oid> temporary_duckdb_tables;
 
-DECLARE_PG_FUNCTION(duckdb_create_table_trigger);
-DECLARE_PG_FUNCTION(duckdb_drop_trigger);
-DECLARE_PG_FUNCTION(duckdb_alter_table_trigger);
-DECLARE_PG_FUNCTION(duckdb_grant_trigger);
-
-Datum
-duckdb_create_table_trigger_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -322,8 +316,7 @@ duckdb_create_table_trigger_cpp(PG_FUNCTION_ARGS) {
  * dropped table was a DuckDB table or not (because we cannot check its access
  * method anymore).
  */
-Datum
-duckdb_drop_trigger_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -498,8 +491,7 @@ duckdb_drop_trigger_cpp(PG_FUNCTION_ARGS) {
 	PG_RETURN_NULL();
 }
 
-Datum
-duckdb_alter_table_trigger_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(duckdb_alter_table_trigger) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 
@@ -605,8 +597,7 @@ duckdb_alter_table_trigger_cpp(PG_FUNCTION_ARGS) {
  * This event trigger is called when a GRANT statement is executed. We use it to
  * block GRANTs on DuckDB tables. We allow grants on schemas though.
  */
-Datum
-duckdb_grant_trigger_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(duckdb_grant_trigger) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
 		elog(ERROR, "not fired by event trigger manager");
 

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include "pgduckdb/utility/copy.hpp"
 #include "pgduckdb/vendor/pg_explain.hpp"
 #include "pgduckdb/vendor/pg_list.hpp"
+#include "pgduckdb/pgduckdb_utils.hpp"
 
 static planner_hook_type prev_planner_hook = NULL;
 static ProcessUtility_hook_type prev_process_utility_hook = NULL;
@@ -165,7 +166,7 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 }
 
 static PlannedStmt *
-DuckdbPlannerHook(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
+DuckdbPlannerHook_Cpp(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
 	if (pgduckdb::IsExtensionRegistered()) {
 		if (NeedsDuckdbExecution(parse)) {
 			IsAllowedStatement(parse, true);
@@ -187,9 +188,15 @@ DuckdbPlannerHook(Query *parse, const char *query_string, int cursor_options, Pa
 	}
 }
 
+static PlannedStmt *
+DuckdbPlannerHook(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
+	return InvokeCPPFunc(DuckdbPlannerHook_Cpp, parse, query_string, cursor_options, bound_params);
+}
+
 static void
-DuckdbUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read_only_tree, ProcessUtilityContext context,
-                  ParamListInfo params, struct QueryEnvironment *query_env, DestReceiver *dest, QueryCompletion *qc) {
+DuckdbUtilityHook_Cpp(PlannedStmt *pstmt, const char *query_string, bool read_only_tree, ProcessUtilityContext context,
+                      ParamListInfo params, struct QueryEnvironment *query_env, DestReceiver *dest,
+                      QueryCompletion *qc) {
 	Node *parsetree = pstmt->utilityStmt;
 	if (pgduckdb::IsExtensionRegistered() && IsA(parsetree, CopyStmt)) {
 		uint64 processed;
@@ -210,6 +217,12 @@ DuckdbUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read_only_t
 	} else {
 		standard_ProcessUtility(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
 	}
+}
+
+static void
+DuckdbUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read_only_tree, ProcessUtilityContext context,
+                  ParamListInfo params, struct QueryEnvironment *query_env, DestReceiver *dest, QueryCompletion *qc) {
+	InvokeCPPFunc(DuckdbUtilityHook_Cpp, pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
 }
 
 extern "C" {

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -178,36 +178,36 @@ DuckdbCacheObject(Datum object, Datum type) {
 
 extern "C" {
 
-PG_FUNCTION_INFO_V1(install_extension);
+DECLARE_PG_FUNCTION(install_extension);
+DECLARE_PG_FUNCTION(pgduckdb_raw_query);
+DECLARE_PG_FUNCTION(cache);
+DECLARE_PG_FUNCTION(pgduckdb_recycle_ddb);
+
 Datum
-install_extension(PG_FUNCTION_ARGS) {
+install_extension_cpp(PG_FUNCTION_ARGS) {
 	Datum extension_name = PG_GETARG_DATUM(0);
 	bool result = pgduckdb::DuckdbInstallExtension(extension_name);
 	PG_RETURN_BOOL(result);
 }
 
-PG_FUNCTION_INFO_V1(pgduckdb_raw_query);
 Datum
-pgduckdb_raw_query(PG_FUNCTION_ARGS) {
+pgduckdb_raw_query_cpp(PG_FUNCTION_ARGS) {
 	const char *query = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	typedef duckdb::unique_ptr<duckdb::QueryResult> (*DuckDBQueryOrThrow)(const std::string &);
-	auto result = pgduckdb::DuckDBFunctionGuard<duckdb::unique_ptr<duckdb::QueryResult>, DuckDBQueryOrThrow>(pgduckdb::DuckDBQueryOrThrow, "pgduckdb_raw_query", query);
+	auto result = pgduckdb::DuckDBQueryOrThrow(query);
 	elog(NOTICE, "result: %s", result->ToString().c_str());
 	PG_RETURN_BOOL(true);
 }
 
-PG_FUNCTION_INFO_V1(cache);
 Datum
-cache(PG_FUNCTION_ARGS) {
+cache_cpp(PG_FUNCTION_ARGS) {
 	Datum object = PG_GETARG_DATUM(0);
 	Datum type = PG_GETARG_DATUM(1);
 	bool result = pgduckdb::DuckdbCacheObject(object, type);
 	PG_RETURN_BOOL(result);
 }
 
-PG_FUNCTION_INFO_V1(pgduckdb_recycle_ddb);
 Datum
-pgduckdb_recycle_ddb(PG_FUNCTION_ARGS) {
+pgduckdb_recycle_ddb_cpp(PG_FUNCTION_ARGS) {
 	pgduckdb::DuckDBManager::Get().Reset();
 	PG_RETURN_BOOL(true);
 }

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -178,36 +178,27 @@ DuckdbCacheObject(Datum object, Datum type) {
 
 extern "C" {
 
-DECLARE_PG_FUNCTION(install_extension);
-DECLARE_PG_FUNCTION(pgduckdb_raw_query);
-DECLARE_PG_FUNCTION(cache);
-DECLARE_PG_FUNCTION(pgduckdb_recycle_ddb);
-
-Datum
-install_extension_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(install_extension) {
 	Datum extension_name = PG_GETARG_DATUM(0);
 	bool result = pgduckdb::DuckdbInstallExtension(extension_name);
 	PG_RETURN_BOOL(result);
 }
 
-Datum
-pgduckdb_raw_query_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(pgduckdb_raw_query) {
 	const char *query = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	auto result = pgduckdb::DuckDBQueryOrThrow(query);
 	elog(NOTICE, "result: %s", result->ToString().c_str());
 	PG_RETURN_BOOL(true);
 }
 
-Datum
-cache_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(cache) {
 	Datum object = PG_GETARG_DATUM(0);
 	Datum type = PG_GETARG_DATUM(1);
 	bool result = pgduckdb::DuckdbCacheObject(object, type);
 	PG_RETURN_BOOL(result);
 }
 
-Datum
-pgduckdb_recycle_ddb_cpp(PG_FUNCTION_ARGS) {
+DECLARE_PG_FUNCTION(pgduckdb_recycle_ddb) {
 	pgduckdb::DuckDBManager::Get().Reset();
 	PG_RETURN_BOOL(true);
 }

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -108,7 +108,8 @@ PlannedStmt *
 DuckdbPlanNode(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params,
                bool throw_error) {
 	/* We need to check can we DuckDB create plan */
-	Plan *plan = pgduckdb::DuckDBFunctionGuard<Plan *>(CreatePlan, "CreatePlan", parse, throw_error);
+
+	Plan *plan = InvokeCPPFunc(CreatePlan, parse, throw_error);
 	Plan *duckdb_plan = (Plan *)castNode(CustomScan, plan);
 
 	if (!duckdb_plan) {

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -28,7 +28,7 @@ extern "C" {
 
 extern "C" {
 char *
-pgduckdb_function_name_cpp(Oid function_oid) {
+pgduckdb_function_name(Oid function_oid) {
 	if (!pgduckdb::IsDuckdbOnlyFunction(function_oid)) {
 		return nullptr;
 	}
@@ -37,10 +37,6 @@ pgduckdb_function_name_cpp(Oid function_oid) {
 	return psprintf("system.main.%s", quote_identifier(func_name));
 }
 
-char *
-pgduckdb_function_name(Oid function_oid) {
-	return InvokeCPPFunc(pgduckdb_function_name_cpp, function_oid);
-}
 /*
  * Given a postgres schema name, this returns a list of two elements: the first
  * is the DuckDB database name and the second is the duckdb schema name. These

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -568,10 +568,8 @@ ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute) {
 	}
 	case REGCLASSOID:
 		return duckdb::LogicalTypeId::UINTEGER;
-	default: {
-		std::string name = "UnsupportedPostgresType (Oid=" + std::to_string(type) + ")";
-		return duckdb::LogicalType::USER(name);
-	}
+	default:
+		return duckdb::LogicalType::USER("UnsupportedPostgresType (Oid=" + std::to_string(type) + ")");
 	}
 }
 
@@ -779,12 +777,10 @@ ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type) {
 	case TIMESTAMPTZOID:
 		return duckdb::Value::TIMESTAMPTZ(
 		    duckdb::timestamp_t(DatumGetTimestampTz(value) + PGDUCKDB_DUCK_TIMESTAMP_OFFSET));
-	case FLOAT4OID: {
+	case FLOAT4OID:
 		return duckdb::Value::FLOAT(DatumGetFloat4(value));
-	}
-	case FLOAT8OID: {
+	case FLOAT8OID:
 		return duckdb::Value::DOUBLE(DatumGetFloat8(value));
-	}
 	default:
 		elog(ERROR, "Could not convert Postgres parameter of type: %d to DuckDB type", postgres_type);
 	}

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -63,11 +63,21 @@ CreateOrGetDirectoryPath(const char* directory_name) {
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
-	auto res = context.Query(query, false);
-	if (res->HasError()) {
-		res->ThrowError();
+	const char *error_message = nullptr;
+	{
+		auto res = context.Query(query, false);
+		if (!res->HasError()) {
+			return res;
+		}
+
+		error_message = pstrdup(res->GetError().c_str());
 	}
-	return res;
+
+	if (error_message) {
+		elog(ERROR, "(PGDuckDB/DuckDBQuery) %s", error_message);
+	}
+
+	return nullptr; // unreachable
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "miscadmin.h"
 #include "lib/stringinfo.h"
 #include "storage/fd.h"
+#include "executor/spi.h"
 }
 
 #include <string>
@@ -17,68 +18,56 @@ extern "C" {
 namespace pgduckdb {
 
 static bool
-CheckDirectory(const char *directory) {
+CheckDirectory(const std::string &directory) {
 	struct stat info;
 
-	if (lstat(directory, &info) != 0) {
+	if (lstat(directory.c_str(), &info) != 0) {
 		if (errno == ENOENT) {
-			elog(DEBUG2, "Directory `%s` doesn't exists.", directory);
+			elog(DEBUG2, "Directory `%s` doesn't exists.", directory.c_str());
 			return false;
 		} else if (errno == EACCES) {
-			elog(ERROR, "Can't access `%s` directory.", directory);
+			throw std::runtime_error("Can't access `" + directory + "` directory.");
 		} else {
-			elog(ERROR, "Other error when reading `%s`.", directory);
+			throw std::runtime_error("Other error when reading `" + directory + "`.");
 		}
 	}
 
 	if (!S_ISDIR(info.st_mode)) {
-		elog(WARNING, "`%s` is not directory.", directory);
+		elog(WARNING, "`%s` is not directory.", directory.c_str());
 	}
 
-	if (access(directory, R_OK | W_OK)) {
-		elog(ERROR, "Directory `%s` permission problem.", directory);
+	if (access(directory.c_str(), R_OK | W_OK)) {
+		throw std::runtime_error("Directory `" + std::string(directory) + "` permission problem.");
 	}
 
 	return true;
 }
 
 std::string
-CreateOrGetDirectoryPath(std::string directory_name) {
-	StringInfo duckdb_data_directory = makeStringInfo();
-	appendStringInfo(duckdb_data_directory, "%s/%s", DataDir, directory_name.c_str());
+CreateOrGetDirectoryPath(const char* directory_name) {
+	std::ostringstream oss;
+	oss << DataDir << "/" << directory_name;
+	const auto duckdb_data_directory = oss.str();
 
-	if (!CheckDirectory(duckdb_data_directory->data)) {
-		if (MakePGDirectory(duckdb_data_directory->data) == -1) {
-			int error = errno;
-			elog(ERROR, "Creating %s directory failed with reason `%s`\n", duckdb_data_directory->data,
-			     strerror(error));
-			pfree(duckdb_data_directory->data);
+	if (!CheckDirectory(duckdb_data_directory)) {
+		if (MakePGDirectory(duckdb_data_directory.c_str()) == -1) {
+			throw std::runtime_error("Creating data directory '" + duckdb_data_directory + "' failed: `" +
+			                         strerror(errno) + "`");
 		}
-		elog(DEBUG2, "Created %s directory", duckdb_data_directory->data);
+
+		elog(DEBUG2, "Created %s directory", duckdb_data_directory.c_str());
 	};
 
-	std::string directory(duckdb_data_directory->data);
-	pfree(duckdb_data_directory->data);
-	return directory;
+	return duckdb_data_directory;
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
-	const char *error_message = nullptr;
-	{
-		auto res = context.Query(query, false);
-		if (!res->HasError()) {
-			return res;
-		}
-
-		error_message = pstrdup(res->GetError().c_str());
+	auto res = context.Query(query, false);
+	if (res->HasError()) {
+		res->ThrowError();
 	}
-
-	if (error_message) {
-		elog(ERROR, "(PGDuckDB/DuckDBQuery) %s", error_message);
-	}
-
-	return nullptr; // unreachable
+	return res;
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>

--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -34,7 +34,7 @@ INSERT INTO int_array_2d VALUES
     ('{{11, 12, 13}, {14, 15, 16}}'),
     ('{{17, 18}, {19, 20}}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/ExecuteQuery) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (single dimensional data, two dimensionsal type)
 CREATE TABLE int_array_2d(a INT[][]);
@@ -44,7 +44,7 @@ INSERT INTO int_array_2d VALUES
     ('{11, 12, 13}'),
     ('{17, 18}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/ExecuteQuery) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (two dimensional data and type)
 CREATE TABLE int_array_2d(a INT[][]);

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -4,7 +4,7 @@ INSERT INTO int_as_varchar SELECT * from (
 		('abc')
 ) t(a);
 SELECT a::INTEGER FROM int_as_varchar;
-ERROR:  (PGDuckDB/ExecuteQuery) Conversion Error: Could not convert string 'abc' to INT32
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Conversion Error: Could not convert string 'abc' to INT32
 LINE 1: SELECT (a)::integer AS a FROM pgduckdb.public.int...
                   ^
 DROP TABLE int_as_varchar;


### PR DESCRIPTION
Forked off https://github.com/duckdb/pg_duckdb/pull/254

This PR reworks `DuckDBFunctionGuard` to make invocation easier:
* no need to specify type in template invocation
* no need to provide the function name

It also introduces a new `DECLARE_PG_FUNCTION(func_name)` macro which wraps a given function and make it a safe `PG_FUNCTION` that catches any C++ exceptions. This works by expecting a `func_name_cpp` (note the `_cpp` suffix) function to be implemented.

It also renames existing `_Unsafe` functions into `_Cpp` for consistency.