### PR TITLE
Bump dev version to 0.3.0

### DIFF
--- a/pg_duckdb.control
+++ b/pg_duckdb.control
@@ -1,5 +1,5 @@
 comment = 'DuckDB Embedded in Postgres'
-default_version = '0.2.0'
+default_version = '0.3.0'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false
 schema = public


### PR DESCRIPTION
Now that 0.2.0 is released we need the regular boilerplate for 0.3.0
development again.
