### PR TITLE
Remove PG code from pgduckdb_tables

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_schema.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_schema.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
+
+#include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgduckdb {
 

--- a/include/pgduckdb/catalog/pgduckdb_table.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_table.hpp
@@ -3,7 +3,9 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
+
+#include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgduckdb {
 

--- a/include/pgduckdb/catalog/pgduckdb_transaction.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction.hpp
@@ -3,7 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/transaction/transaction.hpp"
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 #include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 

--- a/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction_manager.hpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/common/reference_map.hpp"
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 #include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 

--- a/include/pgduckdb/logger.hpp
+++ b/include/pgduckdb/logger.hpp
@@ -6,6 +6,7 @@ extern "C" {
 bool errstart(int elevel, const char *domain);
 void errfinish(const char *filename, int lineno, const char *funcname);
 int	errmsg_internal(const char *fmt,...);
+bool message_level_is_interesting(int elevel);
 }
 
 namespace pgduckdb {
@@ -24,6 +25,12 @@ namespace pgduckdb {
 #define WARNING_CLIENT_ONLY	20
 
 // From PG elog.h
+#ifdef __GNUC__
+#define pg_attribute_unused() __attribute__((unused))
+#else
+#define pg_attribute_unused()
+#endif
+
 #if defined(errno) && defined(__linux__)
 #define pd_prevent_errno_in_scope() int __errno_location pg_attribute_unused()
 #elif defined(errno) && (defined(__darwin__) || defined(__FreeBSD__))

--- a/include/pgduckdb/pg/declarations.hpp
+++ b/include/pgduckdb/pg/declarations.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <inttypes.h>
+
 /*
 This file contains a few Postgres declarations.
 
@@ -10,10 +12,19 @@ It should not include any C++ code, only Postgres C declarations.
 */
 
 extern "C" {
+typedef uint32_t BlockNumber;
+
 typedef double Cardinality;
+
+typedef uintptr_t Datum;
+
+struct FormData_pg_attribute;
+typedef FormData_pg_attribute *Form_pg_attribute;
 
 struct FormData_pg_class;
 typedef FormData_pg_class *Form_pg_class;
+
+struct HeapTupleData;
 
 struct Node;
 
@@ -24,5 +35,10 @@ typedef struct RelationData *Relation;
 
 struct SnapshotData;
 typedef struct SnapshotData *Snapshot;
+
+struct TupleDescData;
+typedef struct TupleDescData *TupleDesc;
+
+struct TupleTableSlot;
 
 }

--- a/include/pgduckdb/pg/relations.hpp
+++ b/include/pgduckdb/pg/relations.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "pgduckdb/pg/declarations.hpp"
+
+namespace pgduckdb {
+
+TupleDesc PDRelationGetDescr(Relation relation);
+
+// Not thread-safe. Must be called under a lock.
+Relation OpenRelation(Oid relationId);
+
+// Not thread-safe. Must be called under a lock.
+void CloseRelation(Relation relation);
+
+int GetTupleDescNatts(const TupleDesc tupleDesc);
+
+const char *GetAttName(const Form_pg_attribute);
+
+Form_pg_attribute GetAttr(const TupleDesc tupleDesc, int i);
+
+void EstimateRelSize(Relation rel, int32_t *attr_widths, BlockNumber *pages, double *tuples, double *allvisfrac);
+
+}

--- a/include/pgduckdb/pg/relations.hpp
+++ b/include/pgduckdb/pg/relations.hpp
@@ -4,7 +4,7 @@
 
 namespace pgduckdb {
 
-TupleDesc PDRelationGetDescr(Relation relation);
+TupleDesc RelationGetDescr(Relation relation);
 
 // Not thread-safe. Must be called under a lock.
 Relation OpenRelation(Oid relationId);

--- a/include/pgduckdb/pg/snapshots.hpp
+++ b/include/pgduckdb/pg/snapshots.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+extern "C" {
+extern Snapshot GetActiveSnapshot(void);
+}

--- a/include/pgduckdb/pgduckdb_ddl.hpp
+++ b/include/pgduckdb/pgduckdb_ddl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 void DuckdbHandleDDL(Node *ParseTree, const char *queryString);
 void DuckdbTruncateTable(Oid relation_oid);

--- a/include/pgduckdb/pgduckdb_metadata_cache.hpp
+++ b/include/pgduckdb/pgduckdb_metadata_cache.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pgduckdb/pg_declarations.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 namespace pgduckdb {
 bool IsExtensionRegistered();

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -6,18 +6,18 @@ namespace pgduckdb {
 
 class PostgresScanGlobalState;
 class PostgresScanLocalState;
-typedef uint64_t idx_t; // From duckdb.h
 
 // DuckDB has date starting from 1/1/1970 while PG starts from 1/1/2000
 constexpr int32_t PGDUCKDB_DUCK_DATE_OFFSET = 10957;
-constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET = static_cast<int64_t>(10957) * static_cast<int64_t>(86400000000) /* USECS_PER_DAY */;
+constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET =
+    static_cast<int64_t>(PGDUCKDB_DUCK_DATE_OFFSET) * static_cast<int64_t>(86400000000) /* USECS_PER_DAY */;
 
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(duckdb::LogicalType type);
 int32_t GetPostgresDuckDBTypemod(duckdb::LogicalType type);
 duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type);
-void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, idx_t offset);
-bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);
+void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, uint64_t offset);
+bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, uint64_t col);
 void InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanGlobalState> scan_global_state,
                           duckdb::shared_ptr<PostgresScanLocalState> scan_local_state, HeapTupleData *tuple);
 

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -1,25 +1,20 @@
 #pragma once
 
