### PR TITLE
Add `autoload` and `autoinstall` GUC

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ Querying data stored in Parquet, CSV, JSON, Iceberg and Delta format can be done
 	LIMIT 100;
 	```
 
-Note, for Azure, you will need to first install the Azure extension:
-You may then store a secret using the `connection_string` parameter as such:
+Note, for Azure, you may store a secret using the `connection_string` parameter as such:
 ```sql
 INSERT INTO duckdb.secrets
 (type, connection_string)

--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ Querying data stored in Parquet, CSV, JSON, Iceberg and Delta format can be done
 	```
 
 Note, for Azure, you will need to first install the Azure extension:
-```sql
-SELECT duckdb.install_extension('azure');
-```
-
 You may then store a secret using the `connection_string` parameter as such:
 ```sql
 INSERT INTO duckdb.secrets

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -6,6 +6,8 @@ extern char *duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;
 extern bool duckdb_enable_external_access;
 extern bool duckdb_allow_unsigned_extensions;
+extern bool duckdb_autoinstall_known_extensions;
+extern bool duckdb_autoload_known_extensions;
 extern int duckdb_max_threads_per_postgres_scan;
 extern char *duckdb_motherduck_postgres_database;
 extern int duckdb_motherduck_enabled;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -26,6 +26,8 @@ char *duckdb_maximum_memory = strdup("4GB");
 char *duckdb_disabled_filesystems = strdup("LocalFileSystem");
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_unsigned_extensions = false;
+bool duckdb_autoinstall_known_extensions = true;
+bool duckdb_autoload_known_extensions = true;
 
 extern "C" {
 PG_MODULE_MAGIC;
@@ -130,6 +132,14 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.allow_unsigned_extensions",
 	                     "Allow DuckDB to load extensions with invalid or missing signatures",
 	                     &duckdb_allow_unsigned_extensions, PGC_SUSET);
+
+	DefineCustomVariable("duckdb.autoinstall_known_extensions",
+	                     "Whether known extensions are allowed to be automatically installed when a DuckDB query depends on them",
+	                     &duckdb_autoinstall_known_extensions, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
+
+	DefineCustomVariable("duckdb.autoload_known_extensions",
+	                     "Whether known extensions are allowed to be automatically loaded when a DuckDB query depends on them",
+	                     &duckdb_autoload_known_extensions, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
 
 	DefineCustomVariable("duckdb.max_memory", "The maximum memory DuckDB can use (e.g., 1GB)", &duckdb_maximum_memory,
 	                     PGC_SUSET);

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -135,11 +135,11 @@ DuckdbInitGUC(void) {
 
 	DefineCustomVariable("duckdb.autoinstall_known_extensions",
 	                     "Whether known extensions are allowed to be automatically installed when a DuckDB query depends on them",
-	                     &duckdb_autoinstall_known_extensions, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
+	                     &duckdb_autoinstall_known_extensions, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.autoload_known_extensions",
 	                     "Whether known extensions are allowed to be automatically loaded when a DuckDB query depends on them",
-	                     &duckdb_autoload_known_extensions, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
+	                     &duckdb_autoload_known_extensions, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.max_memory", "The maximum memory DuckDB can use (e.g., 1GB)", &duckdb_maximum_memory,
 	                     PGC_SUSET);

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -139,6 +139,8 @@ DuckDBManager::Initialize() {
 	config.replacement_scans.emplace_back(pgduckdb::PostgresReplacementScan);
 	SET_DUCKDB_OPTION(allow_unsigned_extensions);
 	SET_DUCKDB_OPTION(enable_external_access);
+	SET_DUCKDB_OPTION(autoinstall_known_extensions);
+	SET_DUCKDB_OPTION(autoload_known_extensions);
 
 	if (duckdb_maximum_memory != NULL) {
 		config.options.maximum_memory = duckdb::DBConfig::ParseMemoryLimit(duckdb_maximum_memory);


### PR DESCRIPTION
Add two GUC settings: `duckdb_autoinstall_known_extensions` and `duckdb_autoload_known_extensions`, which are direct proxy for DuckDB [settings](https://duckdb.org/docs/configuration/overview.html) `autoinstall_known_extensions` and `autoload_known_extensions`.

Mark both option enabled by default.