### PR TITLE
Make `InsertTupleIntoChunk` more efficient

### DIFF
--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -34,6 +34,8 @@ public:
 	std::vector<duckdb::TableFilter *> m_column_filters;
 	/* Duckdb output vector idx with information about postgres column id */
 	duckdb::vector<duckdb::pair<duckdb::idx_t, AttrNumber>> m_output_columns;
+	/* Maps attribute number to output index for quick lookup */
+    duckdb::map<duckdb::idx_t, duckdb::idx_t> m_attr_to_output_map;
 	std::atomic<std::uint32_t> m_total_row_count;
 	duckdb::map<int, Datum> m_relation_missing_attrs;
 };

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -34,8 +34,8 @@ public:
 	std::vector<duckdb::TableFilter *> m_column_filters;
 	/* Duckdb output vector idx with information about postgres column id */
 	duckdb::vector<duckdb::pair<duckdb::idx_t, AttrNumber>> m_output_columns;
-	/* Maps attribute number to output index for quick lookup */
-    duckdb::map<duckdb::idx_t, duckdb::idx_t> m_attr_to_output_map;
+	/* Store the column ID which needs to output in the set for quick lookup */
+    duckdb::set<AttrNumber> attr_to_output_set;
 	std::atomic<std::uint32_t> m_total_row_count;
 	duckdb::map<int, Datum> m_relation_missing_attrs;
 };

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1091,7 +1091,7 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, duckdb::shared_ptr<PostgresScanG
 		    HeapTupleFetchNextColumnDatum(scan_global_state->m_tuple_desc, tuple, heap_tuple_read_state, attr_num,
 		                                  &is_null, scan_global_state->m_relation_missing_attrs);
 
-		bool needs_output = scan_global_state->m_attr_to_output_map.find(attr_num) != scan_global_state->m_attr_to_output_map.end();
+		bool needs_output = scan_global_state->attr_to_output_set.find(attr_num) != scan_global_state->attr_to_output_set.end();
 		if (needs_output) {
 			values[duckdb_scanned_index] = value;
 			nulls[duckdb_scanned_index] = is_null;

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -85,8 +85,8 @@ PostgresScanGlobalState::InitGlobalState(duckdb::TableFunctionInitInput &input) 
 		}
 	}
 
-	for (const auto &[duckdb_scanned_index, attr_num] : m_output_columns) {
-		m_attr_to_output_map.emplace(attr_num, duckdb_scanned_index);
+	for (const auto &[_, attr_num] : m_output_columns) {
+		attr_to_output_set.emplace(attr_num);
 	}
 }
 

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -84,6 +84,10 @@ PostgresScanGlobalState::InitGlobalState(duckdb::TableFunctionInitInput &input) 
 			m_output_columns.emplace_back(output_index++, column_id + 1);
 		}
 	}
+
+	for (const auto &[duckdb_scanned_index, attr_num] : m_output_columns) {
+		m_attr_to_output_map.emplace(attr_num, duckdb_scanned_index);
+	}
 }
 
 void


### PR DESCRIPTION
Fix https://github.com/duckdb/pg_duckdb/issues/402

1. Cache the detoast variables if they are both part of a filter and one of the output variables.
2. Only contain the values that we actually need to output in the value.