### PR TITLE
Correct handling parameter

### DIFF
--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -106,6 +106,10 @@ ExecuteQuery(DuckdbScanState *state) {
 	List *paramlist = NIL;
 	duckdb::vector<duckdb::Value> duckdb_params;
 
+	/*
+	 * Let's recursively iterate through the relevant parameters now,
+	 * and then deal with the parameter values later
+	 */
 	(void) Get_ParamList((Node *)(state->query), (void **) (&paramlist));
 	if (list_length(paramlist)) {
 #if PG_VERSION_NUM >= 150000
@@ -121,7 +125,7 @@ ExecuteQuery(DuckdbScanState *state) {
 
 				/* give hook a chance in case parameter is dynamic */
 				if (paramLI->paramFetch != NULL) {
-					prm = paramLI->paramFetch(paramLI, param->paramid, true, &prmdata);
+					prm = paramLI->paramFetch(paramLI, param->paramid, false, &prmdata);
 				} else {
 					prm = &paramLI->params[param->paramid - 1];
 				}

--- a/test/regression/expected/function.out
+++ b/test/regression/expected/function.out
@@ -1,0 +1,76 @@
+CREATE TABLE ta(a integer);
+INSERT INTO ta VALUES(125);
+-- test procedure
+CREATE OR REPLACE PROCEDURE protest(b INT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    va integer;
+BEGIN
+    SELECT * INTO va FROM ta WHERE a = b;
+    RAISE NOTICE '%', va * 2;
+END;
+$$;
+CALL protest(1);    -- null
+NOTICE:  <NULL>
+CALL protest(125);  -- 250
+NOTICE:  250
+-- test function
+CREATE OR REPLACE FUNCTION functest(b INT)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    va integer;
+BEGIN
+    SELECT * INTO va FROM ta WHERE a = b;
+    RETURN va * 2;
+END;
+$$;
+SELECT functest(124);   -- null
+ functest 
+----------
+         
+(1 row)
+
+SELECT functest(125);   -- 250
+ functest 
+----------
+      250
+(1 row)
+
+CREATE TABLE tb(a int DEFAULT 1, b text, c varchar DEFAULT 'pg_duckdb');
+INSERT INTO tb(a, b) VALUES(1, 'test');
+INSERT INTO tb VALUES(2, 'test2', 'pg_duckdb_test');
+CREATE OR REPLACE FUNCTION functest2(va INT, vc varchar)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    vb text;
+BEGIN
+    SELECT b INTO vb FROM tb WHERE a = va and c = vc;
+    RETURN vb;
+END;
+$$;
+SELECT functest2(1, 'pg_duckdb'); -- test
+ functest2 
+-----------
+ test
+(1 row)
+
+CREATE OR REPLACE PROCEDURE protest2(va INT, vb text)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    vc varchar;
+BEGIN
+    SELECT c INTO vc FROM tb WHERE a = va and b = vb;
+    RAISE NOTICE '%', vc;
+END;
+$$;
+CALL protest2(2, 'test2'); -- pg_duckdb_test
+NOTICE:  pg_duckdb_test
+DROP TABLE ta, tb;
+DROP FUNCTION functest, functest2;
+DROP PROCEDURE protest, protest2;

--- a/test/regression/expected/prepare.out
+++ b/test/regression/expected/prepare.out
@@ -1,7 +1,7 @@
 -- the view should return the empty
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
- name | statement | parameter_types | result_types 
-------+-----------+-----------------+--------------
+SELECT name, statement, parameter_types FROM pg_prepared_statements;
+ name | statement | parameter_types 
+------+-----------+-----------------
 (0 rows)
 
 CREATE DATABASE testdb;
@@ -18,13 +18,13 @@ EXECUTE q1('testdb');
 (1 row)
 
 -- q1
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
- name |                      statement                      | parameter_types |      result_types      
-------+-----------------------------------------------------+-----------------+------------------------
- q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
-      |         SELECT datname, datistemplate, datallowconn+|                 | 
-      |         FROM copy_database WHERE datname = $1;      |                 | 
+ name |                      statement                      | parameter_types 
+------+-----------------------------------------------------+-----------------
+ q1   | PREPARE q1(text) AS                                +| {text}
+      |         SELECT datname, datistemplate, datallowconn+| 
+      |         FROM copy_database WHERE datname = $1;      | 
 (1 row)
 
 CREATE TABLE ta(a int);
@@ -43,14 +43,14 @@ EXECUTE q2;
 (1 row)
 
 -- q1 q2
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
- name |                      statement                      | parameter_types |      result_types      
-------+-----------------------------------------------------+-----------------+------------------------
- q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
-      |         SELECT datname, datistemplate, datallowconn+|                 | 
-      |         FROM copy_database WHERE datname = $1;      |                 | 
- q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}              | {bigint}
+ name |                      statement                      | parameter_types 
+------+-----------------------------------------------------+-----------------
+ q1   | PREPARE q1(text) AS                                +| {text}
+      |         SELECT datname, datistemplate, datallowconn+| 
+      |         FROM copy_database WHERE datname = $1;      | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}
 (2 rows)
 
 PREPARE q3(int) AS
@@ -63,16 +63,16 @@ SELECT * FROM q3_prep_results;
 (1 row)
 
 -- q1 q2 q3
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
- name |                      statement                      | parameter_types |      result_types      
-------+-----------------------------------------------------+-----------------+------------------------
- q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
-      |         SELECT datname, datistemplate, datallowconn+|                 | 
-      |         FROM copy_database WHERE datname = $1;      |                 | 
- q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}              | {bigint}
- q3   | PREPARE q3(int) AS                                 +| {integer}       | {integer}
-      |         SELECT * FROM ta WHERE a = $1;              |                 | 
+ name |                      statement                      | parameter_types 
+------+-----------------------------------------------------+-----------------
+ q1   | PREPARE q1(text) AS                                +| {text}
+      |         SELECT datname, datistemplate, datallowconn+| 
+      |         FROM copy_database WHERE datname = $1;      | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}
+ q3   | PREPARE q3(int) AS                                 +| {integer}
+      |         SELECT * FROM ta WHERE a = $1;              | 
 (3 rows)
 
 CREATE TABLE tb (a int DEFAULT 1, b int, c varchar DEFAULT 'pg_duckdb');
