### PR TITLE
Allow user to configure default MotherDuck database in postgresql.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you installed `pg_duckdb` in a different Postgres database than the default o
 duckdb.motherduck_postgres_database = 'your_database_name'
 ```
 
-If you want to specify MotherDuck database as default (i.e. merged with the Postgres schemas of the same name rather than using the DuckDB `ddb$` schemas), then you can also add the following line to your `postgresql.conf` file:
+If you want to specify MotherDuck database as the default database (the default database is the easiest to use, see below for details), then you can also add the following line to your `postgresql.conf` file:
 
 ```ini
 duckdb.motherduck_default_database = 'your_motherduck_database_name'
@@ -195,7 +195,7 @@ CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
 Any tables that you already had in MotherDuck are automatically available in Postgres. Since DuckDB and MotherDuck allow accessing multiple databases from a single connection and Postgres does not, we map database+schema in DuckDB to a schema name in Postgres.
 
 This is done in the following way:
-1. Each schema in your default MotherDuck database (`my_db`, unless you specify a different database above) are simply merged with the Postgres schemas with the same name.
+1. Each schema in your default MotherDuck database (`my_db`, unless you specify a different default database above) are simply merged with the Postgres schemas with the same name.
 2. Except for the `main` DuckDB schema in your default database, which is merged with the Postgres `public` schema.
 3. Tables in other databases are put into dedicated DuckDB-only schemas. These schemas are of the form `ddb$<duckdb_db_name>$<duckdb_schema_name>` (including the literal `$` characters).
 4. Except for the `main` schema in those other databases. That schema should be accessed using the shorter name `ddb$<db_name>` instead.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ If you installed `pg_duckdb` in a different Postgres database than the default o
 duckdb.motherduck_postgres_database = 'your_database_name'
 ```
 
+If you want to specify MotherDuck database as default (i.e. merged with the Postgres schemas of the same name rather than using the DuckDB `ddb$` schemas), then you can also add the following line to your `postgresql.conf` file:
+
+```ini
+duckdb.motherduck_default_database = 'your_motherduck_database_name'
+```
+
 After doing this (and possibly restarting Postgres). You can then you create tables in the MotherDuck database by using the `duckdb` [Table Access Method][tam] like this:
 ```sql
 CREATE TABLE orders(id bigint, item text, price NUMERIC(10, 2)) USING duckdb;
@@ -189,7 +195,7 @@ CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
 Any tables that you already had in MotherDuck are automatically available in Postgres. Since DuckDB and MotherDuck allow accessing multiple databases from a single connection and Postgres does not, we map database+schema in DuckDB to a schema name in Postgres.
 
 This is done in the following way:
-1. Each schema in your default MotherDuck database are simply merged with the Postgres schemas with the same name.
+1. Each schema in your default MotherDuck database (`my_db`, unless you specify a different database above) are simply merged with the Postgres schemas with the same name.
 2. Except for the `main` DuckDB schema in your default database, which is merged with the Postgres `public` schema.
 3. Tables in other databases are put into dedicated DuckDB-only schemas. These schemas are of the form `ddb$<duckdb_db_name>$<duckdb_schema_name>` (including the literal `$` characters).
 4. Except for the `main` schema in those other databases. That schema should be accessed using the shorter name `ddb$<db_name>` instead.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you installed `pg_duckdb` in a different Postgres database than the default o
 duckdb.motherduck_postgres_database = 'your_database_name'
 ```
 
-If you want to specify MotherDuck database as the default database (the default database is the easiest to use, see below for details), then you can also add the following line to your `postgresql.conf` file:
+The default MotherDuck database will be easiest to use (see below for details). If you want to specify which MotherDuck database is your default database, then you can also add the following line to your `postgresql.conf` file:
 
 ```ini
 duckdb.motherduck_default_database = 'your_motherduck_database_name'

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you installed `pg_duckdb` in a different Postgres database than the default o
 duckdb.motherduck_postgres_database = 'your_database_name'
 ```
 
-The default MotherDuck database will be easiest to use (see below for details). If you want to specify which MotherDuck database is your default database, then you can also add the following line to your `postgresql.conf` file:
+The default MotherDuck database will be easiest to use (see below for details), by default this is `my_db`. If you want to specify which MotherDuck database is your default database, then you can also add the following line to your `postgresql.conf` file:
 
 ```ini
 duckdb.motherduck_default_database = 'your_motherduck_database_name'
@@ -195,7 +195,7 @@ CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
 Any tables that you already had in MotherDuck are automatically available in Postgres. Since DuckDB and MotherDuck allow accessing multiple databases from a single connection and Postgres does not, we map database+schema in DuckDB to a schema name in Postgres.
 
 This is done in the following way:
