### PR TITLE
Fails value insertion if type unsupported by duckdb

### DIFF
--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -199,7 +199,7 @@ SELECT * FROM float8_array_1d;
 (4 rows)
 
 -- NUMERIC (single dimension)
-CREATE TABLE numeric_array_1d(a NUMERIC[]);
+CREATE TABLE numeric_array_1d(a NUMERIC(2, 1)[]);
 INSERT INTO numeric_array_1d SELECT CAST(a as NUMERIC[]) FROM (VALUES
     ('{1.1, 2.2, 3.3}'),
     (NULL),
@@ -373,7 +373,7 @@ SELECT * FROM float8_array_2d;
 (5 rows)
 
 -- NUMERIC (two dimensions)
-CREATE TABLE numeric_array_2d(a NUMERIC[][]);
+CREATE TABLE numeric_array_2d(a NUMERIC(3, 1)[][]);
 INSERT INTO numeric_array_2d VALUES
     ('{{1.1,2.2},{3.3,4.4}}'),
     ('{{5.5,6.6,7.7},{8.8,9.9,10.1}}'),

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -201,21 +201,6 @@ SELECT * FROM float8_tbl;
  4.582345020342342e+20
 (3 rows)
 
--- NUMERIC as DOUBLE
-CREATE TABLE numeric_as_double(a NUMERIC);
-INSERT INTO numeric_as_double SELECT a FROM (VALUES
-    (0.234234234),
-    (NULL),
-    (458234502034234234234.000012)
-) t(a);
-SELECT * FROM numeric_as_double;
-           a           
------------------------
-           0.234234234
-                      
- 4.582345020342342e+20
-(3 rows)
-
 -- NUMERIC with a physical type of SMALLINT
 CREATE TABLE smallint_numeric(a NUMERIC(4, 2));
 INSERT INTO smallint_numeric SELECT a FROM (VALUES
@@ -330,7 +315,6 @@ DROP TABLE timestamp_tbl;
 DROP TABLE timestamptz_tbl;
 DROP TABLE float4_tbl;
 DROP TABLE float8_tbl;
-DROP TABLE numeric_as_double;
 DROP TABLE smallint_numeric;
 DROP TABLE integer_numeric;
 DROP TABLE bigint_numeric;

--- a/test/regression/expected/unsupported_types.out
+++ b/test/regression/expected/unsupported_types.out
@@ -1,0 +1,2 @@
+CREATE TEMP TABLE numeric_tbl (a NUMERIC) USING duckdb;
+ERROR:  Unsupported type when creating column: type precision 40 with scale 5 is not supported by duckdb, which only allows maximum precision 38

--- a/test/regression/expected/unsupported_types.out
+++ b/test/regression/expected/unsupported_types.out
@@ -1,2 +1,3 @@
-CREATE TEMP TABLE numeric_tbl (a NUMERIC) USING duckdb;
-ERROR:  Unsupported type when creating column: type precision 40 with scale 5 is not supported by duckdb, which only allows maximum precision 38
+CREATE TEMP TABLE large_numeric_tbl (a NUMERIC) USING duckdb;
+INSERT INTO large_numeric_tbl VALUES(856324.111122223333::NUMERIC(40,12));
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Parser Error: Width must be between 1 and 38!

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -26,3 +26,4 @@ test: transaction_errors
 test: secrets
 test: prepare
 test: function
+test: unsupported_types

--- a/test/regression/sql/array_type_support.sql
+++ b/test/regression/sql/array_type_support.sql
@@ -125,7 +125,7 @@ INSERT INTO float8_array_1d SELECT CAST(a as FLOAT8[]) FROM (VALUES
 SELECT * FROM float8_array_1d;
 
 -- NUMERIC (single dimension)
-CREATE TABLE numeric_array_1d(a NUMERIC[]);
+CREATE TABLE numeric_array_1d(a NUMERIC(2, 1)[]);
 INSERT INTO numeric_array_1d SELECT CAST(a as NUMERIC[]) FROM (VALUES
     ('{1.1, 2.2, 3.3}'),
     (NULL),
@@ -226,7 +226,7 @@ INSERT INTO float8_array_2d VALUES
 SELECT * FROM float8_array_2d;
 
 -- NUMERIC (two dimensions)
-CREATE TABLE numeric_array_2d(a NUMERIC[][]);
+CREATE TABLE numeric_array_2d(a NUMERIC(3, 1)[][]);
 INSERT INTO numeric_array_2d VALUES
     ('{{1.1,2.2},{3.3,4.4}}'),
     ('{{5.5,6.6,7.7},{8.8,9.9,10.1}}'),

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -90,15 +90,6 @@ INSERT INTO float8_tbl SELECT CAST(a AS FLOAT8) FROM (VALUES
 ) t(a);
 SELECT * FROM float8_tbl;
 
--- NUMERIC as DOUBLE
-CREATE TABLE numeric_as_double(a NUMERIC);
-INSERT INTO numeric_as_double SELECT a FROM (VALUES
-    (0.234234234),
-    (NULL),
-    (458234502034234234234.000012)
-) t(a);
-SELECT * FROM numeric_as_double;
-
 -- NUMERIC with a physical type of SMALLINT
 CREATE TABLE smallint_numeric(a NUMERIC(4, 2));
 INSERT INTO smallint_numeric SELECT a FROM (VALUES
@@ -171,7 +162,6 @@ DROP TABLE timestamp_tbl;
 DROP TABLE timestamptz_tbl;
 DROP TABLE float4_tbl;
 DROP TABLE float8_tbl;
-DROP TABLE numeric_as_double;
 DROP TABLE smallint_numeric;
 DROP TABLE integer_numeric;
 DROP TABLE bigint_numeric;

--- a/test/regression/sql/unsupported_types.sql
+++ b/test/regression/sql/unsupported_types.sql
@@ -1,0 +1,1 @@
+CREATE TEMP TABLE numeric_tbl (a NUMERIC) USING duckdb;

--- a/test/regression/sql/unsupported_types.sql
+++ b/test/regression/sql/unsupported_types.sql
@@ -1,1 +1,2 @@
-CREATE TEMP TABLE numeric_tbl (a NUMERIC) USING duckdb;
+CREATE TEMP TABLE large_numeric_tbl (a NUMERIC) USING duckdb;
+INSERT INTO large_numeric_tbl VALUES(856324.111122223333::NUMERIC(40,12));


### PR DESCRIPTION
I would like to followup on issue: https://github.com/duckdb/pg_duckdb/issues/467

I think current implementation is not ideal:
- If user creates a table with duckdb unsupported numeric type, we **silently** fallback to double type
- Later write operation **doesn't always** fail, based on the input numeric value, which adds more confusion to the users

Here I propose two improvements:
- method-1: No silent fallback on type conversion "failure"; so we print a warning message with `elog(WARNING, ...)`, and get users aware of the fallback behavior;
- method-2: Instead of falling back to double type, we fallback to user-defined type, since it's not supported by duckdb (system) anyway.

In this PR, I selected method-2, but I'm open to other feedbacks and suggestions.
The goal here is to disallow silent fallback and surprising write behavior.

Edit:
Followup on feedback https://github.com/duckdb/pg_duckdb/pull/471#issuecomment-2514571362, I fail the table creation if column type is not supported by duckdb.