### PR TITLE
Make sure `pycheck` uses the right installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ installcheck: all install
 	$(MAKE) check-regression-duckdb
 
 pycheck: all install
-	pytest -n $(PYTEST_CONCURRENCY)
+	LD_LIBRARY_PATH=$(PG_LIBDIR):${LD_LIBRARY_PATH} pytest -n $(PYTEST_CONCURRENCY)
 
 check: installcheck pycheck
 

--- a/Makefile.global
+++ b/Makefile.global
@@ -2,6 +2,7 @@ PG_CONFIG ?= pg_config
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 PG_LIB := $(shell $(PG_CONFIG) --pkglibdir)
+PG_LIBDIR := $(shell $(PG_CONFIG) --libdir)
 INCLUDEDIR := ${shell $(PG_CONFIG) --includedir}
 INCLUDEDIR_SERVER := ${shell $(PG_CONFIG) --includedir-server}
 


### PR DESCRIPTION
As reported by [this issue](https://github.com/duckdb/pg_duckdb/issues/505), the `pycheck` test suite uses the global PG installation instead of the one specified by `pg_config`. This fixes it.