### PR TITLE
Do not use -Wno-register for C compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ else
 	ERROR_ON_WARNING =
 endif
 
-COMPILER_FLAGS=-Wno-sign-compare -Wno-register -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra ${ERROR_ON_WARNING}
+COMPILER_FLAGS=-Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra ${ERROR_ON_WARNING}
 
 override PG_CPPFLAGS += -Iinclude -isystem third_party/duckdb/src/include -isystem third_party/duckdb/third_party/re2 ${COMPILER_FLAGS}
-override PG_CXXFLAGS += -std=c++17 ${DUCKDB_BUILD_CXX_FLAGS} ${COMPILER_FLAGS}
+override PG_CXXFLAGS += -std=c++17 ${DUCKDB_BUILD_CXX_FLAGS} ${COMPILER_FLAGS} -Wno-register
 
 SHLIB_LINK += -Wl,-rpath,$(PG_LIB)/ -lpq -Lthird_party/duckdb/build/$(DUCKDB_BUILD_TYPE)/src -L$(PG_LIB) -lduckdb -lstdc++ -llz4
 


### PR DESCRIPTION
The `-Wno-register` flag is only applicable to C++, and my compiler
complains about that:

```
cc1: warning: command-line option ‘-Wno-register’ is valid for C++/ObjC++ but not for C
cc1: warning: command-line option ‘-Wno-register’ is valid for C++/ObjC++ but not for C
cc1: warning: command-line option ‘-Wno-register’ is valid for C++/ObjC++ but not for C
cc1: warning: command-line option ‘-Wno-register’ is valid for C++/ObjC++ but not for C
```
