### PR TITLE
feat: Add support for Azure secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ INSERT INTO duckdb.secrets
 VALUES ('Azure', '<your connection string>');
 ```
 
+Note: writes to Azure are not yet supported, [here][duckdb/duckdb_azure#44] is the current discussion for more information.
+
 ### Connect with MotherDuck
 
 pg_duckdb also integrates with [MotherDuck][md]. To enable this support you first need to [generate an access token][md-access-token] and then add the following line to your `postgresql.conf` file:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See our [official documentation][docs] for further details.
 - `SELECT` queries executed by the DuckDB engine can directly read Postgres tables. (If you only query Postgres tables you need to run `SET duckdb.force_execution TO true`, see the **IMPORTANT** section above for details)
 	- Able to read [data types](https://www.postgresql.org/docs/current/datatype.html) that exist in both Postgres and DuckDB. The following data types are supported: numeric, character, binary, date/time, boolean, uuid, json, and arrays.
 	- If DuckDB cannot support the query for any reason, execution falls back to Postgres.
-- Read and Write support for object storage (AWS S3, Cloudflare R2, or Google GCS):
+- Read and Write support for object storage (AWS S3, Azure, Cloudflare R2, or Google GCS):
 	- Read parquet, CSV and JSON files:
 		- `SELECT n FROM read_parquet('s3://bucket/file.parquet') AS (n int)`
 		- `SELECT n FROM read_csv('s3://bucket/file.csv') AS (n int)`
@@ -124,9 +124,9 @@ CREATE EXTENSION pg_duckdb;
 
 See our [official documentation][docs] for more usage information.
 
-pg_duckdb relies on DuckDB's vectorized execution engine to read and write data to object storage bucket (AWS S3, Cloudflare R2, or Google GCS) and/or MotherDuck. The follow two sections describe how to get started with these destinations.
+pg_duckdb relies on DuckDB's vectorized execution engine to read and write data to object storage bucket (AWS S3, Azure, Cloudflare R2, or Google GCS) and/or MotherDuck. The follow two sections describe how to get started with these destinations.
 
-### Object storage bucket (AWS S3, Cloudflare R2, or Google GCS)
+### Object storage bucket (AWS S3, Azure, Cloudflare R2, or Google GCS)
 
 Querying data stored in Parquet, CSV, JSON, Iceberg and Delta format can be done with `read_parquet`, `read_csv`, `read_json`, `iceberg_scan` and `delta_scan` respectively.
 
@@ -156,6 +156,18 @@ Querying data stored in Parquet, CSV, JSON, Iceberg and Delta format can be done
 	ORDER BY total DESC
 	LIMIT 100;
 	```
+
+Note, for Azure, you will need to first install the Azure extension:
+```sql
+SELECT duckdb.install_extension('azure');
+```
+
+You may then store a secret using the `connection_string` parameter as such:
+```sql
+INSERT INTO duckdb.secrets
+(type, connection_string)
+VALUES ('Azure', '<your connection string>');
+```
 
 ### Connect with MotherDuck
 

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -35,8 +35,6 @@ typedef struct DuckdbSecret {
 	std::string connection_string; // Used for Azure
 } DuckdbSecret;
 
