### PR TITLE
Move catalog implementation to `pgduckdb` namespace

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_catalog.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_catalog.hpp
@@ -4,46 +4,54 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "pgduckdb/catalog/pgduckdb_schema.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-class PostgresCatalog : public Catalog {
+class PostgresCatalog : public duckdb::Catalog {
 public:
-	PostgresCatalog(AttachedDatabase &db, const string &connection_string, AccessMode access_mode);
-
-public:
-	static unique_ptr<Catalog> Attach(StorageExtensionInfo *storage_info, ClientContext &context, AttachedDatabase &db,
-	                                  const string &name, AttachInfo &info, AccessMode access_mode);
+	PostgresCatalog(duckdb::AttachedDatabase &db, const duckdb::string &connection_string,
+	                duckdb::AccessMode access_mode);
 
 public:
-	string path;
-	AccessMode access_mode;
+	static duckdb::unique_ptr<duckdb::Catalog> Attach(duckdb::StorageExtensionInfo *storage_info,
+	                                                  duckdb::ClientContext &context, duckdb::AttachedDatabase &db,
+	                                                  const duckdb::string &name, duckdb::AttachInfo &info,
+	                                                  duckdb::AccessMode access_mode);
+
+public:
+	duckdb::string path;
+	duckdb::AccessMode access_mode;
 
 public:
 	// -- Catalog API --
 	void Initialize(bool load_builtin) override;
-	string GetCatalogType() override;
-	optional_ptr<CatalogEntry> CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) override;
-	optional_ptr<SchemaCatalogEntry> GetSchema(CatalogTransaction transaction, const string &schema_name,
-	                                           OnEntryNotFound if_not_found,
-	                                           QueryErrorContext error_context = QueryErrorContext()) override;
-	void ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) override;
-	unique_ptr<PhysicalOperator> PlanCreateTableAs(ClientContext &context, LogicalCreateTable &op,
-	                                               unique_ptr<PhysicalOperator> plan) override;
-	unique_ptr<PhysicalOperator> PlanInsert(ClientContext &context, LogicalInsert &op,
-	                                        unique_ptr<PhysicalOperator> plan) override;
-	unique_ptr<PhysicalOperator> PlanDelete(ClientContext &context, LogicalDelete &op,
-	                                        unique_ptr<PhysicalOperator> plan) override;
-	unique_ptr<PhysicalOperator> PlanUpdate(ClientContext &context, LogicalUpdate &op,
-	                                        unique_ptr<PhysicalOperator> plan) override;
-	unique_ptr<LogicalOperator> BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
-	                                            unique_ptr<LogicalOperator> plan) override;
-	DatabaseSize GetDatabaseSize(ClientContext &context) override;
+	duckdb::string GetCatalogType() override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateSchema(duckdb::CatalogTransaction transaction,
+	                                                        duckdb::CreateSchemaInfo &info) override;
+	duckdb::optional_ptr<duckdb::SchemaCatalogEntry>
+	GetSchema(duckdb::CatalogTransaction transaction, const duckdb::string &schema_name,
+	          duckdb::OnEntryNotFound if_not_found,
+	          duckdb::QueryErrorContext error_context = duckdb::QueryErrorContext()) override;
+	void ScanSchemas(duckdb::ClientContext &context,
+	                 std::function<void(duckdb::SchemaCatalogEntry &)> callback) override;
+	duckdb::unique_ptr<duckdb::PhysicalOperator>
+	PlanCreateTableAs(duckdb::ClientContext &context, duckdb::LogicalCreateTable &op,
+	                  duckdb::unique_ptr<duckdb::PhysicalOperator> plan) override;
+	duckdb::unique_ptr<duckdb::PhysicalOperator> PlanInsert(duckdb::ClientContext &context, duckdb::LogicalInsert &op,
+	                                                        duckdb::unique_ptr<duckdb::PhysicalOperator> plan) override;
+	duckdb::unique_ptr<duckdb::PhysicalOperator> PlanDelete(duckdb::ClientContext &context, duckdb::LogicalDelete &op,
+	                                                        duckdb::unique_ptr<duckdb::PhysicalOperator> plan) override;
+	duckdb::unique_ptr<duckdb::PhysicalOperator> PlanUpdate(duckdb::ClientContext &context, duckdb::LogicalUpdate &op,
+	                                                        duckdb::unique_ptr<duckdb::PhysicalOperator> plan) override;
+	duckdb::unique_ptr<duckdb::LogicalOperator>
+	BindCreateIndex(duckdb::Binder &binder, duckdb::CreateStatement &stmt, duckdb::TableCatalogEntry &table,
+	                duckdb::unique_ptr<duckdb::LogicalOperator> plan) override;
+	duckdb::DatabaseSize GetDatabaseSize(duckdb::ClientContext &context) override;
 	bool InMemory() override;