-1. Each schema in your default MotherDuck database (`my_db`, unless you specify a different default database above) are simply merged with the Postgres schemas with the same name.
+1. Each schema in your default MotherDuck database (see above on how to specify which database is the default) are simply merged with the Postgres schemas with the same name.
 2. Except for the `main` DuckDB schema in your default database, which is merged with the Postgres `public` schema.
 3. Tables in other databases are put into dedicated DuckDB-only schemas. These schemas are of the form `ddb$<duckdb_db_name>$<duckdb_schema_name>` (including the literal `$` characters).
 4. Except for the `main` schema in those other databases. That schema should be accessed using the shorter name `ddb$<db_name>` instead.

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -55,7 +55,7 @@ CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
 
 Any tables that you already had in MotherDuck are automatically available in Postgres. Since DuckDB and MotherDuck allow accessing multiple databases from a single connection and Postgres does not, we map database+schema in DuckDB to a schema name in Postgres.
 
-The default MotherDuck database will be easiest to use (see below for details). If you want to specify which MotherDuck database is used as your default database, then you can also add the following line to your `postgresql.conf` file:
+The default MotherDuck database will be easiest to use (see below for details), by default this is `my_db`. If you want to specify which MotherDuck database is your default database, then you can also add the following line to your `postgresql.conf` file:
 
 ```ini
 duckdb.motherduck_default_database = 'your_motherduck_database_name'

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -55,7 +55,13 @@ CREATE TABLE users_md_copy USING duckdb AS SELECT * FROM users;
 
 Any tables that you already had in MotherDuck are automatically available in Postgres. Since DuckDB and MotherDuck allow accessing multiple databases from a single connection and Postgres does not, we map database+schema in DuckDB to a schema name in Postgres.
 
-This is done in the following way:
+The default MotherDuck database will be easiest to use (see below for details). If you want to specify which MotherDuck database is used as your default database, then you can also add the following line to your `postgresql.conf` file:
+
+```ini
+duckdb.motherduck_default_database = 'your_motherduck_database_name'
+```
+
+The mapping of database+schema to schema name is then done in the following way:
 
 1. Each schema in your default MotherDuck database are simply merged with the Postgres schemas with the same name.
 2. Except for the `main` DuckDB schema in your default database, which is merged with the Postgres `public` schema.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -38,6 +38,17 @@ Default: `"postgres"`
 
 Access: General
 
+### `duckdb.motherduck_default_database`
+
+Which MotherDuck database to use as the default database, i.e. the one that
+gets merged with Postgres schemas instead of getting dedicated `ddb$` prefixed
+schemas. The empty string means that pg_duckdb should use the default database
+set by MotherDuck, which is currently always `my_db`.
+
+Default: `""`
+
+Access: Needs to be in the `postgresql.conf` file and requires a restart
+
 ## Security
 
 ### `duckdb.postgres_role`

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -11,3 +11,4 @@ extern char *duckdb_motherduck_postgres_database;
 extern int duckdb_motherduck_enabled;
 extern char *duckdb_motherduck_token;
 extern char *duckdb_postgres_role;
+extern char *duckdb_motherduck_default_database;

--- a/sql/pg_duckdb--0.1.0--0.2.0.sql
+++ b/sql/pg_duckdb--0.1.0--0.2.0.sql
@@ -74,3 +74,6 @@ CREATE PROCEDURE duckdb.recycle_ddb()
 REVOKE ALL ON PROCEDURE duckdb.recycle_ddb() FROM PUBLIC;
 
 ALTER TABLE duckdb.secrets ADD COLUMN scope TEXT;
+
+ALTER TABLE duckdb.tables ADD COLUMN default_database TEXT NOT NULL DEFAULT 'my_db';
+ALTER TABLE duckdb.tables ALTER COLUMN default_database DROP DEFAULT;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -166,6 +166,7 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.motherduck_postgres_database", "Which database to enable MotherDuck support in",
 	                     &duckdb_motherduck_postgres_database);
 
-	DefineCustomVariable("duckdb.motherduck_default_database", "Which database in MotherDuck to designate as default (in place of my_db)",
-						 &duckdb_motherduck_default_database);
+	DefineCustomVariable("duckdb.motherduck_default_database",
+	                     "Which database in MotherDuck to designate as default (in place of my_db)",
+	                     &duckdb_motherduck_default_database, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
 }

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -18,6 +18,7 @@ int duckdb_max_threads_per_postgres_scan = 1;
 int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
 char *duckdb_motherduck_postgres_database = strdup("postgres");
+char *duckdb_motherduck_default_database = strdup("");
 char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;
@@ -164,4 +165,7 @@ DuckdbInitGUC(void) {
 
 	DefineCustomVariable("duckdb.motherduck_postgres_database", "Which database to enable MotherDuck support in",
 	                     &duckdb_motherduck_postgres_database);
+
+	DefineCustomVariable("duckdb.motherduck_default_database", "Which database in MotherDuck to designate as default (in place of my_db)",
+						 &duckdb_motherduck_default_database);
 }

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -682,9 +682,10 @@ SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 			continue;
 		}
 
-		Oid arg_types[] = {TEXTOID, TEXTOID};
+		Oid arg_types[] = {TEXTOID, TEXTOID, TEXTOID};
 		Datum values[] = {CStringGetTextDatum(motherduck_db.c_str()),
-		                  CStringGetTextDatum(pgduckdb::current_motherduck_catalog_version)};
+		                  CStringGetTextDatum(pgduckdb::current_motherduck_catalog_version),
+		                  CStringGetTextDatum(default_db.c_str())};
 
 		/*
 		 * We use a cursor here instead of plain SPI_execute, to put a limit on
@@ -695,7 +696,10 @@ SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 		Portal deleted_tables_portal =
 		    SPI_cursor_open_with_args(nullptr, R"(
 			SELECT relid::text FROM duckdb.tables
-			WHERE duckdb_db = $1 AND motherduck_catalog_version != $2
+			WHERE duckdb_db = $1 AND (
+				motherduck_catalog_version != $2 OR
+				default_database != $3
+			)
 			)",
 		                              lengthof(arg_types), arg_types, values, NULL, false, 0);
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -605,9 +605,6 @@ SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 		last_known_motherduck_catalog_versions[motherduck_db] = catalog_version;
 		auto schemas = duckdb::Catalog::GetSchemas(context, motherduck_db);
 		bool is_default_db = motherduck_db == default_db;
-		if (duckdb_motherduck_default_database[0] != '\0') {
-			is_default_db = motherduck_db == duckdb_motherduck_default_database;
-		}
 		bool all_tables_synced_successfully = true;
 		for (duckdb::SchemaCatalogEntry &schema : schemas) {
 			if (schema.name == "information_schema" || schema.name == "pg_catalog") {

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -605,6 +605,9 @@ SyncMotherDuckCatalogsWithPg_Cpp(bool drop_with_cascade) {
 		last_known_motherduck_catalog_versions[motherduck_db] = catalog_version;
 		auto schemas = duckdb::Catalog::GetSchemas(context, motherduck_db);
 		bool is_default_db = motherduck_db == default_db;
+		if (duckdb_motherduck_default_database[0] != '\0') {
+			is_default_db = motherduck_db == duckdb_motherduck_default_database;
+		}
 		bool all_tables_synced_successfully = true;
 		for (duckdb::SchemaCatalogEntry &schema : schemas) {
 			if (schema.name == "information_schema" || schema.name == "pg_catalog") {

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -78,26 +78,22 @@ CreateOrGetDirectoryPath(const char *directory_name) {
 	return duckdb_data_directory;
 }
 
-char *
-uri_escape(const char *str)
-{
-    StringInfoData buf;
-    initStringInfo(&buf);
+static char *
+uri_escape(const char *str) {
+	StringInfoData buf;
+	initStringInfo(&buf);
 
-    while (*str)
-    {
-        char c = *str++;
-        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '~')
-        {
-            appendStringInfoChar(&buf, c);
-        }
-        else
-        {
-            appendStringInfo(&buf, "%%%02X", (unsigned char)c);
-        }
-    }
+	while (*str) {
+		char c = *str++;
+		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+		    c == '.' || c == '~') {
+			appendStringInfoChar(&buf, c);
+		} else {
+			appendStringInfo(&buf, "%%%02X", (unsigned char)c);
+		}
+	}
 
-    return buf.data;
+	return buf.data;
 }
 
 namespace ddb {
@@ -172,7 +168,8 @@ DuckDBManager::Initialize() {
 		if (duckdb_motherduck_token[0] == '\0') {
 			connection_string = psprintf("md:%s", duckdb_motherduck_default_database);
 		} else {
-			connection_string = psprintf("md:%s?motherduck_token=%s", duckdb_motherduck_default_database, duckdb_motherduck_token);
+			connection_string =
+			    psprintf("md:%s?motherduck_token=%s", duckdb_motherduck_default_database, duckdb_motherduck_token);
 		}
 	}
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -164,7 +164,11 @@ DuckDBManager::Initialize() {
 	auto &context = *connection->context;
 
 	auto &db_manager = duckdb::DatabaseManager::Get(context);
-	default_dbname = db_manager.GetDefaultDatabase(context);
+	if (duckdb_motherduck_default_database[0] == '\0') {
+		default_dbname = db_manager.GetDefaultDatabase(context);
+	} else {
+		default_dbname = duckdb_motherduck_default_database;
+	}
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 


### PR DESCRIPTION
Fixes #459

Allow the user to configure a different default MotherDuck database from `my_db` in `postgresql.conf`. This affords flexibility because there is currently no user-facing API to change the internal "default" DB in MotherDuck.