### PR TITLE
Only allow duckdb.motherduck_postgres_database in postgresql.conf

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -36,7 +36,7 @@ Which database to enable MotherDuck support in
 
 Default: `"postgres"`
 
-Access: General
+Access: Needs to be in the `postgresql.conf` file and requires a restart
 
 ### `duckdb.motherduck_default_database`
 

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -164,7 +164,7 @@ DuckdbInitGUC(void) {
 	                     PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
 
 	DefineCustomVariable("duckdb.motherduck_postgres_database", "Which database to enable MotherDuck support in",
-	                     &duckdb_motherduck_postgres_database);
+	                     &duckdb_motherduck_postgres_database, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
 
 	DefineCustomVariable("duckdb.motherduck_default_database",
 	                     "Which database in MotherDuck to designate as default (in place of my_db)",


### PR DESCRIPTION
This was always the intention, as we currently don't allow switching the
database without restarting postgres. But we forgot to set the correct
GUC flags.
