### PR TITLE
Use new clang-format in CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,8 +19,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install clang-format (11.0.1) and ruff
-        run: python3 -m pip install "clang-format==11.0.1" ruff
+      - name: Install clang-format and ruff
+        run: python3 -m pip install -r dev_requirements.txt
       - name: Run clang-format
         run: git clang-format refs/remotes/origin/main --diff
       - name: Run ruff check

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -205,7 +205,7 @@ ConvertBinaryDatum(const duckdb::Value &value) {
 	auto str = value.GetValueUnsafe<duckdb::string_t>();
 	auto blob_len = str.GetSize();
 	auto blob = str.GetDataUnsafe();
-	bytea* result = (bytea *)palloc0(blob_len + VARHDRSZ);
+	bytea *result = (bytea *)palloc0(blob_len + VARHDRSZ);
 	SET_VARSIZE(result, blob_len + VARHDRSZ);
 	memcpy(VARDATA(result), blob, blob_len);
 	return PointerGetDatum(result);


### PR DESCRIPTION
In #496 we started using the newest clang-format to format our files,
but CI was still installing the old version. This meant that we were not
catching some unformatted files correctly. An example of this being:
https://github.com/duckdb/pg_duckdb/pull/511#discussion_r1901376718

This starts using the correct clang-format version in CI too and formats
any incorrectly formatted files.