@@ -86,18 +86,18 @@ EXECUTE q4(1, 'pg_duckdb');
 (1 row)
 
 -- q1 q2 q3 q4
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
- name |                      statement                      |        parameter_types        |      result_types      
-------+-----------------------------------------------------+-------------------------------+------------------------
- q1   | PREPARE q1(text) AS                                +| {text}                        | {text,boolean,boolean}
-      |         SELECT datname, datistemplate, datallowconn+|                               | 
-      |         FROM copy_database WHERE datname = $1;      |                               | 
- q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}                            | {bigint}
- q3   | PREPARE q3(int) AS                                 +| {integer}                     | {integer}
-      |         SELECT * FROM ta WHERE a = $1;              |                               | 
- q4   | PREPARE q4(int, varchar) AS                        +| {integer,"character varying"} | {integer}
-      |         SELECT b FROM tb WHERE a = $1 AND c = $2;   |                               | 
+ name |                      statement                      |        parameter_types        
+------+-----------------------------------------------------+-------------------------------
+ q1   | PREPARE q1(text) AS                                +| {text}
+      |         SELECT datname, datistemplate, datallowconn+| 
+      |         FROM copy_database WHERE datname = $1;      | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}
+ q3   | PREPARE q3(int) AS                                 +| {integer}
+      |         SELECT * FROM ta WHERE a = $1;              | 
+ q4   | PREPARE q4(int, varchar) AS                        +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND c = $2;   | 
 (4 rows)
 
 -- test DEALLOCATE ALL;

--- a/test/regression/expected/prepare.out
+++ b/test/regression/expected/prepare.out
@@ -4,17 +4,16 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements;
 ------+-----------+-----------------
 (0 rows)
 
-CREATE DATABASE testdb;
 CREATE TABLE copy_database(datname text, datistemplate boolean, datallowconn boolean);
 INSERT INTO copy_database SELECT datname, datistemplate, datallowconn FROM pg_database;
 -- parameterized queries
 PREPARE q1(text) AS
 	SELECT datname, datistemplate, datallowconn
 	FROM copy_database WHERE datname = $1;