-	string GetDBPath() override;
-	void DropSchema(ClientContext &context, DropInfo &info) override;
+	duckdb::string GetDBPath() override;
+	void DropSchema(duckdb::ClientContext &context, duckdb::DropInfo &info) override;
 
 private:
-	case_insensitive_map_t<unique_ptr<PostgresSchema>> schemas;
+	duckdb::case_insensitive_map_t<duckdb::unique_ptr<PostgresSchema>> schemas;
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/include/pgduckdb/catalog/pgduckdb_schema.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_schema.hpp
@@ -3,37 +3,46 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "pgduckdb/pg_declarations.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-class PostgresSchema : public SchemaCatalogEntry {
+class PostgresSchema : public duckdb::SchemaCatalogEntry {
 public:
-	PostgresSchema(Catalog &catalog, CreateSchemaInfo &info, Snapshot snapshot);
+	PostgresSchema(duckdb::Catalog &catalog, duckdb::CreateSchemaInfo &info, Snapshot snapshot);
 
 public:
 	// -- Schema API --
-	void Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
-	void Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
-	optional_ptr<CatalogEntry> CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
-	                                       TableCatalogEntry &table) override;
-	optional_ptr<CatalogEntry> CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) override;
-	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;
-	optional_ptr<CatalogEntry> CreateView(CatalogTransaction transaction, CreateViewInfo &info) override;
-	optional_ptr<CatalogEntry> CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) override;
-	optional_ptr<CatalogEntry> CreateTableFunction(CatalogTransaction transaction,
-	                                               CreateTableFunctionInfo &info) override;
-	optional_ptr<CatalogEntry> CreateCopyFunction(CatalogTransaction transaction,
-	                                              CreateCopyFunctionInfo &info) override;
-	optional_ptr<CatalogEntry> CreatePragmaFunction(CatalogTransaction transaction,
-	                                                CreatePragmaFunctionInfo &info) override;
-	optional_ptr<CatalogEntry> CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) override;
-	optional_ptr<CatalogEntry> CreateType(CatalogTransaction transaction, CreateTypeInfo &info) override;
-	optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, CatalogType type, const string &name) override;
-	void DropEntry(ClientContext &context, DropInfo &info) override;
-	void Alter(CatalogTransaction transaction, AlterInfo &info) override;
+	void Scan(duckdb::ClientContext &context, duckdb::CatalogType type,
+	          const std::function<void(CatalogEntry &)> &callback) override;
+	void Scan(duckdb::CatalogType type, const std::function<void(duckdb::CatalogEntry &)> &callback) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateIndex(duckdb::CatalogTransaction transaction,
+	                                                       duckdb::CreateIndexInfo &info,
+	                                                       duckdb::TableCatalogEntry &table) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateFunction(duckdb::CatalogTransaction transaction,
+	                                                          duckdb::CreateFunctionInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateTable(duckdb::CatalogTransaction transaction,
+	                                                       duckdb::BoundCreateTableInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateView(duckdb::CatalogTransaction transaction,
+	                                                      duckdb::CreateViewInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateSequence(duckdb::CatalogTransaction transaction,
+	                                                          duckdb::CreateSequenceInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateTableFunction(duckdb::CatalogTransaction transaction,
+	                                                               duckdb::CreateTableFunctionInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateCopyFunction(duckdb::CatalogTransaction transaction,
+	                                                              duckdb::CreateCopyFunctionInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreatePragmaFunction(duckdb::CatalogTransaction transaction,
+	                                                                duckdb::CreatePragmaFunctionInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateCollation(duckdb::CatalogTransaction transaction,
+	                                                           duckdb::CreateCollationInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> CreateType(duckdb::CatalogTransaction transaction,
+	                                                      duckdb::CreateTypeInfo &info) override;
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetEntry(duckdb::CatalogTransaction transaction,
+	                                                    duckdb::CatalogType type, const duckdb::string &name) override;
+	void DropEntry(duckdb::ClientContext &context, duckdb::DropInfo &info) override;
+	void Alter(duckdb::CatalogTransaction transaction, duckdb::AlterInfo &info) override;
 
 public:
 	Snapshot snapshot;
-	Catalog &catalog;
+	duckdb::Catalog &catalog;
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/include/pgduckdb/catalog/pgduckdb_storage.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_storage.hpp
@@ -2,11 +2,11 @@
 
 #include "duckdb/storage/storage_extension.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-class PostgresStorageExtension : public StorageExtension {
+class PostgresStorageExtension : public duckdb::StorageExtension {
 public:
 	PostgresStorageExtension();
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/include/pgduckdb/catalog/pgduckdb_table.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_table.hpp
@@ -5,20 +5,20 @@
 
 #include "pgduckdb/pg_declarations.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-class PostgresTable : public TableCatalogEntry {
+class PostgresTable : public duckdb::TableCatalogEntry {
 public:
 	virtual ~PostgresTable();
 
 public:
 	static ::Relation OpenRelation(Oid relid);
-	static void SetTableInfo(CreateTableInfo &info, ::Relation rel);
+	static void SetTableInfo(duckdb::CreateTableInfo &info, ::Relation rel);
 	static Cardinality GetTableCardinality(::Relation rel);
 
 protected:
-	PostgresTable(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info, ::Relation rel,
-	              Cardinality cardinality, Snapshot snapshot);
+	PostgresTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema, duckdb::CreateTableInfo &info,
+	              ::Relation rel, Cardinality cardinality, Snapshot snapshot);
 
 protected:
 	::Relation rel;
@@ -28,14 +28,16 @@ protected:
 
 class PostgresHeapTable : public PostgresTable {
 public:
-	PostgresHeapTable(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info, ::Relation rel,
-	                  Cardinality cardinality, Snapshot snapshot);
+	PostgresHeapTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema, duckdb::CreateTableInfo &info,
+	                  ::Relation rel, Cardinality cardinality, Snapshot snapshot);
 
 public:
 	// -- Table API --
-	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
-	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
-	TableStorageInfo GetStorageInfo(ClientContext &context) override;
+	duckdb::unique_ptr<duckdb::BaseStatistics> GetStatistics(duckdb::ClientContext &context,
+	                                                         duckdb::column_t column_id) override;
+	duckdb::TableFunction GetScanFunction(duckdb::ClientContext &context,
+	                                      duckdb::unique_ptr<duckdb::FunctionData> &bind_data) override;
+	duckdb::TableStorageInfo GetStorageInfo(duckdb::ClientContext &context) override;
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/include/pgduckdb/catalog/pgduckdb_transaction.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction.hpp
@@ -1,42 +1,45 @@
 #pragma once
 
 #include "duckdb/transaction/transaction.hpp"
+
 #include "pgduckdb/catalog/pgduckdb_table.hpp"
 #include "pgduckdb/catalog/pgduckdb_schema.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
 class PostgresCatalog;
 
 class SchemaItems {
 public:
-	SchemaItems(unique_ptr<PostgresSchema> &&schema, const string &name) : name(name), schema(std::move(schema)) {
+	SchemaItems(duckdb::unique_ptr<PostgresSchema> &&schema, const duckdb::string &name)
+	    : name(name), schema(std::move(schema)) {
 	}
 
-	optional_ptr<CatalogEntry> GetTable(const string &name);
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetTable(const duckdb::string &name);
 
-	optional_ptr<CatalogEntry> GetSchema() const;
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetSchema() const;
 
 private:
-	string name;
-	unique_ptr<PostgresSchema> schema;
-	case_insensitive_map_t<unique_ptr<PostgresTable>> tables;
+	duckdb::string name;
+	duckdb::unique_ptr<PostgresSchema> schema;
+	duckdb::case_insensitive_map_t<duckdb::unique_ptr<PostgresTable>> tables;
 };
 
-class PostgresTransaction : public Transaction {
+class PostgresTransaction : public duckdb::Transaction {
 public:
-	PostgresTransaction(TransactionManager &manager, ClientContext &context, PostgresCatalog &catalog,
+	PostgresTransaction(duckdb::TransactionManager &manager, duckdb::ClientContext &context, PostgresCatalog &catalog,
 	                    Snapshot snapshot);
 	~PostgresTransaction() override;
 
-	optional_ptr<CatalogEntry> GetCatalogEntry(CatalogType type, const string &schema, const string &name);
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetCatalogEntry(duckdb::CatalogType type, const duckdb::string &schema,
+	                                                           const duckdb::string &name);
 
 private:
-	optional_ptr<CatalogEntry> GetSchema(const string &name);
+	duckdb::optional_ptr<duckdb::CatalogEntry> GetSchema(const duckdb::string &name);
 
-	case_insensitive_map_t<SchemaItems> schemas;
+	duckdb::case_insensitive_map_t<SchemaItems> schemas;
 	PostgresCatalog &catalog;
 	Snapshot snapshot;
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
@@ -1,26 +1,27 @@
 #pragma once
 
 #include "duckdb/transaction/transaction_manager.hpp"
-#include "pgduckdb/catalog/pgduckdb_catalog.hpp"
-#include "pgduckdb/catalog/pgduckdb_transaction.hpp"
 #include "duckdb/common/reference_map.hpp"
 
-namespace duckdb {
+#include "pgduckdb/catalog/pgduckdb_catalog.hpp"
+#include "pgduckdb/catalog/pgduckdb_transaction.hpp"
 
-class PostgresTransactionManager : public TransactionManager {
+namespace pgduckdb {
+
+class PostgresTransactionManager : public duckdb::TransactionManager {
 public:
-	PostgresTransactionManager(AttachedDatabase &db_p, PostgresCatalog &catalog);
+	PostgresTransactionManager(duckdb::AttachedDatabase &db_p, PostgresCatalog &catalog);
 
-	Transaction &StartTransaction(ClientContext &context) override;
-	ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override;
-	void RollbackTransaction(Transaction &transaction) override;
+	duckdb::Transaction &StartTransaction(duckdb::ClientContext &context) override;
+	duckdb::ErrorData CommitTransaction(duckdb::ClientContext &context, duckdb::Transaction &transaction) override;
+	void RollbackTransaction(duckdb::Transaction &transaction) override;
 
-	void Checkpoint(ClientContext &context, bool force = false) override;
+	void Checkpoint(duckdb::ClientContext &context, bool force = false) override;
 
 private:
 	PostgresCatalog &catalog;
-	mutex transaction_lock;
-	reference_map_t<Transaction, unique_ptr<Transaction>> transactions;
+	duckdb::mutex transaction_lock;
+	duckdb::reference_map_t<duckdb::Transaction, duckdb::unique_ptr<duckdb::Transaction>> transactions;
 };
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/src/catalog/pgduckdb_catalog.cpp
+++ b/src/catalog/pgduckdb_catalog.cpp
@@ -4,17 +4,19 @@
 #include "pgduckdb/catalog/pgduckdb_storage.hpp"
 #include "pgduckdb/catalog/pgduckdb_transaction.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-PostgresCatalog::PostgresCatalog(AttachedDatabase &db, const string &connection_string, AccessMode access_mode)
+PostgresCatalog::PostgresCatalog(duckdb::AttachedDatabase &db, const duckdb::string &connection_string,
+                                 duckdb::AccessMode access_mode)
     : Catalog(db), path(connection_string), access_mode(access_mode) {
 }
 
-unique_ptr<Catalog>
-PostgresCatalog::Attach(StorageExtensionInfo *storage_info_p, ClientContext &context, AttachedDatabase &db,
-                        const string &name, AttachInfo &info, AccessMode access_mode) {
-	string connection_string = info.path;
-	return make_uniq<PostgresCatalog>(db, connection_string, access_mode);
+duckdb::unique_ptr<duckdb::Catalog>
+PostgresCatalog::Attach(duckdb::StorageExtensionInfo *storage_info_p, duckdb::ClientContext &context,
+                        duckdb::AttachedDatabase &db, const duckdb::string &name, duckdb::AttachInfo &info,
+                        duckdb::AccessMode access_mode) {
+	auto connection_string = info.path;
+	return duckdb::make_uniq<PostgresCatalog>(db, connection_string, access_mode);
 }
 
 // ------------------ Catalog API ---------------------
@@ -24,60 +26,65 @@ PostgresCatalog::Initialize(bool load_builtin) {
 	return;
 }
 
-string
+duckdb::string
 PostgresCatalog::GetCatalogType() {
 	return "pgduckdb";
 }
 
-optional_ptr<CatalogEntry>
-PostgresCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
-	throw NotImplementedException("CreateSchema not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresCatalog::CreateSchema(duckdb::CatalogTransaction transaction, duckdb::CreateSchemaInfo &info) {
+	throw duckdb::NotImplementedException("CreateSchema not supported yet");
 }
 
-optional_ptr<SchemaCatalogEntry>
-PostgresCatalog::GetSchema(CatalogTransaction transaction, const string &schema_name, OnEntryNotFound if_not_found,
-                           QueryErrorContext error_context) {
+duckdb::optional_ptr<duckdb::SchemaCatalogEntry>
+PostgresCatalog::GetSchema(duckdb::CatalogTransaction transaction, const duckdb::string &schema_name,
+                           duckdb::OnEntryNotFound if_not_found, duckdb::QueryErrorContext error_context) {
 	auto &pg_transaction = transaction.transaction->Cast<PostgresTransaction>();
-	auto res = pg_transaction.GetCatalogEntry(CatalogType::SCHEMA_ENTRY, schema_name, "");
+	auto res = pg_transaction.GetCatalogEntry(duckdb::CatalogType::SCHEMA_ENTRY, schema_name, "");
 	D_ASSERT(res);
-	D_ASSERT(res->type == CatalogType::SCHEMA_ENTRY);
-	return (SchemaCatalogEntry *)res.get();
+	D_ASSERT(res->type == duckdb::CatalogType::SCHEMA_ENTRY);
+	return (duckdb::SchemaCatalogEntry *)res.get();
 }
 
 void
-PostgresCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
+PostgresCatalog::ScanSchemas(duckdb::ClientContext &context,
+                             std::function<void(duckdb::SchemaCatalogEntry &)> callback) {
 	return;
 }
 
-unique_ptr<PhysicalOperator>
-PostgresCatalog::PlanCreateTableAs(ClientContext &context, LogicalCreateTable &op, unique_ptr<PhysicalOperator> plan) {
-	throw NotImplementedException("PlanCreateTableAs not supported yet");
+duckdb::unique_ptr<duckdb::PhysicalOperator>
+PostgresCatalog::PlanCreateTableAs(duckdb::ClientContext &context, duckdb::LogicalCreateTable &op,
+                                   duckdb::unique_ptr<duckdb::PhysicalOperator> plan) {
+	throw duckdb::NotImplementedException("PlanCreateTableAs not supported yet");
 }
 
-unique_ptr<PhysicalOperator>
-PostgresCatalog::PlanInsert(ClientContext &context, LogicalInsert &op, unique_ptr<PhysicalOperator> plan) {
-	throw NotImplementedException("PlanInsert not supported yet");
+duckdb::unique_ptr<duckdb::PhysicalOperator>
+PostgresCatalog::PlanInsert(duckdb::ClientContext &context, duckdb::LogicalInsert &op,
+                            duckdb::unique_ptr<duckdb::PhysicalOperator> plan) {
+	throw duckdb::NotImplementedException("PlanInsert not supported yet");
 }
 
-unique_ptr<PhysicalOperator>
-PostgresCatalog::PlanDelete(ClientContext &context, LogicalDelete &op, unique_ptr<PhysicalOperator> plan) {
-	throw NotImplementedException("PlanDelete not supported yet");
+duckdb::unique_ptr<duckdb::PhysicalOperator>
+PostgresCatalog::PlanDelete(duckdb::ClientContext &context, duckdb::LogicalDelete &op,
+                            duckdb::unique_ptr<duckdb::PhysicalOperator> plan) {
+	throw duckdb::NotImplementedException("PlanDelete not supported yet");
 }
 
-unique_ptr<PhysicalOperator>
-PostgresCatalog::PlanUpdate(ClientContext &context, LogicalUpdate &op, unique_ptr<PhysicalOperator> plan) {
-	throw NotImplementedException("PlanUpdate not supported yet");
+duckdb::unique_ptr<duckdb::PhysicalOperator>
+PostgresCatalog::PlanUpdate(duckdb::ClientContext &context, duckdb::LogicalUpdate &op,
+                            duckdb::unique_ptr<duckdb::PhysicalOperator> plan) {
+	throw duckdb::NotImplementedException("PlanUpdate not supported yet");
 }
 
-unique_ptr<LogicalOperator>
-PostgresCatalog::BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
-                                 unique_ptr<LogicalOperator> plan) {
-	throw NotImplementedException("BindCreateIndex not supported yet");
+duckdb::unique_ptr<duckdb::LogicalOperator>
+PostgresCatalog::BindCreateIndex(duckdb::Binder &binder, duckdb::CreateStatement &stmt,
+                                 duckdb::TableCatalogEntry &table, duckdb::unique_ptr<duckdb::LogicalOperator> plan) {
+	throw duckdb::NotImplementedException("BindCreateIndex not supported yet");
 }
 
-DatabaseSize
-PostgresCatalog::GetDatabaseSize(ClientContext &context) {
-	throw NotImplementedException("GetDatabaseSize not supported yet");
+duckdb::DatabaseSize
+PostgresCatalog::GetDatabaseSize(duckdb::ClientContext &context) {
+	throw duckdb::NotImplementedException("GetDatabaseSize not supported yet");
 }
 
 bool
@@ -85,14 +92,14 @@ PostgresCatalog::InMemory() {
 	return false;
 }
 
-string
+duckdb::string
 PostgresCatalog::GetDBPath() {
 	return path;
 }
 
 void
-PostgresCatalog::DropSchema(ClientContext &context, DropInfo &info) {
-	throw NotImplementedException("DropSchema not supported yet");
+PostgresCatalog::DropSchema(duckdb::ClientContext &context, duckdb::DropInfo &info) {
+	throw duckdb::NotImplementedException("DropSchema not supported yet");
 }
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/src/catalog/pgduckdb_schema.cpp
+++ b/src/catalog/pgduckdb_schema.cpp
@@ -3,86 +3,89 @@
 #include "pgduckdb/catalog/pgduckdb_transaction.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-PostgresSchema::PostgresSchema(Catalog &catalog, CreateSchemaInfo &info, Snapshot snapshot)
+PostgresSchema::PostgresSchema(duckdb::Catalog &catalog, duckdb::CreateSchemaInfo &info, Snapshot snapshot)
     : SchemaCatalogEntry(catalog, info), snapshot(snapshot), catalog(catalog) {
 }
 
 void
-PostgresSchema::Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
+PostgresSchema::Scan(duckdb::ClientContext &context, duckdb::CatalogType type,
+                     const std::function<void(CatalogEntry &)> &callback) {
 	return;
 }
 
 void
-PostgresSchema::Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
-	throw NotImplementedException("Scan(no context) not supported yet");
+PostgresSchema::Scan(duckdb::CatalogType type, const std::function<void(duckdb::CatalogEntry &)> &callback) {
+	throw duckdb::NotImplementedException("Scan(no context) not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info, TableCatalogEntry &table) {
-	throw NotImplementedException("CreateIndex not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateIndex(duckdb::CatalogTransaction transaction, duckdb::CreateIndexInfo &info,
+                            duckdb::TableCatalogEntry &table) {
+	throw duckdb::NotImplementedException("CreateIndex not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) {
-	throw NotImplementedException("CreateFunction not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateFunction(duckdb::CatalogTransaction transaction, duckdb::CreateFunctionInfo &info) {
+	throw duckdb::NotImplementedException("CreateFunction not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
-	throw NotImplementedException("CreateTable not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateTable(duckdb::CatalogTransaction transaction, duckdb::BoundCreateTableInfo &info) {
+	throw duckdb::NotImplementedException("CreateTable not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
-	throw NotImplementedException("CreateView not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateView(duckdb::CatalogTransaction transaction, duckdb::CreateViewInfo &info) {
+	throw duckdb::NotImplementedException("CreateView not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) {
-	throw NotImplementedException("CreateSequence not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateSequence(duckdb::CatalogTransaction transaction, duckdb::CreateSequenceInfo &info) {
+	throw duckdb::NotImplementedException("CreateSequence not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateTableFunction(CatalogTransaction transaction, CreateTableFunctionInfo &info) {
-	throw NotImplementedException("CreateTableFunction not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateTableFunction(duckdb::CatalogTransaction transaction, duckdb::CreateTableFunctionInfo &info) {
+	throw duckdb::NotImplementedException("CreateTableFunction not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateCopyFunction(CatalogTransaction transaction, CreateCopyFunctionInfo &info) {
-	throw NotImplementedException("CreateCopyFunction not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateCopyFunction(duckdb::CatalogTransaction transaction, duckdb::CreateCopyFunctionInfo &info) {
+	throw duckdb::NotImplementedException("CreateCopyFunction not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreatePragmaFunction(CatalogTransaction transaction, CreatePragmaFunctionInfo &info) {
-	throw NotImplementedException("CreatePragmaFunction not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreatePragmaFunction(duckdb::CatalogTransaction transaction, duckdb::CreatePragmaFunctionInfo &info) {
+	throw duckdb::NotImplementedException("CreatePragmaFunction not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) {
-	throw NotImplementedException("CreateCollation not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateCollation(duckdb::CatalogTransaction transaction, duckdb::CreateCollationInfo &info) {
+	throw duckdb::NotImplementedException("CreateCollation not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::CreateType(CatalogTransaction transaction, CreateTypeInfo &info) {
-	throw NotImplementedException("CreateType not supported yet");
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::CreateType(duckdb::CatalogTransaction transaction, duckdb::CreateTypeInfo &info) {
+	throw duckdb::NotImplementedException("CreateType not supported yet");
 }
 
-optional_ptr<CatalogEntry>
-PostgresSchema::GetEntry(CatalogTransaction transaction, CatalogType type, const string &entry_name) {
+duckdb::optional_ptr<duckdb::CatalogEntry>
+PostgresSchema::GetEntry(duckdb::CatalogTransaction transaction, duckdb::CatalogType type,
+                         const duckdb::string &entry_name) {
 	auto &pg_transaction = transaction.transaction->Cast<PostgresTransaction>();
 	return pg_transaction.GetCatalogEntry(type, name, entry_name);
 }
 
 void
-PostgresSchema::DropEntry(ClientContext &context, DropInfo &info) {
-	throw NotImplementedException("DropEntry not supported yet");
+PostgresSchema::DropEntry(duckdb::ClientContext &context, duckdb::DropInfo &info) {
+	throw duckdb::NotImplementedException("DropEntry not supported yet");
 }
 
 void
-PostgresSchema::Alter(CatalogTransaction transaction, AlterInfo &info) {
-	throw NotImplementedException("Alter not supported yet");
+PostgresSchema::Alter(duckdb::CatalogTransaction transaction, duckdb::AlterInfo &info) {
+	throw duckdb::NotImplementedException("Alter not supported yet");
 }
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/src/catalog/pgduckdb_storage.cpp
+++ b/src/catalog/pgduckdb_storage.cpp
@@ -2,11 +2,12 @@
 #include "pgduckdb/catalog/pgduckdb_catalog.hpp"
 #include "pgduckdb/catalog/pgduckdb_transaction_manager.hpp"
 
-namespace duckdb {
+namespace pgduckdb {
 
-static unique_ptr<TransactionManager>
-CreateTransactionManager(StorageExtensionInfo *storage_info, AttachedDatabase &db, Catalog &catalog) {
-	return make_uniq<PostgresTransactionManager>(db, catalog.Cast<PostgresCatalog>());
+static duckdb::unique_ptr<duckdb::TransactionManager>
+CreateTransactionManager(duckdb::StorageExtensionInfo *storage_info, duckdb::AttachedDatabase &db,
+                         duckdb::Catalog &catalog) {
+	return duckdb::make_uniq<PostgresTransactionManager>(db, catalog.Cast<PostgresCatalog>());
 }
 
 PostgresStorageExtension::PostgresStorageExtension() {
@@ -14,4 +15,4 @@ PostgresStorageExtension::PostgresStorageExtension() {
 	create_transaction_manager = CreateTransactionManager;
 }
 
-} // namespace duckdb
+} // namespace pgduckdb

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -78,7 +78,7 @@ DuckDBManager::Initialize() {
 	database = new duckdb::DuckDB(connection_string, &config);
 
 	auto &dbconfig = duckdb::DBConfig::GetConfig(*database->instance);
-	dbconfig.storage_extensions["pgduckdb"] = duckdb::make_uniq<duckdb::PostgresStorageExtension>();
+	dbconfig.storage_extensions["pgduckdb"] = duckdb::make_uniq<PostgresStorageExtension>();
 	duckdb::ExtensionInstallInfo extension_install_info;
 	database->instance->SetExtensionLoaded("pgduckdb", extension_install_info);
 


### PR DESCRIPTION
Note: stacked on top of https://github.com/duckdb/pg_duckdb/pull/386 (only last commit is relevant)

Move catalog implementation to `pgduckdb` namespace (out of `duckdb`) for clarity and consistency.