### PR TITLE
Fix temporary tables CTAS test

### DIFF
--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -226,8 +226,17 @@ SELECT * FROM t;
 (1 row)
 
 -- CTAS from DuckDB table to postgres table
-CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t_heap;
+CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t;
 SELECT * FROM t_heap2;
+ c 
+---
+ 1
+(1 row)
+
+-- CTAS from postgres table to postgres table (not actually handled by
+-- pg_duckdb, but should still work)
+CREATE TEMP TABLE t_heap3(c) USING heap AS SELECT * FROM t_heap;
+SELECT * FROM t_heap3;
  c 
 ---
  1
@@ -472,4 +481,4 @@ SELECT * FROM ta;
  3 | 3
 (6 rows)
 
-DROP TABLE webpages, t, t_heap, t_heap2, ta, tb, tc, td;
+DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -159,8 +159,13 @@ CREATE TEMP TABLE t(b) USING duckdb AS SELECT * FROM t_heap;
 SELECT * FROM t;
 
 -- CTAS from DuckDB table to postgres table
-CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t_heap;
+CREATE TEMP TABLE t_heap2(c) USING heap AS SELECT * FROM t;
 SELECT * FROM t_heap2;
+
+-- CTAS from postgres table to postgres table (not actually handled by
+-- pg_duckdb, but should still work)
+CREATE TEMP TABLE t_heap3(c) USING heap AS SELECT * FROM t_heap;
+SELECT * FROM t_heap3;
 
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 
@@ -250,4 +255,4 @@ INSERT INTO ta (a) SELECT * FROM generate_series(1, 3); -- OK
 INSERT INTO ta (b) SELECT * FROM generate_series(1, 3); -- OK
 SELECT * FROM ta;
 
-DROP TABLE webpages, t, t_heap, t_heap2, ta, tb, tc, td;
+DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td;


### PR DESCRIPTION
It was [pointed out][1] by @dpxcc that one of our tests was not testing what it was describing to test. This fixes that. To be clear the functionality was already working.

[1]: https://github.com/duckdb/pg_duckdb/pull/241#discussion_r1904832729
