### PR TITLE
Make sure test run with UTF8 encoding

### DIFF
--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -6,6 +6,7 @@ include $(ROOT_DIR)/Makefile.global
 
 check-regression-duckdb:
 	TEST_DIR=$(CURDIR) $(pg_regress_installcheck) \
+	--encoding=UTF8 \
 	--temp-instance=./tmp_check \
 	--temp-config regression.conf \
 	--load-extension=pg_duckdb \


### PR DESCRIPTION
As reported in https://github.com/duckdb/pg_duckdb/issues/505, in some PG installation, default encoding might not be UTF8. This fixes it.