### PR TITLE
Improve CI debugging

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Install pytest and other test requirements
         run: python3 -m pip install -r duckdb/requirements.txt
 
-      - name: Build and test pg_duckdb extension
+      - name: Build pg_duckdb extension
         id: build
         run: |
           pushd duckdb
@@ -127,6 +127,11 @@ jobs:
           make pycheck
 
       - name: Print regression.diffs if regression tests failed
-        if: failure() && steps.installcheck.outcome != 'success'
+        if: failure() && steps.installcheck.outcome == 'failure'
         run: |
           cat duckdb/test/regression/regression.diffs
+
+      - name: Print postmaster.log if regression tests failed
+        if: failure() && steps.installcheck.outcome == 'failure'
+        run: |
+          cat duckdb/test/regression/log/postmaster.log


### PR DESCRIPTION
This improves our CI output in a few small ways:
1. Fix name of build step
2. Only show regression.diffs when installcheck failed. The showing of regression.diffs would actually fail itself if the build build failed, because the file would not exist.
3. Show postmaster.log if installcheck failed too. This can be helpful in case loading pg_duckdb.so failed e.g. due to missing symbols because you forgot to add a file.
