### PR TITLE
Cached file management

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -84,4 +84,6 @@ private:
 	std::string default_dbname;
 };
 
+std::string CreateOrGetDirectoryPath(const char *directory_name);
+
 } // namespace pgduckdb

--- a/sql/pg_duckdb--0.1.0--0.2.0.sql
+++ b/sql/pg_duckdb--0.1.0--0.2.0.sql
@@ -49,9 +49,10 @@ END;
 $func$;
 
 CREATE TYPE duckdb.cache_info AS (
-  cache_key TEXT,
   remote_path TEXT,
-  file_size TEXT
+  cache_key TEXT,
+  cache_file_size BIGINT,
+  cache_file_timestamp TIMESTAMPTZ
 );
 
 CREATE FUNCTION duckdb.cache_info()

--- a/sql/pg_duckdb--0.1.0--0.2.0.sql
+++ b/sql/pg_duckdb--0.1.0--0.2.0.sql
@@ -47,3 +47,21 @@ BEGIN
     RAISE EXCEPTION 'Function `read_json(TEXT[])` only works with Duckdb execution.';
 END;
 $func$;
+
+CREATE TYPE duckdb.cache_info AS (
+  cache_key TEXT,
+  remote_path TEXT,
+  file_size TEXT
+);
+
+CREATE FUNCTION duckdb.cache_info()
+    RETURNS SETOF duckdb.cache_info
+    SET search_path = pg_catalog, pg_temp
+    LANGUAGE C AS 'MODULE_PATHNAME', 'cache_info';
+REVOKE ALL ON FUNCTION duckdb.cache_info() FROM PUBLIC;
+
+CREATE FUNCTION duckdb.cache_delete(cache_key TEXT)
+    RETURNS bool
+    SET search_path = pg_catalog, pg_temp
+    LANGUAGE C AS 'MODULE_PATHNAME', 'cache_delete';
+REVOKE ALL ON FUNCTION duckdb.cache_delete(cache_key TEXT) FROM PUBLIC;

--- a/third_party/cached_httpfs/http_file_cache.cpp
+++ b/third_party/cached_httpfs/http_file_cache.cpp
@@ -53,7 +53,8 @@ void CachedFileHandle::WriteMetadata(const string &cache_key, const string &remo
 	string metadata_file_name = file->cache_directory + "/" + cache_key + ".meta";
 	FileOpenFlags flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE | FileLockType::WRITE_LOCK;
 	auto handle = file->fs.OpenFile(metadata_file_name, flags);
-	string metadata_info = cache_key + "," + remote_path + "," + std::to_string(total_size);
+	auto cached_file_timestamp = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	string metadata_info = cache_key + "," + remote_path + "," + std::to_string(total_size) + "," + std::to_string(cached_file_timestamp);
 	handle->Write((void *)metadata_info.c_str(), metadata_info.length(), 0);
 	handle->Close();
 

--- a/third_party/cached_httpfs/httpfs.cpp
+++ b/third_party/cached_httpfs/httpfs.cpp
@@ -777,6 +777,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 	if (current_file_cache) {
 		MD5Context md5_context;
+
 		// NO ETag header
 		if (res->headers.find("ETag") == res->headers.end() || res->headers["ETag"].empty()) {
 			md5_context.Add(StringUtil::Lower(path));
@@ -797,10 +798,10 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 					                    full_download_result->http_url, to_string(full_download_result->code),
 					                    full_download_result->error);
 				}
-
+				// Write metadata for cached file
+				cached_file_handle->WriteMetadata(md5_key, StringUtil::Lower(path), length);
 				// Mark the file as initialized, set its final length, and unlock it to allowing parallel reads
 				cached_file_handle->SetInitialized(length);
-
 				// We shouldn't write these to cache
 				should_write_cache = false;
 			} else {

--- a/third_party/cached_httpfs/include/http_file_cache.hpp
+++ b/third_party/cached_httpfs/include/http_file_cache.hpp
@@ -28,6 +28,7 @@ private:
 	void ReleaseDirectoryCacheLock();
 
 private:
+	string cache_directory;
 	// FileSystem
 	FileSystem &fs;
 	// File name
@@ -52,6 +53,8 @@ public:
 	void Allocate(idx_t size);
 	//! Grow file to new size, copying over `bytes_to_copy` to the new buffer
 	void GrowFile(idx_t new_capacity, idx_t bytes_to_copy);
+	//! Write cached file metadata
+	void WriteMetadata(const string &cache_key, const string &remote_path, idx_t total_size);
 	//! Indicate the file is fully downloaded and safe for parallel reading without lock
 	void SetInitialized(idx_t total_size);
 	//! Write to the buffer


### PR DESCRIPTION
For each cached file we will now create additional metadata file that contains simple metadata. Added funcitons `duckdb.cache_info()` and `duckdb.cache_delete(cache_key TEXT)` that are used for managing cached files.