-#include "duckdb.hpp"
-#include "duckdb/common/shared_ptr.hpp"
-#include "duckdb/common/extra_type_info.hpp"
-
-extern "C" {
-#include "postgres.h"
-#include "executor/tuptable.h"
-}
-
-#include "pgduckdb/scan/postgres_scan.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 namespace pgduckdb {
 
+class PostgresScanGlobalState;
+class PostgresScanLocalState;
+typedef uint64_t idx_t; // From duckdb.h
+
 // DuckDB has date starting from 1/1/1970 while PG starts from 1/1/2000
 constexpr int32_t PGDUCKDB_DUCK_DATE_OFFSET = 10957;
-constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET = INT64CONST(10957) * USECS_PER_DAY;
+constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET = static_cast<int64_t>(10957) * static_cast<int64_t>(86400000000) /* USECS_PER_DAY */;
 
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(duckdb::LogicalType type);
-int32 GetPostgresDuckDBTypemod(duckdb::LogicalType type);
+int32_t GetPostgresDuckDBTypemod(duckdb::LogicalType type);
 duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type);
 void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, idx_t offset);
 bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col);

--- a/include/pgduckdb/scan/postgres_seq_scan.hpp
+++ b/include/pgduckdb/scan/postgres_seq_scan.hpp
@@ -3,10 +3,14 @@
 #include "duckdb.hpp"
 
 #include "pgduckdb/pgduckdb_guc.h"