-bool DoesSecretRequiresKeyIdOrSecret(const SecretType type);
-
 std::string SecretTypeToString(SecretType type);
 
 extern std::vector<DuckdbSecret> ReadDuckdbSecrets();

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -6,21 +6,24 @@
 namespace pgduckdb {
 
 /* constants for duckdb.secrets */
-#define Natts_duckdb_secret              10
-#define Anum_duckdb_secret_name          1
-#define Anum_duckdb_secret_type          2
-#define Anum_duckdb_secret_key_id        3
-#define Anum_duckdb_secret_secret        4
-#define Anum_duckdb_secret_region        5
-#define Anum_duckdb_secret_session_token 6
-#define Anum_duckdb_secret_endpoint      7
-#define Anum_duckdb_secret_r2_account_id 8
-#define Anum_duckdb_secret_use_ssl       9
-#define Anum_duckdb_secret_scope         10
+#define Natts_duckdb_secret                  11
+#define Anum_duckdb_secret_name              1
+#define Anum_duckdb_secret_type              2
+#define Anum_duckdb_secret_key_id            3
+#define Anum_duckdb_secret_secret            4
+#define Anum_duckdb_secret_region            5
+#define Anum_duckdb_secret_session_token     6
+#define Anum_duckdb_secret_endpoint          7
+#define Anum_duckdb_secret_r2_account_id     8
+#define Anum_duckdb_secret_use_ssl           9
+#define Anum_duckdb_secret_scope             10
+#define Anum_duckdb_secret_connection_string 11
+
+enum SecretType { S3, R2, GCS, AZURE };
 
 typedef struct DuckdbSecret {
 	std::string name;
-	std::string type;
+	SecretType type;
 	std::string key_id;
 	std::string secret;
 	std::string region;
@@ -29,7 +32,12 @@ typedef struct DuckdbSecret {
 	std::string r2_account_id;
 	bool use_ssl;
 	std::string scope;
+	std::string connection_string; // Used for Azure
 } DuckdbSecret;
+
+bool DoesSecretRequiresKeyIdOrSecret(const SecretType type);
+
+std::string SecretTypeToString(SecretType type);
 
 extern std::vector<DuckdbSecret> ReadDuckdbSecrets();
 

--- a/sql/pg_duckdb--0.1.0--0.2.0.sql
+++ b/sql/pg_duckdb--0.1.0--0.2.0.sql
@@ -84,7 +84,7 @@ ALTER TABLE duckdb.secrets ALTER COLUMN secret DROP NOT NULL;
 
 -- Update "type_constraint" CHECK on "type" to allow "Azure"
 ALTER TABLE duckdb.secrets DROP CONSTRAINT type_constraint;
-ALTER TABLE duckdb.secrets ADD CONSTRAINT type_constraint CHECK (type IN ('S3', 'GCS', 'R2', 'Azure'));
+ALTER TABLE duckdb.secrets ADD CONSTRAINT type_constraint CHECK (upper(type) IN ('S3', 'GCS', 'R2', 'AZURE'));
 
 -- Add "azure_connection_string" column
 ALTER TABLE duckdb.secrets ADD COLUMN connection_string TEXT;

--- a/sql/pg_duckdb--0.1.0--0.2.0.sql
+++ b/sql/pg_duckdb--0.1.0--0.2.0.sql
@@ -77,3 +77,14 @@ ALTER TABLE duckdb.secrets ADD COLUMN scope TEXT;
 
 ALTER TABLE duckdb.tables ADD COLUMN default_database TEXT NOT NULL DEFAULT 'my_db';
 ALTER TABLE duckdb.tables ALTER COLUMN default_database DROP DEFAULT;
+
+-- Alter duckdb.secrets to allow column "key_id" & "secret" to be NULL
+ALTER TABLE duckdb.secrets ALTER COLUMN key_id DROP NOT NULL;
+ALTER TABLE duckdb.secrets ALTER COLUMN secret DROP NOT NULL;
+
+-- Update "type_constraint" CHECK on "type" to allow "Azure"
+ALTER TABLE duckdb.secrets DROP CONSTRAINT type_constraint;
+ALTER TABLE duckdb.secrets ADD CONSTRAINT type_constraint CHECK (type IN ('S3', 'GCS', 'R2', 'Azure'));
+
+-- Add "azure_connection_string" column
+ALTER TABLE duckdb.secrets ADD COLUMN connection_string TEXT;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -253,7 +253,6 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 	auto duckdb_secrets = ReadDuckdbSecrets();
 
 	int secret_id = 0;
-	bool azure_loaded = false;
 	for (auto &secret : duckdb_secrets) {
 		std::ostringstream query;
 		query << "CREATE SECRET pgduckb_secret_" << secret_id << " ";
@@ -266,11 +265,6 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 		}
 
 		query << ");";
-
-		if (secret.type == SecretType::AZURE && !azure_loaded) {
-			DuckDBQueryOrThrow(context, "INSTALL azure; LOAD azure;");
-			azure_loaded = true;
-		}
 
 		DuckDBQueryOrThrow(context, query.str());
 		secret_id++;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -298,17 +298,17 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 
 void
 DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
+	const auto extensions_table_last_seq = GetSeqLastValue("extensions_table_seq");
+	if (IsExtensionsSeqLessThan(extensions_table_last_seq)) {
+		LoadExtensions(context);
+		UpdateExtensionsSeq(extensions_table_last_seq);
+	}
+
 	const auto secret_table_last_seq = GetSeqLastValue("secrets_table_seq");
 	if (IsSecretSeqLessThan(secret_table_last_seq)) {
 		DropSecrets(context);
 		LoadSecrets(context);
 		UpdateSecretSeq(secret_table_last_seq);
-	}
-
-	const auto extensions_table_last_seq = GetSeqLastValue("extensions_table_seq");
-	if (IsExtensionsSeqLessThan(extensions_table_last_seq)) {
-		LoadExtensions(context);
-		UpdateExtensionsSeq(extensions_table_last_seq);
 	}
 
 	auto http_file_cache_set_dir_query =

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -253,6 +253,7 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 	auto duckdb_secrets = ReadDuckdbSecrets();
 
 	int secret_id = 0;
+	bool azure_loaded = false;
 	for (auto &secret : duckdb_secrets) {
 		std::ostringstream query;
 		query << "CREATE SECRET pgduckb_secret_" << secret_id << " ";
@@ -265,6 +266,11 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 		}
 
 		query << ");";
+
+		if (secret.type == SecretType::AZURE && !azure_loaded) {
+			DuckDBQueryOrThrow(context, "INSTALL azure; LOAD azure;");
+			azure_loaded = true;
+		}
 
 		DuckDBQueryOrThrow(context, query.str());
 		secret_id++;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -258,12 +258,10 @@ DuckDBManager::LoadSecrets(duckdb::ClientContext &context) {
 		query << "CREATE SECRET pgduckb_secret_" << secret_id << " ";
 		query << "(TYPE " << SecretTypeToString(secret.type) << ", ";
 
-		if (DoesSecretRequiresKeyIdOrSecret(secret.type)) {
-			WriteSecretQueryForS3R2OrGCP(secret, query);
-		} else if (secret.type == SecretType::AZURE) {
+		if (secret.type == SecretType::AZURE) {
 			query << "CONNECTION_STRING '" << secret.connection_string << "'";
 		} else {
-			throw std::runtime_error("Invalid secret type: '" + std::to_string(secret.type) + "'");
+			WriteSecretQueryForS3R2OrGCP(secret, query);
 		}
 
 		query << ");";


### PR DESCRIPTION
Add support for Azure secrets:
1. Install Azure extension
```sql
SELECT duckdb.install_extension('azure');
```

2. Add a secret:
```sql
INSERT INTO duckdb.secrets
(type, connection_string)
VALUES ('Azure', '<your connection string>');
```

3. Run a query:
```sql
SELECT count(*) 
FROM read_parquet('azure://my_container/orders.parquet') AS (order_id int);
```