### PR TITLE
Read cache metadata correctly

### DIFF
--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -264,7 +264,7 @@ DuckdbGetCachedFilesInfos() {
 				     p.path().c_str());
 				break;
 			}
-			cache_info.push_back(CacheFileInfo {metadata_tokens[0], metadata_tokens[1], std::stoi(metadata_tokens[2]),
+			cache_info.push_back(CacheFileInfo {metadata_tokens[0], metadata_tokens[1], std::stoll(metadata_tokens[2]),
 			                                    std::stoi(metadata_tokens[3])});
 		}
 	}

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -265,7 +265,7 @@ DuckdbGetCachedFilesInfos() {
 				break;
 			}
 			cache_info.push_back(CacheFileInfo {metadata_tokens[0], metadata_tokens[1], std::stoll(metadata_tokens[2]),
-			                                    std::stoi(metadata_tokens[3])});
+			                                    std::stoll(metadata_tokens[3])});
 		}
 	}
 	return cache_info;


### PR DESCRIPTION
Currently we will not be able to read cache metadata for files that are bigger than 4GB because we use stoi function. Use stoll instead that will read long long values. Timestamp also needs to be read with stoll.