### PR TITLE
Rewrite copy helper in C form

### DIFF
--- a/include/pgduckdb/utility/copy.hpp
+++ b/include/pgduckdb/utility/copy.hpp
@@ -5,4 +5,4 @@ extern "C" {
 #include "nodes/plannodes.h"
 }
 
-bool DuckdbCopy(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment *query_env, uint64 *processed);
+const char* MakeDuckdbCopyQuery(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment *query_env);

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -149,7 +149,6 @@ appendCreateCopyOptions(StringInfo info, CopyStmt *copy_stmt) {
 				appendStringInfo(info, "*");
 				break;
 			default:
-				// elog(ERROR, "Expected single table to be created, but found %" PRIu64, static_cast<uint64_t>(SPI_processed));
 				elog(ERROR, "Unexpected node type in COPY: %" PRIu64, (uint64_t)nodeTag(defel->arg));
 			}
 		}


### PR DESCRIPTION
Copy utilities was mostly using Postgres functions, so this PR removes any C++ function calls.
It also moves out the DuckDB query execution off the function itself, which only construct the query string to be executed.