-EXECUTE q1('testdb');
- datname | datistemplate | datallowconn 
----------+---------------+--------------
- testdb  | f             | t
+EXECUTE q1('postgres');
+ datname  | datistemplate | datallowconn 
+----------+---------------+--------------
+ postgres | f             | t
 (1 row)
 
 -- q1
@@ -85,6 +84,12 @@ EXECUTE q4(1, 'pg_duckdb');
  2
 (1 row)
 
+EXECUTE q4(1, 'pg_duckdb');
+ b 
+---
+ 2
+(1 row)
+
 -- q1 q2 q3 q4
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
@@ -108,5 +113,4 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
 ------+-----------+-----------------
 (0 rows)
 
-DROP DATABASE testdb;
 DROP TABLE copy_database, ta, tb;

--- a/test/regression/expected/prepare.out
+++ b/test/regression/expected/prepare.out
@@ -105,6 +105,96 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |         SELECT b FROM tb WHERE a = $1 AND c = $2;   | 
 (4 rows)
 
+TRUNCATE tb;
+INSERT INTO tb VALUES(10, 10, 'test');
+INSERT INTO tb VALUES(100, 100, 'pg_duckdb');
+PREPARE q5(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1 AND b = $1 AND c = $2;
+EXECUTE q5(10, 'test');
+ b  
+----
+ 10
+(1 row)
+
+EXECUTE q5(100, 'pg_duckdb');
+  b  
+-----
+ 100
+(1 row)
+
+-- q1 q2 q3 q4 q5
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                          statement                           |        parameter_types        
+------+--------------------------------------------------------------+-------------------------------
+ q1   | PREPARE q1(text) AS                                         +| {text}
+      |         SELECT datname, datistemplate, datallowconn         +| 
+      |         FROM copy_database WHERE datname = $1;               | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;                       | {}
+ q3   | PREPARE q3(int) AS                                          +| {integer}
+      |         SELECT * FROM ta WHERE a = $1;                       | 
+ q4   | PREPARE q4(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND c = $2;            | 
+ q5   | PREPARE q5(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND b = $1 AND c = $2; | 
+(5 rows)
+
+PREPARE q6(int, varchar) AS
+	SELECT b FROM tb WHERE c = $2;
+EXECUTE q6(10, 'test');
+ b  
+----
+ 10
+(1 row)
+
+-- q1 q2 q3 q4 q5 q6
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                          statement                           |        parameter_types        
+------+--------------------------------------------------------------+-------------------------------
+ q1   | PREPARE q1(text) AS                                         +| {text}
+      |         SELECT datname, datistemplate, datallowconn         +| 
+      |         FROM copy_database WHERE datname = $1;               | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;                       | {}
+ q3   | PREPARE q3(int) AS                                          +| {integer}
+      |         SELECT * FROM ta WHERE a = $1;                       | 
+ q4   | PREPARE q4(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND c = $2;            | 
+ q5   | PREPARE q5(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND b = $1 AND c = $2; | 
+ q6   | PREPARE q6(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE c = $2;                       | 
+(6 rows)
+
+PREPARE q7(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1;
+EXECUTE q7(100, 'pg_duckdb');
+  b  
+-----
+ 100
+(1 row)
+
+-- q1 q2 q3 q4 q5 q6 q7
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                          statement                           |        parameter_types        
+------+--------------------------------------------------------------+-------------------------------
+ q1   | PREPARE q1(text) AS                                         +| {text}
+      |         SELECT datname, datistemplate, datallowconn         +| 
+      |         FROM copy_database WHERE datname = $1;               | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;                       | {}
+ q3   | PREPARE q3(int) AS                                          +| {integer}
+      |         SELECT * FROM ta WHERE a = $1;                       | 
+ q4   | PREPARE q4(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND c = $2;            | 
+ q5   | PREPARE q5(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1 AND b = $1 AND c = $2; | 
+ q6   | PREPARE q6(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE c = $2;                       | 
+ q7   | PREPARE q7(int, varchar) AS                                 +| {integer,"character varying"}
+      |         SELECT b FROM tb WHERE a = $1;                       | 
+(7 rows)
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/test/regression/expected/prepare.out
+++ b/test/regression/expected/prepare.out
@@ -1,0 +1,112 @@
+-- the view should return the empty
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types 
+------+-----------+-----------------+--------------
+(0 rows)
+
+CREATE DATABASE testdb;
+CREATE TABLE copy_database(datname text, datistemplate boolean, datallowconn boolean);
+INSERT INTO copy_database SELECT datname, datistemplate, datallowconn FROM pg_database;
+-- parameterized queries
+PREPARE q1(text) AS
+	SELECT datname, datistemplate, datallowconn
+	FROM copy_database WHERE datname = $1;
+EXECUTE q1('testdb');
+ datname | datistemplate | datallowconn 
+---------+---------------+--------------
+ testdb  | f             | t
+(1 row)
+
+-- q1
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                      statement                      | parameter_types |      result_types      
+------+-----------------------------------------------------+-----------------+------------------------
+ q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
+      |         SELECT datname, datistemplate, datallowconn+|                 | 
+      |         FROM copy_database WHERE datname = $1;      |                 | 
+(1 row)
+
+CREATE TABLE ta(a int);
+INSERT INTO ta(a) SELECT * FROM generate_series(1, 1000);
+SELECT COUNT(*) FROM ta;
+ count 
+-------
+  1000
+(1 row)
+
+PREPARE q2 AS SELECT COUNT(*) FROM ta;
+EXECUTE q2;
+ count 
+-------
+  1000
+(1 row)
+
+-- q1 q2
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                      statement                      | parameter_types |      result_types      
+------+-----------------------------------------------------+-----------------+------------------------
+ q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
+      |         SELECT datname, datistemplate, datallowconn+|                 | 
+      |         FROM copy_database WHERE datname = $1;      |                 | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}              | {bigint}
+(2 rows)
+
+PREPARE q3(int) AS
+	SELECT * FROM ta WHERE a = $1;
+CREATE TEMPORARY TABLE q3_prep_results AS EXECUTE q3(200);
+SELECT * FROM q3_prep_results;
+  a  
+-----
+ 200
+(1 row)
+
+-- q1 q2 q3
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                      statement                      | parameter_types |      result_types      
+------+-----------------------------------------------------+-----------------+------------------------
+ q1   | PREPARE q1(text) AS                                +| {text}          | {text,boolean,boolean}
+      |         SELECT datname, datistemplate, datallowconn+|                 | 
+      |         FROM copy_database WHERE datname = $1;      |                 | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}              | {bigint}
+ q3   | PREPARE q3(int) AS                                 +| {integer}       | {integer}
+      |         SELECT * FROM ta WHERE a = $1;              |                 | 
+(3 rows)
+
+CREATE TABLE tb (a int DEFAULT 1, b int, c varchar DEFAULT 'pg_duckdb');
+INSERT INTO tb(b) VALUES(2);
+PREPARE q4(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1 AND c = $2;
+EXECUTE q4(1, 'pg_duckdb');
+ b 
+---
+ 2
+(1 row)
+
+-- q1 q2 q3 q4
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+ name |                      statement                      |        parameter_types        |      result_types      
+------+-----------------------------------------------------+-------------------------------+------------------------
+ q1   | PREPARE q1(text) AS                                +| {text}                        | {text,boolean,boolean}
+      |         SELECT datname, datistemplate, datallowconn+|                               | 
+      |         FROM copy_database WHERE datname = $1;      |                               | 
+ q2   | PREPARE q2 AS SELECT COUNT(*) FROM ta;              | {}                            | {bigint}
+ q3   | PREPARE q3(int) AS                                 +| {integer}                     | {integer}
+      |         SELECT * FROM ta WHERE a = $1;              |                               | 
+ q4   | PREPARE q4(int, varchar) AS                        +| {integer,"character varying"} | {integer}
+      |         SELECT b FROM tb WHERE a = $1 AND c = $2;   |                               | 
+(4 rows)
+
+-- test DEALLOCATE ALL;
+DEALLOCATE ALL;
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+ name | statement | parameter_types 
+------+-----------+-----------------
+(0 rows)
+
+DROP DATABASE testdb;
+DROP TABLE copy_database, ta, tb;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -24,3 +24,5 @@ test: altered_tables
 test: transactions
 test: transaction_errors
 test: secrets
+test: prepare
+test: function

--- a/test/regression/sql/function.sql
+++ b/test/regression/sql/function.sql
@@ -1,0 +1,68 @@
+CREATE TABLE ta(a integer);
+INSERT INTO ta VALUES(125);
+
+-- test procedure
+CREATE OR REPLACE PROCEDURE protest(b INT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    va integer;
+BEGIN
+    SELECT * INTO va FROM ta WHERE a = b;
+    RAISE NOTICE '%', va * 2;
+END;
+$$;
+
+CALL protest(1);    -- null
+CALL protest(125);  -- 250
+
+-- test function
+CREATE OR REPLACE FUNCTION functest(b INT)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    va integer;
+BEGIN
+    SELECT * INTO va FROM ta WHERE a = b;
+    RETURN va * 2;
+END;
+$$;
+
+SELECT functest(124);   -- null
+SELECT functest(125);   -- 250
+
+CREATE TABLE tb(a int DEFAULT 1, b text, c varchar DEFAULT 'pg_duckdb');
+INSERT INTO tb(a, b) VALUES(1, 'test');
+INSERT INTO tb VALUES(2, 'test2', 'pg_duckdb_test');
+
+CREATE OR REPLACE FUNCTION functest2(va INT, vc varchar)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    vb text;
+BEGIN
+    SELECT b INTO vb FROM tb WHERE a = va and c = vc;
+    RETURN vb;
+END;
+$$;
+
+SELECT functest2(1, 'pg_duckdb'); -- test
+
+CREATE OR REPLACE PROCEDURE protest2(va INT, vb text)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    vc varchar;
+BEGIN
+    SELECT c INTO vc FROM tb WHERE a = va and b = vb;
+    RAISE NOTICE '%', vc;
+END;
+$$;
+
+CALL protest2(2, 'test2'); -- pg_duckdb_test
+
+DROP TABLE ta, tb;
+DROP FUNCTION functest, functest2;
+DROP PROCEDURE protest, protest2;

--- a/test/regression/sql/prepare.sql
+++ b/test/regression/sql/prepare.sql
@@ -45,6 +45,34 @@ EXECUTE q4(1, 'pg_duckdb');
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
+TRUNCATE tb;
+INSERT INTO tb VALUES(10, 10, 'test');
+INSERT INTO tb VALUES(100, 100, 'pg_duckdb');
+PREPARE q5(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1 AND b = $1 AND c = $2;
+EXECUTE q5(10, 'test');
+EXECUTE q5(100, 'pg_duckdb');
+
+-- q1 q2 q3 q4 q5
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+
+PREPARE q6(int, varchar) AS
+	SELECT b FROM tb WHERE c = $2;
+EXECUTE q6(10, 'test');
+
+-- q1 q2 q3 q4 q5 q6
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+
+PREPARE q7(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1;
+EXECUTE q7(100, 'pg_duckdb');
+
+-- q1 q2 q3 q4 q5 q6 q7
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/test/regression/sql/prepare.sql
+++ b/test/regression/sql/prepare.sql
@@ -1,5 +1,5 @@
 -- the view should return the empty
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+SELECT name, statement, parameter_types FROM pg_prepared_statements;
 
 CREATE DATABASE testdb;
 CREATE TABLE copy_database(datname text, datistemplate boolean, datallowconn boolean);
@@ -12,7 +12,7 @@ PREPARE q1(text) AS
 EXECUTE q1('testdb');
 
 -- q1
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
 CREATE TABLE ta(a int);
@@ -22,7 +22,7 @@ PREPARE q2 AS SELECT COUNT(*) FROM ta;
 EXECUTE q2;
 
 -- q1 q2
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
 PREPARE q3(int) AS
@@ -32,7 +32,7 @@ CREATE TEMPORARY TABLE q3_prep_results AS EXECUTE q3(200);
 SELECT * FROM q3_prep_results;
 
 -- q1 q2 q3
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
 CREATE TABLE tb (a int DEFAULT 1, b int, c varchar DEFAULT 'pg_duckdb');
@@ -42,7 +42,7 @@ PREPARE q4(int, varchar) AS
 EXECUTE q4(1, 'pg_duckdb');
 
 -- q1 q2 q3 q4
-SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
 -- test DEALLOCATE ALL;

--- a/test/regression/sql/prepare.sql
+++ b/test/regression/sql/prepare.sql
@@ -1,0 +1,54 @@
+-- the view should return the empty
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+
+CREATE DATABASE testdb;
+CREATE TABLE copy_database(datname text, datistemplate boolean, datallowconn boolean);
+INSERT INTO copy_database SELECT datname, datistemplate, datallowconn FROM pg_database;
+-- parameterized queries
+PREPARE q1(text) AS
+	SELECT datname, datistemplate, datallowconn
+	FROM copy_database WHERE datname = $1;
+
+EXECUTE q1('testdb');
+
+-- q1
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+
+CREATE TABLE ta(a int);
+INSERT INTO ta(a) SELECT * FROM generate_series(1, 1000);
+SELECT COUNT(*) FROM ta;
+PREPARE q2 AS SELECT COUNT(*) FROM ta;
+EXECUTE q2;
+
+-- q1 q2
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+
+PREPARE q3(int) AS
+	SELECT * FROM ta WHERE a = $1;
+
+CREATE TEMPORARY TABLE q3_prep_results AS EXECUTE q3(200);
+SELECT * FROM q3_prep_results;
+
+-- q1 q2 q3
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+
+CREATE TABLE tb (a int DEFAULT 1, b int, c varchar DEFAULT 'pg_duckdb');
+INSERT INTO tb(b) VALUES(2);
+PREPARE q4(int, varchar) AS
+	SELECT b FROM tb WHERE a = $1 AND c = $2;
+EXECUTE q4(1, 'pg_duckdb');
+
+-- q1 q2 q3 q4
+SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+    ORDER BY name;
+
+-- test DEALLOCATE ALL;
+DEALLOCATE ALL;
+SELECT name, statement, parameter_types FROM pg_prepared_statements
+    ORDER BY name;
+
+DROP DATABASE testdb;
+DROP TABLE copy_database, ta, tb;

--- a/test/regression/sql/prepare.sql
+++ b/test/regression/sql/prepare.sql
@@ -1,7 +1,6 @@
 -- the view should return the empty
 SELECT name, statement, parameter_types FROM pg_prepared_statements;
 
-CREATE DATABASE testdb;
 CREATE TABLE copy_database(datname text, datistemplate boolean, datallowconn boolean);
 INSERT INTO copy_database SELECT datname, datistemplate, datallowconn FROM pg_database;
 -- parameterized queries
@@ -9,7 +8,7 @@ PREPARE q1(text) AS
 	SELECT datname, datistemplate, datallowconn
 	FROM copy_database WHERE datname = $1;
 
-EXECUTE q1('testdb');
+EXECUTE q1('postgres');
 
 -- q1
 SELECT name, statement, parameter_types FROM pg_prepared_statements
@@ -40,6 +39,7 @@ INSERT INTO tb(b) VALUES(2);
 PREPARE q4(int, varchar) AS
 	SELECT b FROM tb WHERE a = $1 AND c = $2;
 EXECUTE q4(1, 'pg_duckdb');
+EXECUTE q4(1, 'pg_duckdb');
 
 -- q1 q2 q3 q4
 SELECT name, statement, parameter_types FROM pg_prepared_statements
@@ -50,5 +50,4 @@ DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
-DROP DATABASE testdb;
 DROP TABLE copy_database, ta, tb;


### PR DESCRIPTION
DuckDB complains when it receives parameters that were not actually used in the query. From Postgres we get all supplied parameters though. So this changes the code to filter the unused ones out. To do this we lot DuckDB parse the query and tell us which parameters it expects, and then we remove the unexpected ones.

Fixes #411 
Fixes #234 