### PR TITLE
Run clang-format on all headers too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,5 +116,5 @@ format:
 	ruff format
 
 format-all:
-	find src include -iname '*.h' -o -iname '*.cpp' -o -iname '*.c' | xargs clang-format -i
+	find src include -iname '*.hpp' -o -iname '*.h' -o -iname '*.cpp' -o -iname '*.c' | xargs clang-format -i
 	ruff format

--- a/include/pgduckdb/logger.hpp
+++ b/include/pgduckdb/logger.hpp
@@ -7,24 +7,24 @@
 extern "C" {
 bool errstart(int elevel, const char *domain);
 void errfinish(const char *filename, int lineno, const char *funcname);
-int	errmsg_internal(const char *fmt,...);
+int errmsg_internal(const char *fmt, ...);
 bool message_level_is_interesting(int elevel);
 }
 
 namespace pgduckdb {
 
 /* PG Error level codes */
-#define DEBUG5		10
-#define DEBUG4		11
-#define DEBUG3		12
-#define DEBUG2		13
-#define DEBUG1		14
-#define LOG			15
-#define INFO		17
-#define NOTICE		18
-#define WARNING		19
-#define PGWARNING	19
-#define WARNING_CLIENT_ONLY	20
+#define DEBUG5              10
+#define DEBUG4              11
+#define DEBUG3              12
+#define DEBUG2              13
+#define DEBUG1              14
+#define LOG                 15
+#define INFO                17
+#define NOTICE              18
+#define WARNING             19
+#define PGWARNING           19
+#define WARNING_CLIENT_ONLY 20
 
 // From PG elog.h
 #ifdef __GNUC__
@@ -41,23 +41,21 @@ namespace pgduckdb {
 #define pd_prevent_errno_in_scope()
 #endif
 
-#define pd_ereport_domain(elevel, domain, ...)	\
-	do { \
-		pd_prevent_errno_in_scope(); \
-		static_assert(elevel >= DEBUG5 && elevel <= WARNING_CLIENT_ONLY, "Invalid error level"); \
-		if (message_level_is_interesting(elevel)) { \
-			std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock()); \
-			if (errstart(elevel, domain)) \
-				__VA_ARGS__, errfinish(__FILE__, __LINE__, __func__); \
-		} \
-	} while(0)
+#define pd_ereport_domain(elevel, domain, ...)                                                                         \
+	do {                                                                                                               \
+		pd_prevent_errno_in_scope();                                                                                   \
+		static_assert(elevel >= DEBUG5 && elevel <= WARNING_CLIENT_ONLY, "Invalid error level");                       \
+		if (message_level_is_interesting(elevel)) {                                                                    \
+			std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());                                            \
+			if (errstart(elevel, domain))                                                                              \
+				__VA_ARGS__, errfinish(__FILE__, __LINE__, __func__);                                                  \
+		}                                                                                                              \
+	} while (0)
 
 #define TEXTDOMAIN NULL
 
-#define pd_ereport(elevel, ...)	\
-	pd_ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
+#define pd_ereport(elevel, ...) pd_ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
 
-#define pd_log(elevel, ...)  \
-	pd_ereport(elevel, errmsg_internal(__VA_ARGS__))
+#define pd_log(elevel, ...) pd_ereport(elevel, errmsg_internal(__VA_ARGS__))
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pg/error_data.hpp
+++ b/include/pgduckdb/pg/error_data.hpp
@@ -5,5 +5,5 @@ struct ErrorData;
 }
 
 namespace pgduckdb::pg {
-const char* GetErrorDataMessage(ErrorData* error_data);
+const char *GetErrorDataMessage(ErrorData *error_data);
 }

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -21,7 +21,7 @@ typedef struct MemoryContextData *MemoryContext;
 extern sigjmp_buf *PG_exception_stack;
 extern MemoryContext CurrentMemoryContext;
 extern ErrorContextCallback *error_context_stack;
-extern ErrorData * CopyErrorData();
+extern ErrorData *CopyErrorData();
 extern void FlushErrorState();
 }
 
@@ -73,7 +73,6 @@ __PostgresFunctionGuard__(const char *func_name, FuncArgs... args) {
 
 #define PostgresFunctionGuard(FUNC, ...)                                                                               \
 	pgduckdb::__PostgresFunctionGuard__<decltype(&FUNC), &FUNC>(__func__, __VA_ARGS__)
-
 
 duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query);
 

--- a/include/pgduckdb/utility/allocator.hpp
+++ b/include/pgduckdb/utility/allocator.hpp
@@ -8,8 +8,9 @@ struct DuckDBMallocator {
 
 	DuckDBMallocator() = default;
 
-    template<class U>
-    constexpr DuckDBMallocator(const DuckDBMallocator <U>&) noexcept {}
+	template <class U>
+	constexpr DuckDBMallocator(const DuckDBMallocator<U> &) noexcept {
+	}
 
 	[[nodiscard]] T *
 	allocate(std::size_t n) {
@@ -31,10 +32,16 @@ struct DuckDBMallocator {
 	}
 };
 
-template<class T, class U>
-bool operator==(const DuckDBMallocator <T>&, const DuckDBMallocator <U>&) { return true; }
+template <class T, class U>
+bool
+operator==(const DuckDBMallocator<T> &, const DuckDBMallocator<U> &) {
+	return true;
+}
 
-template<class T, class U>
-bool operator!=(const DuckDBMallocator <T>&, const DuckDBMallocator <U>&) { return false; }
+template <class T, class U>
+bool
+operator!=(const DuckDBMallocator<T> &, const DuckDBMallocator<U> &) {
+	return false;
+}
 
 } // namespace pgduckdb

--- a/include/pgduckdb/utility/copy.hpp
+++ b/include/pgduckdb/utility/copy.hpp
@@ -5,4 +5,4 @@ extern "C" {
 #include "nodes/plannodes.h"
 }
 
-const char* MakeDuckdbCopyQuery(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment *query_env);
+const char *MakeDuckdbCopyQuery(PlannedStmt *pstmt, const char *query_string, struct QueryEnvironment *query_env);

--- a/include/pgduckdb/utility/cpp_wrapper.hpp
+++ b/include/pgduckdb/utility/cpp_wrapper.hpp
@@ -28,7 +28,7 @@ __CPPFunctionGuard__(const char *func_name, FuncArgs... args) {
 	elog(ERROR, "(PGDuckDB/%s) %s", func_name, error_message);
 }
 
-}
+} // namespace pgduckdb
 
 #define InvokeCPPFunc(FUNC, ...) pgduckdb::__CPPFunctionGuard__<decltype(&FUNC), &FUNC>(__FUNCTION__, __VA_ARGS__)
 


### PR DESCRIPTION
In #496 I failed to include the `.hpp` in my clang-format run. This does
that too, and updates our `format-all` rule accordingly.
