### PR TITLE
Correctly populate targetlist of CustomScan

### DIFF
--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -90,7 +90,7 @@ CreatePlan(Query *query, bool throw_error) {
 		/* We fill in the varno later, once we know the index of the custom RTE
 		 * that we create. We'll know this at the end of DuckdbPlanNode. This
 		 * can probably be simplified when we don't call the standard_planner
-		 * anymore innside DuckdbPlanNodei, because then we only need a single
+		 * anymore inside DuckdbPlanNode, because then we only need a single
 		 * RTE. */
 		Var *var = makeVar(0, i + 1, postgresColumnOid, typtup->typtypmod, typtup->typcollation, 0);
 

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include "pgduckdb/pgduckdb_node.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
+#include "pgduckdb/vendor/pg_list.hpp"
 
 bool duckdb_explain_analyze = false;
 

--- a/test/pycheck/explain_test.py
+++ b/test/pycheck/explain_test.py
@@ -1,3 +1,9 @@
+"""Tests for EXPLAIN
+
+These tests are using Python mainly because the output of EXPLAIN ANALYZE
+contains timings, so the output is not deterministic.
+"""
+
 from .utils import Cursor
 
 import pytest
@@ -10,18 +16,21 @@ def test_explain(cur: Cursor):
     plan = "\n".join(result)
     assert "UNGROUPED_AGGREGATE" in plan
     assert "Total Time:" not in plan
+    assert "Output:" not in plan
 
     result = cur.sql("EXPLAIN ANALYZE SELECT count(*) FROM test_table")
     plan = "\n".join(result)
     assert "Query Profiling Information" in plan
     assert "UNGROUPED_AGGREGATE" in plan
     assert "Total Time:" in plan
+    assert "Output:" not in plan
 
     result = cur.sql("EXPLAIN SELECT count(*) FROM test_table where id = %s", (1,))
     plan = "\n".join(result)
     assert "UNGROUPED_AGGREGATE" in plan
     assert "id=1 AND id IS NOT NULL" in plan
     assert "Total Time:" not in plan
+    assert "Output:" not in plan
 
     result = cur.sql(
         "EXPLAIN ANALYZE SELECT count(*) FROM test_table where id = %s", (1,)
@@ -30,6 +39,20 @@ def test_explain(cur: Cursor):
     assert "UNGROUPED_AGGREGATE" in plan
     assert "id=1 AND id IS NOT NULL" in plan
     assert "Total Time:" in plan
+    assert "Output:" not in plan
+
+    result = cur.sql("EXPLAIN VERBOSE SELECT count(*) FROM test_table")
+    plan = "\n".join(result)
+    assert "UNGROUPED_AGGREGATE" in plan
+    assert "Total Time:" not in plan
+    assert "Output:" in plan
+
+    result = cur.sql("EXPLAIN (VERBOSE, ANALYZE) SELECT count(*) FROM test_table")
+    plan = "\n".join(result)
+    assert "Query Profiling Information" in plan
+    assert "UNGROUPED_AGGREGATE" in plan
+    assert "Total Time:" in plan
+    assert "Output:" in plan
 
 
 def test_explain_ctas(cur: Cursor):


### PR DESCRIPTION
`EXPLAIN VERBOSE` was erroring out when the plan contained one of our `CustomScan` nodes. The reason for this was that we were not populating the `targetlist` and `custom_scan_tlist` fields in a way that PG understood so it was recursing infinitely into the same function. This changes how we populate those fields to match what PG expects.

Sadly the additional info in the plan is currently not super useful, and arguably wrong. It will always show the following line in the explain plan.
```
   Output: duckdb_scan.explain_key, duckdb_scan.explain_value
```

To fix that we shouldn't include the EXPLAIN part when sending it to DuckDB for initial planning. Sadly that then breaks the code that we use for executing the query. So for now we're happy with not throwing an error, and that we're populating `targetlist` correctly (which might have some more benefits that we didn't know of).

Fixes #465
Fixes #466
Fixes #463