### PR TITLE
Handle "WITH RECURSIVE" abnormal crashes

### DIFF
--- a/src/vendor/pg_ruleutils_14.c
+++ b/src/vendor/pg_ruleutils_14.c
@@ -6121,7 +6121,6 @@ get_setop_query(Node *setOp, Query *query, deparse_context *context,
 		Query	   *subquery = rte->subquery;
 
 		Assert(subquery != NULL);
-		Assert(subquery->setOperations == NULL);
 		/* Need parens if WITH, ORDER BY, FOR UPDATE, or LIMIT; see gram.y */
 		need_paren = (subquery->cteList ||
 					  subquery->sortClause ||

--- a/src/vendor/pg_ruleutils_15.c
+++ b/src/vendor/pg_ruleutils_15.c
@@ -6202,7 +6202,6 @@ get_setop_query(Node *setOp, Query *query, deparse_context *context,
 		Query	   *subquery = rte->subquery;
 
 		Assert(subquery != NULL);
-		Assert(subquery->setOperations == NULL);
 		/* Need parens if WITH, ORDER BY, FOR UPDATE, or LIMIT; see gram.y */
 		need_paren = (subquery->cteList ||
 					  subquery->sortClause ||

--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -6161,7 +6161,6 @@ get_setop_query(Node *setOp, Query *query, deparse_context *context,
 		Query	   *subquery = rte->subquery;
 
 		Assert(subquery != NULL);
-		Assert(subquery->setOperations == NULL);
 		/* Need parens if WITH, ORDER BY, FOR UPDATE, or LIMIT; see gram.y */
 		need_paren = (subquery->cteList ||
 					  subquery->sortClause ||

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -6175,7 +6175,6 @@ get_setop_query(Node *setOp, Query *query, deparse_context *context,
 		Query	   *subquery = rte->subquery;
 
 		Assert(subquery != NULL);
-		Assert(subquery->setOperations == NULL);
 		/* Need parens if WITH, ORDER BY, FOR UPDATE, or LIMIT; see gram.y */
 		need_paren = (subquery->cteList ||
 					  subquery->sortClause ||

--- a/test/regression/expected/cte.out
+++ b/test/regression/expected/cte.out
@@ -9,3 +9,37 @@ WITH modifying_cte AS (
 (1 row)
 
 DROP TABLE t;
+WITH RECURSIVE outermost(x) AS (
+ SELECT 1
+ UNION (WITH innermost1 AS (
+  SELECT 2
+  UNION (WITH innermost2 AS (
+   SELECT 3
+   UNION (WITH innermost3 AS (
+    SELECT 4
+    UNION (WITH innermost4 AS (
+     SELECT 5
+     UNION (WITH innermost5 AS (
+      SELECT 6
+      UNION (WITH innermost6 AS
+       (SELECT 7)
+       SELECT * FROM innermost6))
+      SELECT * FROM innermost5))
+     SELECT * FROM innermost4))
+    SELECT * FROM innermost3))
+   SELECT * FROM innermost2))
+  SELECT * FROM outermost
+  UNION SELECT * FROM innermost1)
+ )
+ SELECT * FROM outermost ORDER BY 1;
+ x 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+ 7
+(7 rows)
+

--- a/test/regression/expected/cte.out
+++ b/test/regression/expected/cte.out
@@ -8,7 +8,6 @@ WITH modifying_cte AS (
  1
 (1 row)
 
-DROP TABLE t;
 WITH RECURSIVE outermost(x) AS (
  SELECT 1
  UNION (WITH innermost1 AS (
@@ -43,3 +42,4 @@ WITH RECURSIVE outermost(x) AS (
  7
 (7 rows)
 
+DROP TABLE t;

--- a/test/regression/sql/cte.sql
+++ b/test/regression/sql/cte.sql
@@ -5,8 +5,6 @@ WITH modifying_cte AS (
     INSERT INTO t VALUES (1) RETURNING *
 ) select * from modifying_cte;
 
-DROP TABLE t;
-
 WITH RECURSIVE outermost(x) AS (
  SELECT 1
  UNION (WITH innermost1 AS (
@@ -30,3 +28,5 @@ WITH RECURSIVE outermost(x) AS (
   UNION SELECT * FROM innermost1)
  )
  SELECT * FROM outermost ORDER BY 1;
+
+DROP TABLE t;

--- a/test/regression/sql/cte.sql
+++ b/test/regression/sql/cte.sql
@@ -6,3 +6,27 @@ WITH modifying_cte AS (
 ) select * from modifying_cte;
 
 DROP TABLE t;
+
+WITH RECURSIVE outermost(x) AS (
+ SELECT 1
+ UNION (WITH innermost1 AS (
+  SELECT 2
+  UNION (WITH innermost2 AS (
+   SELECT 3
+   UNION (WITH innermost3 AS (
+    SELECT 4
+    UNION (WITH innermost4 AS (
+     SELECT 5
+     UNION (WITH innermost5 AS (
+      SELECT 6
+      UNION (WITH innermost6 AS
+       (SELECT 7)
+       SELECT * FROM innermost6))
+      SELECT * FROM innermost5))
+     SELECT * FROM innermost4))
+    SELECT * FROM innermost3))
+   SELECT * FROM innermost2))
+  SELECT * FROM outermost
+  UNION SELECT * FROM innermost1)
+ )
+ SELECT * FROM outermost ORDER BY 1;


### PR DESCRIPTION
This seems to be a PG bug. When a CTE expression with multiple unions is run, this line assertion will necessarily be triggered, causing the program to terminate.