### PR TITLE
Automatically detect DuckDB update in Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+!.git/modules/third_party/duckdb/HEAD
 *.o
 *.so
 *.dylib

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ USER postgres
 # for each directory, because docker puts only the contents of the source
 # directory into the target directory, and not the directory itself too.
 COPY --chown=postgres:postgres Makefile Makefile.global pg_duckdb.control .
+COPY --chown=postgres:postgres .git/modules/third_party/duckdb/HEAD .git/modules/third_party/duckdb/HEAD
 COPY --chown=postgres:postgres sql sql
 COPY --chown=postgres:postgres src src
 COPY --chown=postgres:postgres include include

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,12 @@ SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUI
 
 include Makefile.global
 
-# We need the DuckDB header files to build the .o files. We depend on the
-# duckdb Makefile, because that target pulls in the submodule which includes
-# those header files.
-$(OBJS): third_party/duckdb/Makefile
+# We need the DuckDB header files to build our own .o files. We depend on the
+# duckdb submodule HEAD, because that target pulls in the submodule which
+# includes those header files. This does mean that we rebuild our .o files
+# whenever we change the DuckDB version, but that seems like a fairly
+# reasonable thing to do anyway, even if not always strictly necessary always.
+$(OBJS): .git/modules/third_party/duckdb/HEAD
 
 COMPILE.cc.bc += $(PG_CPPFLAGS)
 COMPILE.cxx.bc += $(PG_CXXFLAGS)
@@ -73,10 +75,10 @@ check: installcheck pycheck
 
 duckdb: $(FULL_DUCKDB_LIB)
 
-third_party/duckdb/Makefile:
+.git/modules/third_party/duckdb/HEAD:
 	git submodule update --init --recursive
 
-$(FULL_DUCKDB_LIB): third_party/duckdb/Makefile
+$(FULL_DUCKDB_LIB): .git/modules/third_party/duckdb/HEAD
 	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
 	GEN=$(DUCKDB_GEN) \
 	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)" \


### PR DESCRIPTION
After updating my submodules for #400 I had to call `make clean-duckdb`
to trigger a rebuild of duckdb. This changes our Makefile to
automatically detect changes in the submodule.
