### PR TITLE
Cache DuckDB connection object and hook into PG transaction life cycle

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_transaction.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_state.hpp"
 #include "duckdb/transaction/transaction.hpp"
 #include "pgduckdb/pg_declarations.hpp"
 
@@ -8,6 +10,8 @@ namespace pgduckdb {
 class PostgresCatalog;
 class PostgresSchema;
 class PostgresTable;
+
+void ClosePostgresRelations(duckdb::ClientContext &context);
 
 class SchemaItems {
 public:
@@ -23,6 +27,12 @@ private:
 	duckdb::case_insensitive_map_t<duckdb::unique_ptr<PostgresTable>> tables;
 };
 
+class PostgresContextState : public duckdb::ClientContextState {
+public:
+	duckdb::case_insensitive_map_t<SchemaItems> schemas;
+	void QueryEnd() override;
+};
+
 class PostgresTransaction : public duckdb::Transaction {
 public:
 	PostgresTransaction(duckdb::TransactionManager &manager, duckdb::ClientContext &context, PostgresCatalog &catalog,
@@ -35,7 +45,6 @@ public:
 private:
 	duckdb::optional_ptr<duckdb::CatalogEntry> GetSchema(const duckdb::string &name);
 
-	duckdb::case_insensitive_map_t<SchemaItems> schemas;
 	PostgresCatalog &catalog;
 	Snapshot snapshot;
 };

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -18,7 +18,6 @@ public:
 	}
 
 	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
-
 	static duckdb::Connection *GetConnection();
 	static duckdb::Connection *GetConnectionUnsafe();
 

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -2,6 +2,12 @@
 
 #include "duckdb.hpp"
 
+// FIXME: Make sure we don't need this
+extern "C" {
+#include "postgres.h"
+#include "access/xact.h"
+}
+
 namespace pgduckdb {
 
 class DuckDBManager {
@@ -16,6 +22,8 @@ public:
 	}
 
 	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
+
+	static duckdb::Connection *GetConnection();
 
 	inline const std::string &
 	GetDefaultDBName() const {
@@ -39,6 +47,10 @@ private:
 	void DropSecrets(duckdb::ClientContext &);
 	void LoadExtensions(duckdb::ClientContext &);
 	void LoadFunctions(duckdb::ClientContext &);
+	void RefreshConnectionState(duckdb::ClientContext &);
+
+	static void DuckdbXactCallback_Cpp(XactEvent event, void *arg);
+	static void DuckdbXactCallback(XactEvent event, void *arg);
 
 	inline bool
 	IsSecretSeqLessThan(int64_t seq) const {
@@ -60,7 +72,6 @@ private:
 		extensions_table_current_seq = seq;
 	}
 
-	bool disabled_filesystems_is_set;
 	int secret_table_num_rows;
 	int64_t secret_table_current_seq;
 	int64_t extensions_table_current_seq;
@@ -76,6 +87,7 @@ private:
 	 * as the one reported in #279).
 	 */
 	duckdb::DuckDB *database;
+	duckdb::unique_ptr<duckdb::Connection> connection;
 	std::string default_dbname;
 };
 

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -2,13 +2,9 @@
 
 #include "duckdb.hpp"
 
-// FIXME: Make sure we don't need this
-extern "C" {
-#include "postgres.h"
-#include "access/xact.h"
-}
-
 namespace pgduckdb {
+
+extern bool started_duckdb_transaction;
 
 class DuckDBManager {
 public:
@@ -24,6 +20,7 @@ public:
 	static duckdb::unique_ptr<duckdb::Connection> CreateConnection();
 
 	static duckdb::Connection *GetConnection();
+	static duckdb::Connection *GetConnectionUnsafe();
 
 	inline const std::string &
 	GetDefaultDBName() const {
@@ -48,9 +45,6 @@ private:
 	void LoadExtensions(duckdb::ClientContext &);
 	void LoadFunctions(duckdb::ClientContext &);
 	void RefreshConnectionState(duckdb::ClientContext &);
-
-	static void DuckdbXactCallback_Cpp(XactEvent event, void *arg);
-	static void DuckdbXactCallback(XactEvent event, void *arg);
 
 	inline bool
 	IsSecretSeqLessThan(int64_t seq) const {

--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -13,5 +13,4 @@ extern bool duckdb_explain_analyze;
 
 PlannedStmt *DuckdbPlanNode(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params,
                             bool throw_error);
-std::tuple<duckdb::unique_ptr<duckdb::PreparedStatement>, duckdb::unique_ptr<duckdb::Connection>>
-DuckdbPrepare(const Query *query);
+duckdb::unique_ptr<duckdb::PreparedStatement> DuckdbPrepare(const Query *query);

--- a/include/pgduckdb/pgduckdb_xact.hpp
+++ b/include/pgduckdb/pgduckdb_xact.hpp
@@ -1,0 +1,3 @@
+namespace pgduckdb {
+void RegisterDuckdbXactCallback();
+}

--- a/src/catalog/pgduckdb_transaction.cpp
+++ b/src/catalog/pgduckdb_transaction.cpp
@@ -15,6 +15,12 @@ extern "C" {
 
 namespace pgduckdb {
 
+void
+ClosePostgresRelations(duckdb::ClientContext &context) {
+	auto context_state = context.registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
+	context_state->QueryEnd();
+}
+
 PostgresTransaction::PostgresTransaction(duckdb::TransactionManager &manager, duckdb::ClientContext &context,
                                          PostgresCatalog &catalog, Snapshot snapshot)
     : duckdb::Transaction(manager, context), catalog(catalog), snapshot(snapshot) {
@@ -24,7 +30,7 @@ PostgresTransaction::~PostgresTransaction() {
 }
 
 SchemaItems::SchemaItems(duckdb::unique_ptr<PostgresSchema> &&schema, const duckdb::string &name)
-	: name(name), schema(std::move(schema)) {
+    : name(name), schema(std::move(schema)) {
 }
 
 duckdb::optional_ptr<duckdb::CatalogEntry>
@@ -85,16 +91,23 @@ SchemaItems::GetSchema() const {
 
 duckdb::optional_ptr<duckdb::CatalogEntry>
 PostgresTransaction::GetSchema(const duckdb::string &name) {
-	auto it = schemas.find(name);
-	if (it != schemas.end()) {
+	auto context_state = context.lock()->registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
+	auto schemas = &context_state->schemas;
+	auto it = schemas->find(name);
+	if (it != schemas->end()) {
 		return it->second.GetSchema();
 	}
 
 	duckdb::CreateSchemaInfo create_schema;
 	create_schema.schema = name;
 	auto pg_schema = duckdb::make_uniq<PostgresSchema>(catalog, create_schema, snapshot);
-	schemas.emplace(std::make_pair(name, SchemaItems(std::move(pg_schema), name)));
-	return schemas.at(name).GetSchema();
+	schemas->emplace(std::make_pair(name, SchemaItems(std::move(pg_schema), name)));
+	return schemas->at(name).GetSchema();
+}
+
+void
+PostgresContextState::QueryEnd() {
+	schemas.clear();
 }
 
 duckdb::optional_ptr<duckdb::CatalogEntry>
@@ -102,8 +115,10 @@ PostgresTransaction::GetCatalogEntry(duckdb::CatalogType type, const duckdb::str
                                      const duckdb::string &name) {
 	switch (type) {
 	case duckdb::CatalogType::TABLE_ENTRY: {
-		auto it = schemas.find(schema);
-		if (it == schemas.end()) {
+		auto context_state = context.lock()->registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
+		auto schemas = &context_state->schemas;
+		auto it = schemas->find(schema);
+		if (it == schemas->end()) {
 			return nullptr;
 		}
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -554,11 +554,11 @@ SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 
 	initial_cache_version = pgduckdb::CacheVersion();
 
-	auto connection = pgduckdb::DuckDBManager::Get().CreateConnection();
+	auto connection = pgduckdb::DuckDBManager::GetConnection();
 	auto &context = *connection->context;
 
 	auto &db_manager = duckdb::DatabaseManager::Get(context);
-	const auto& default_db = db_manager.GetDefaultDatabase(context);
+	const auto &default_db = db_manager.GetDefaultDatabase(context);
 	auto result =
 	    context.Query("SELECT alias, server_catalog_version::text FROM __md_local_databases_metadata()", false);
 	if (result->HasError()) {

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -328,8 +328,10 @@ DuckDBManager::GetConnection() {
 
 /*
  * Returns the cached connection to the global DuckDB instance, but does not do
- * any checks nor refreshes the connection state. Only use this in rare cases
- * where you know the connection is already in a good state.
+ * any checks required to correctly initialize the DuckDB transaction nor
+ * refreshes the secrets/extensions/etc. Only use this in rare cases where you
+ * know for sure that the connection is already initialized for the correctly
+ * for the current query, and you just want a pointer to it.
  */
 duckdb::Connection *
 DuckDBManager::GetConnectionUnsafe() {

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -160,6 +160,8 @@ DuckdbCacheObject(Datum object, Datum type) {
 		return false;
 	}
 
+	/* Use a separate connection to cache the objects, so we are sure not to
+	 * leak the value change of enable_http_file_cache in case of an error */
 	auto con = DuckDBManager::CreateConnection();
 	auto &context = *con->context;
 
@@ -169,7 +171,6 @@ DuckdbCacheObject(Datum object, Datum type) {
 	auto cache_object_query =
 	    duckdb::StringUtil::Format("SELECT 1 FROM %s('%s');", object_type_fun, object_path.c_str());
 	DuckDBQueryOrThrow(context, cache_object_query);
-	DuckDBQueryOrThrow(context, "SET enable_http_file_cache TO false;");
 
 	return true;
 }

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -102,15 +102,6 @@ CreatePlan(Query *query, bool throw_error) {
 	duckdb_node->custom_private = list_make1(query);
 	duckdb_node->methods = &duckdb_scan_scan_methods;
 
-	/*
-	 * We close the relations here, to make sure we don't leak references to
-	 * the execution phase, because a different ResourceOwner is used there.
-	 * So we re-open them during actual query execution with the correct
-	 * ResourceOwner.
-	 */
-	auto duckdb_connection = pgduckdb::DuckDBManager::GetConnection();
-	pgduckdb::ClosePostgresRelations(*duckdb_connection->context);
-
 	return (Plan *)duckdb_node;
 }
 

--- a/src/pgduckdb_utils.cpp
+++ b/src/pgduckdb_utils.cpp
@@ -18,9 +18,8 @@ DuckDBQueryOrThrow(duckdb::Connection &connection, const std::string &query) {
 
 duckdb::unique_ptr<duckdb::QueryResult>
 DuckDBQueryOrThrow(const std::string &query) {
-	auto connection = pgduckdb::DuckDBManager::CreateConnection();
+	auto connection = pgduckdb::DuckDBManager::GetConnection();
 	return DuckDBQueryOrThrow(*connection, query);
 }
 
 } // namespace pgduckdb
-

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -1,0 +1,61 @@
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+#include "pgduckdb/pgduckdb_utils.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "access/xact.h" // RegisterXactCallback and XactEvent
+}
+
+namespace pgduckdb {
+
+static void
+DuckdbXactCallback_Cpp(XactEvent event, void *arg) {
+	if (!started_duckdb_transaction) {
+		return;
+	}
+	auto connection = DuckDBManager::GetConnectionUnsafe();
+	auto &context = *connection->context;
+
+	switch (event) {
+	case XACT_EVENT_PRE_COMMIT:
+	case XACT_EVENT_PARALLEL_PRE_COMMIT:
+		// Commit the DuckDB transaction too
+		context.transaction.Commit();
+		started_duckdb_transaction = false;
+		break;
+
+	case XACT_EVENT_ABORT:
+	case XACT_EVENT_PARALLEL_ABORT:
+		// Abort the Postgres transaction too
+		context.transaction.Rollback(nullptr);
+		started_duckdb_transaction = false;
+		break;
+
+	case XACT_EVENT_PREPARE:
+	case XACT_EVENT_PRE_PREPARE:
+		// Throw an error for prepare events
+		throw duckdb::NotImplementedException("Prepared transactions are not implemented in DuckDB.");
+
+	case XACT_EVENT_COMMIT:
+	case XACT_EVENT_PARALLEL_COMMIT:
+		// No action needed for commit event, we already did committed the
+		// DuckDB transaction in the PRE_COMMIT event.
+		break;
+
+	default:
+		// Fail hard if future PG versions introduce a new event
+		throw duckdb::NotImplementedException("Not implemented XactEvent: %d", event);
+	}
+}
+
+static void
+DuckdbXactCallback(XactEvent event, void *arg) {
+	InvokeCPPFunc(DuckdbXactCallback_Cpp, event, arg);
+}
+
+void
+RegisterDuckdbXactCallback() {
+	PostgresFunctionGuard(RegisterXactCallback, DuckdbXactCallback, nullptr);
+}
+
+} // namespace pgduckdb

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -41,8 +41,8 @@ DuckdbXactCallback_Cpp(XactEvent event, void *arg) {
 		// No action needed for commit event, we already did committed the
 		// DuckDB transaction in the PRE_COMMIT event. We don't commit the
 		// DuckDB transaction here, because any failure to commit would
-		// then turn into a Postgres PANIC (i.e. a crash). To quote the relevant postgres
-		// comment:
+		// then turn into a Postgres PANIC (i.e. a crash). To quote the
+		// relevant Postgres comment:
 		// > Note that if an error is raised here, it's too late to abort
 		// > the transaction. This should be just noncritical resource
 		// > releasing.

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -39,7 +39,13 @@ DuckdbXactCallback_Cpp(XactEvent event, void *arg) {
 	case XACT_EVENT_COMMIT:
 	case XACT_EVENT_PARALLEL_COMMIT:
 		// No action needed for commit event, we already did committed the
-		// DuckDB transaction in the PRE_COMMIT event.
+		// DuckDB transaction in the PRE_COMMIT event. We don't commit the
+		// DuckDB transaction here, because any failure to commit would
+		// then turn into a Postgres PANIC (i.e. a crash). To quote the relevant postgres
+		// comment:
+		// > Note that if an error is raised here, it's too late to abort
+		// > the transaction. This should be just noncritical resource
+		// > releasing.
 		break;
 
 	default:

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -26,7 +26,7 @@ DuckdbXactCallback_Cpp(XactEvent event, void *arg) {
 
 	case XACT_EVENT_ABORT:
 	case XACT_EVENT_PARALLEL_ABORT:
-		// Abort the Postgres transaction too
+		// Abort the DuckDB transaction too
 		context.transaction.Rollback(nullptr);
 		started_duckdb_transaction = false;
 		break;


### PR DESCRIPTION
Instead of creating a new `duckdb::Connection` over and over again, this starts caching the DuckDB connection. For this to work correctly in case of errors we need to link DuckDB and Postgres its transaction life cycle together. Otherwise DuckDB state from a previous PG query might accidentally survive until the next PG. This is also in preparation of supporting multi-statement transactions.

There was one more problem to solve: This PR changes the lifecycle of the `duckdb::Transaction`. 
Before the lifecycle of the different components was as follows, from long-lived to short-lived:
1. Postgres transaction
2. Postgres query
3. DuckDB transaction
4. DuckDB query

Now 2 and 3 are swapped:
1. Postgres transaction
2. DuckDB transaction
3. Postgres query
4. DuckDB query

This causes problems, because the `Relation` from the Postgres relcache should always be closed before the end of the postgres query. Previously we bound `SchemaItems` cache to the lifecycle of the DuckDB transaction, which now outlives the postgres query. To solve this we change its lifecycle to be bound the the DuckDB query.