-#include "pgduckdb/scan/postgres_scan.hpp"
-#include "pgduckdb/scan/heap_reader.hpp"
+#include "pgduckdb/pg/declarations.hpp"
 
 namespace pgduckdb {
+
+class HeapReaderGlobalState;
+class HeapReader;
+class PostgresScanGlobalState;
+class PostgresScanLocalState;
 
 // Global State
 

--- a/include/pgduckdb/utility/rename_ruleutils.h
+++ b/include/pgduckdb/utility/rename_ruleutils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  * This file contains the renaming of the functions exposed by
  * vendor/pg_ruleutils.h functions to avoid conflicts with the PostgreSQL

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -1,19 +1,15 @@
-#include "pgduckdb/pgduckdb_types.hpp"
-#include "pgduckdb/pgduckdb_process_lock.hpp"
-#include "pgduckdb/catalog/pgduckdb_schema.hpp"
 #include "pgduckdb/catalog/pgduckdb_table.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
-#include "pgduckdb/scan/postgres_seq_scan.hpp"
-#include "pgduckdb/scan/postgres_scan.hpp"
-#include "pgduckdb/pgduckdb_utils.hpp"
-#include "pgduckdb/logger.hpp"
 
-extern "C" {
-#include "access/relation.h"   // relation_open and relation_close
-#include "utils/rel.h"         // RelationGetDescr
-#include "optimizer/plancat.h" // estimate_rel_size
-#include "catalog/namespace.h" // makeRangeVarFromNameList
-}
+#include "pgduckdb/catalog/pgduckdb_schema.hpp"
+#include "pgduckdb/logger.hpp"
+#include "pgduckdb/pg/relations.hpp"
+#include "pgduckdb/pgduckdb_process_lock.hpp"
+#include "pgduckdb/pgduckdb_types.hpp" // ConvertPostgresToDuckColumnType
+#include "pgduckdb/scan/postgres_seq_scan.hpp"
+
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+
+#include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgduckdb {
 
@@ -24,44 +20,23 @@ PostgresTable::PostgresTable(duckdb::Catalog &catalog, duckdb::SchemaCatalogEntr
 
 PostgresTable::~PostgresTable() {
 	std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());
-
-	/*
-	 * We always open & close the relation using the
-	 * TopTransactionResourceOwner to avoid having to close the relation
-	 * whenever Postgres switches resource owners, because opening a relation
-	 * with one resource owner and closing it with another is not allowed.
-	 */
-	ResourceOwner saveResourceOwner = CurrentResourceOwner;
-	CurrentResourceOwner = TopTransactionResourceOwner;
-	PostgresFunctionGuard(relation_close, rel, NoLock);
-
-	CurrentResourceOwner = saveResourceOwner;
+	CloseRelation(rel);
 }
 
 Relation
 PostgresTable::OpenRelation(Oid relid) {
 	std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());
-
-	/*
-	 * We always open & close the relation using the
-	 * TopTransactionResourceOwner to avoid having to close the relation
-	 * whenever Postgres switches resource owners, because opening a relation
-	 * with one resource owner and closing it with another is not allowed.
-	 */
-	ResourceOwner saveResourceOwner = CurrentResourceOwner;
-	CurrentResourceOwner = TopTransactionResourceOwner;
-	auto relation = PostgresFunctionGuard(relation_open, relid, AccessShareLock);
-	CurrentResourceOwner = saveResourceOwner;
-	return relation;
+	return pgduckdb::OpenRelation(relid);
 }
 
 void
 PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, Relation rel) {
-	auto tupleDesc = RelationGetDescr(rel);
+	auto tupleDesc = PDRelationGetDescr(rel);
 
-	for (int i = 0; i < tupleDesc->natts; ++i) {
-		Form_pg_attribute attr = &tupleDesc->attrs[i];
-		auto col_name = duckdb::string(NameStr(attr->attname));
+	const auto n = GetTupleDescNatts(tupleDesc);
+	for (int i = 0; i < n; ++i) {
+		Form_pg_attribute attr = GetAttr(tupleDesc, i);
+		auto col_name = duckdb::string(GetAttName(attr));
 		auto duck_type = ConvertPostgresToDuckColumnType(attr);
 		info.columns.AddColumn(duckdb::ColumnDefinition(col_name, duck_type));
 		/* Log column name and type */
@@ -75,7 +50,7 @@ PostgresTable::GetTableCardinality(Relation rel) {
 	Cardinality cardinality;
 	BlockNumber n_pages;
 	double allvisfrac;
-	estimate_rel_size(rel, NULL, &n_pages, &cardinality, &allvisfrac);
+	EstimateRelSize(rel, NULL, &n_pages, &cardinality, &allvisfrac);
 	return cardinality;
 }
 

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -31,7 +31,7 @@ PostgresTable::OpenRelation(Oid relid) {
 
 void
 PostgresTable::SetTableInfo(duckdb::CreateTableInfo &info, Relation rel) {
-	auto tupleDesc = PDRelationGetDescr(rel);
+	auto tupleDesc = RelationGetDescr(rel);
 
 	const auto n = GetTupleDescNatts(tupleDesc);
 	for (int i = 0; i < n; ++i) {

--- a/src/catalog/pgduckdb_transaction_manager.cpp
+++ b/src/catalog/pgduckdb_transaction_manager.cpp
@@ -1,16 +1,12 @@
 #include "pgduckdb/catalog/pgduckdb_transaction_manager.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "pgduckdb/catalog/pgduckdb_transaction.hpp"
-#include "pgduckdb/catalog/pgduckdb_schema.hpp"
-#include "pgduckdb/catalog/pgduckdb_table.hpp"
+#include "pgduckdb/pg/snapshots.hpp"
 #include "pgduckdb/pgduckdb_process_lock.hpp"
 
 #include "duckdb/main/attached_database.hpp"
 
-extern "C" {
-#include "postgres.h"
-#include "utils/snapmgr.h" // GetActiveSnapshot
-}
+#include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgduckdb {
 

--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -1,0 +1,63 @@
+#include "pgduckdb/pg/relations.hpp"
+
+#include "pgduckdb/pgduckdb_utils.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "access/relation.h"   // relation_open and relation_close
+#include "optimizer/plancat.h" // estimate_rel_size
+#include "utils/rel.h"
+#include "utils/resowner.h" // CurrentResourceOwner and TopTransactionResourceOwner
+}
+
+namespace pgduckdb {
+
+TupleDesc PDRelationGetDescr(Relation relation) {
+	return relation->rd_att;
+}
+
+int GetTupleDescNatts(const TupleDesc tupleDesc) {
+	return tupleDesc->natts;
+}
+
+const char *GetAttName(const Form_pg_attribute att) {
+	return NameStr(att->attname);
+}
+
+Form_pg_attribute GetAttr(const TupleDesc tupleDesc, int i) {
+	return &tupleDesc->attrs[i];
+}
+
+Relation OpenRelation(Oid relationId) {
+	/*
+	 * We always open & close the relation using the
+	 * TopTransactionResourceOwner to avoid having to close the relation
+	 * whenever Postgres switches resource owners, because opening a relation
+	 * with one resource owner and closing it with another is not allowed.
+	 */
+	ResourceOwner saveResourceOwner = CurrentResourceOwner;
+	CurrentResourceOwner = TopTransactionResourceOwner;
+	auto rel = PostgresFunctionGuard(relation_open, relationId, AccessShareLock);
+	CurrentResourceOwner = saveResourceOwner;
+	return rel;
+}
+
+void CloseRelation(Relation rel) {
+	/*
+	 * We always open & close the relation using the
+	 * TopTransactionResourceOwner to avoid having to close the relation
+	 * whenever Postgres switches resource owners, because opening a relation
+	 * with one resource owner and closing it with another is not allowed.
+	 */
+	ResourceOwner saveResourceOwner = CurrentResourceOwner;
+	CurrentResourceOwner = TopTransactionResourceOwner;
+	PostgresFunctionGuard(relation_close, rel, NoLock);
+
+	CurrentResourceOwner = saveResourceOwner;
+}
+
+void EstimateRelSize(Relation rel, int32_t *attr_widths, BlockNumber *pages, double *tuples, double *allvisfrac) {
+	::estimate_rel_size(rel, attr_widths, pages, tuples, allvisfrac);
+}
+
+} // namespace pgduckdb

--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -12,8 +12,10 @@ extern "C" {
 
 namespace pgduckdb {
 
-TupleDesc PDRelationGetDescr(Relation relation) {
-	return relation->rd_att;
+#undef RelationGetDescr
+
+TupleDesc RelationGetDescr(Relation rel) {
+	return rel->rd_att;
 }
 
 int GetTupleDescNatts(const TupleDesc tupleDesc) {
@@ -57,7 +59,7 @@ void CloseRelation(Relation rel) {
 }
 
 void EstimateRelSize(Relation rel, int32_t *attr_widths, BlockNumber *pages, double *tuples, double *allvisfrac) {
-	::estimate_rel_size(rel, attr_widths, pages, tuples, allvisfrac);
+	PostgresFunctionGuard(estimate_rel_size, rel, attr_widths, pages, tuples, allvisfrac);
 }
 
 } // namespace pgduckdb

--- a/src/pgduckdb_filter.cpp
+++ b/src/pgduckdb_filter.cpp
@@ -7,6 +7,9 @@ extern "C" {
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/timestamp.h"
+#if PG_VERSION_NUM >= 160000
+#include "varatt.h"
+#endif
 }
 
 #include "pgduckdb/pgduckdb_filter.hpp"

--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -16,7 +16,7 @@ PostgresSeqScanGlobalState::PostgresSeqScanGlobalState(Relation rel, duckdb::Tab
     : m_global_state(duckdb::make_shared_ptr<PostgresScanGlobalState>()),
       m_heap_reader_global_state(duckdb::make_shared_ptr<HeapReaderGlobalState>(rel)), m_rel(rel) {
 	m_global_state->InitGlobalState(input);
-	m_global_state->m_tuple_desc = PDRelationGetDescr(m_rel);
+	m_global_state->m_tuple_desc = RelationGetDescr(m_rel);
 	m_global_state->InitRelationMissingAttrs(m_global_state->m_tuple_desc);
 	pd_log(DEBUG2, "(DuckDB/PostgresSeqScanGlobalState) Running %" PRIu64 " threads -- ", (uint64_t)MaxThreads());
 }

--- a/src/scan/postgres_seq_scan.cpp
+++ b/src/scan/postgres_seq_scan.cpp
@@ -3,11 +3,8 @@
 #include "pgduckdb/scan/postgres_seq_scan.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/logger.hpp"
-#include <inttypes.h>
-
-extern "C" {
-#include "utils/rel.h" // RelationGetDescr
-}
+#include "pgduckdb/scan/heap_reader.hpp"
+#include "pgduckdb/pg/relations.hpp"
 
 namespace pgduckdb {
 
@@ -19,7 +16,7 @@ PostgresSeqScanGlobalState::PostgresSeqScanGlobalState(Relation rel, duckdb::Tab
     : m_global_state(duckdb::make_shared_ptr<PostgresScanGlobalState>()),
       m_heap_reader_global_state(duckdb::make_shared_ptr<HeapReaderGlobalState>(rel)), m_rel(rel) {
 	m_global_state->InitGlobalState(input);
-	m_global_state->m_tuple_desc = RelationGetDescr(m_rel);
+	m_global_state->m_tuple_desc = PDRelationGetDescr(m_rel);
 	m_global_state->InitRelationMissingAttrs(m_global_state->m_tuple_desc);
 	pd_log(DEBUG2, "(DuckDB/PostgresSeqScanGlobalState) Running %" PRIu64 " threads -- ", (uint64_t)MaxThreads());
 }


### PR DESCRIPTION
Convert `pgduckdb_tables` file to a pure C++ file.