### PR TITLE
Simplify `DuckDBQueryOrThrow`

### DIFF
--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -63,21 +63,11 @@ CreateOrGetDirectoryPath(const char* directory_name) {
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query) {
-	const char *error_message = nullptr;
-	{
-		auto res = context.Query(query, false);
-		if (!res->HasError()) {
-			return res;
-		}
-
-		error_message = pstrdup(res->GetError().c_str());
+	auto res = context.Query(query, false);
+	if (res->HasError()) {
+		res->ThrowError();
 	}
-
-	if (error_message) {
-		elog(ERROR, "(PGDuckDB/DuckDBQuery) %s", error_message);
-	}
-
-	return nullptr; // unreachable
+	return res;
 }
 
 duckdb::unique_ptr<duckdb::QueryResult>


### PR DESCRIPTION
Now that we correctly handle C++ exceptions, simplify the `DuckDBQueryOrThrow` helper.