### PR TITLE
Remove top-level namespace qualifiers

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_table.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_table.hpp
@@ -12,16 +12,16 @@ public:
 	virtual ~PostgresTable();
 
 public:
-	static ::Relation OpenRelation(Oid relid);
-	static void SetTableInfo(duckdb::CreateTableInfo &info, ::Relation rel);
-	static Cardinality GetTableCardinality(::Relation rel);
+	static Relation OpenRelation(Oid relid);
+	static void SetTableInfo(duckdb::CreateTableInfo &info, Relation rel);
+	static Cardinality GetTableCardinality(Relation rel);
 
 protected:
 	PostgresTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema, duckdb::CreateTableInfo &info,
-	              ::Relation rel, Cardinality cardinality, Snapshot snapshot);
+	              Relation rel, Cardinality cardinality, Snapshot snapshot);
 
 protected:
-	::Relation rel;
+	Relation rel;
 	Cardinality cardinality;
 	Snapshot snapshot;
 };
@@ -29,7 +29,7 @@ protected:
 class PostgresHeapTable : public PostgresTable {
 public:
 	PostgresHeapTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema, duckdb::CreateTableInfo &info,
-	                  ::Relation rel, Cardinality cardinality, Snapshot snapshot);
+	                  Relation rel, Cardinality cardinality, Snapshot snapshot);
 
 public:
 	// -- Table API --

--- a/include/pgduckdb/scan/postgres_seq_scan.hpp
+++ b/include/pgduckdb/scan/postgres_seq_scan.hpp
@@ -41,11 +41,11 @@ public:
 
 struct PostgresSeqScanFunctionData : public duckdb::TableFunctionData {
 public:
-	PostgresSeqScanFunctionData(::Relation rel, uint64_t cardinality, Snapshot snapshot);
+	PostgresSeqScanFunctionData(Relation rel, uint64_t cardinality, Snapshot snapshot);
 	~PostgresSeqScanFunctionData() override;
 
 public:
-	::Relation m_rel;
+	Relation m_rel;
 	uint64_t m_cardinality;
 	Snapshot m_snapshot;
 };

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -16,7 +16,7 @@ extern "C" {
 namespace pgduckdb {
 
 PostgresTable::PostgresTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema,
-                             duckdb::CreateTableInfo &info, ::Relation rel, Cardinality cardinality, Snapshot snapshot)
+                             duckdb::CreateTableInfo &info, Relation rel, Cardinality cardinality, Snapshot snapshot)
     : duckdb::TableCatalogEntry(catalog, schema, info), rel(rel), cardinality(cardinality), snapshot(snapshot) {
 }
 
@@ -25,14 +25,14 @@ PostgresTable::~PostgresTable() {
 	RelationClose(rel);
 }
 
-::Relation
+Relation
 PostgresTable::OpenRelation(Oid relid) {
 	std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());
-	return PostgresFunctionGuard(::RelationIdGetRelation, relid);
+	return PostgresFunctionGuard(RelationIdGetRelation, relid);
 }
 
 void
-PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, ::Relation rel) {
+PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, Relation rel) {
 	auto tupleDesc = RelationGetDescr(rel);
 
 	for (int i = 0; i < tupleDesc->natts; ++i) {
@@ -47,7 +47,7 @@ PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, ::Relation rel) {
 }
 
 Cardinality
-PostgresTable::GetTableCardinality(::Relation rel) {
+PostgresTable::GetTableCardinality(Relation rel) {
 	Cardinality cardinality;
 	BlockNumber n_pages;
 	double allvisfrac;
@@ -60,7 +60,7 @@ PostgresTable::GetTableCardinality(::Relation rel) {
 //===--------------------------------------------------------------------===//
 
 PostgresHeapTable::PostgresHeapTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntry &schema,
-                                     duckdb::CreateTableInfo &info, ::Relation rel, Cardinality cardinality,
+                                     duckdb::CreateTableInfo &info, Relation rel, Cardinality cardinality,
                                      Snapshot snapshot)
     : PostgresTable(catalog, schema, info, rel, cardinality, snapshot) {
 }

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -61,7 +61,7 @@ SchemaItems::GetTable(const duckdb::string &entry_name) {
 
 	ReleaseSysCache(tuple);
 
-	::Relation rel = PostgresTable::OpenRelation(rel_oid);
+	Relation rel = PostgresTable::OpenRelation(rel_oid);
 
 	duckdb::CreateTableInfo info;
 	info.table = entry_name;

--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -44,7 +44,7 @@ PostgresSeqScanLocalState::~PostgresSeqScanLocalState() {
 // PostgresSeqScanFunctionData
 //
 
-PostgresSeqScanFunctionData::PostgresSeqScanFunctionData(::Relation rel, uint64_t cardinality, Snapshot snapshot)
+PostgresSeqScanFunctionData::PostgresSeqScanFunctionData(Relation rel, uint64_t cardinality, Snapshot snapshot)
     : m_rel(rel), m_cardinality(cardinality), m_snapshot(snapshot) {
 }
 


### PR DESCRIPTION
Now that #387 is merged, we don't have name conflicts between DuckDB and PG names. This PR removes the top-level namespace qualifiers.