### PR TITLE
Remove most C++ from `pgduckdb.cpp`

### DIFF
--- a/include/pgduckdb/pgduckdb.h
+++ b/include/pgduckdb/pgduckdb.h
@@ -7,7 +7,7 @@ typedef enum {
 	MOTHERDUCK_AUTO,
 } MotherDuckEnabled;
 
-// pgduckdb.c
+// pgduckdb.cpp
 extern "C" void _PG_init(void);
 
 // pgduckdb_hooks.c

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "pgduckdb/pg/declarations.hpp"
-
 namespace pgduckdb {
 
 void InitBackgroundWorkersShmem(void);

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -1,4 +1,6 @@
-#include "duckdb.hpp"
+#include "pgduckdb/pgduckdb.h"
+
+#include <type_traits>
 
 extern "C" {
 #include "postgres.h"
@@ -7,14 +9,9 @@ extern "C" {
 #include "postmaster/bgworker_internals.h"
 }
 
-#include "pgduckdb/pgduckdb.h"
-#include "pgduckdb/pgduckdb_fdw.hpp"
-#include "pgduckdb/pgduckdb_node.hpp"
 #include "pgduckdb/pgduckdb_background_worker.hpp"
-#include "pgduckdb/pgduckdb_metadata_cache.hpp"
+#include "pgduckdb/pgduckdb_node.hpp"
 #include "pgduckdb/pgduckdb_xact.hpp"
-
-static void DuckdbInitGUC(void);
 
 namespace {
 char *
@@ -47,6 +44,8 @@ char *duckdb_max_temp_directory_size = strdup("");
 
 extern "C" {
 PG_MODULE_MAGIC;
+
+void DuckdbInitGUC();
 
 void
 _PG_init(void) {
@@ -107,11 +106,12 @@ DefineCustomVariable(const char *name, const char *short_desc, T *var, T min, T 
 	} else {
 		static_assert("Unsupported type");
 	}
+
 	func(name, gettext_noop(short_desc), NULL, var, *var, min, max, context, flags, check_hook, assign_hook, show_hook);
 }
 
-static void
-DuckdbInitGUC(void) {
+void
+DuckdbInitGUC() {
 	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution);
 
 	DefineCustomVariable("duckdb.unsafe_allow_mixed_transactions",

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -275,11 +275,7 @@ IsDuckdbPlan(PlannedStmt *stmt) {
 	}
 
 	CustomScan *custom_scan = castNode(CustomScan, plan);
-	if (custom_scan->methods != &duckdb_scan_scan_methods) {
-		return false;
-	}
-
-	return true;
+	return custom_scan->methods == &duckdb_scan_scan_methods;
 }
 
 /*

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -362,7 +362,7 @@ Duckdb_ExplainCustomScan(CustomScanState *node, List * /*ancestors*/, ExplainSta
 	InvokeCPPFunc(Duckdb_ExplainCustomScan_Cpp, node, es);
 }
 
-extern "C" void
+void
 DuckdbInitNode() {
 	/* setup scan methods */
 	memset(&duckdb_scan_scan_methods, 0, sizeof(duckdb_scan_scan_methods));


### PR DESCRIPTION
* bring all initialization methods declarations in the `pgduckdb.h` files
* remove most C++ includes from `pgduckdb.cpp` (last remaining is `type_traits` for the GUC helpers)