### PR TITLE
Add `duckdb.log_pg_subplans` GUC setting

### DIFF
--- a/include/pgduckdb/pg/explain.hpp
+++ b/include/pgduckdb/pg/explain.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "pgduckdb/pg/declarations.hpp"
+
+namespace pgduckdb {
+const char *ExplainPGQuery(const char *query_str);
+} // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -1,6 +1,7 @@
 #pragma once
 
 extern bool duckdb_force_execution;
+extern bool duckdb_log_pg_subplans;
 extern int duckdb_maximum_threads;
 extern char *duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -11,6 +11,8 @@
 
 namespace pgduckdb {
 
+bool IsExplaining();
+
 // Global State
 
 struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {

--- a/src/pg/explain.cpp
+++ b/src/pg/explain.cpp
@@ -1,0 +1,33 @@
+
+extern "C" {
+#include "postgres.h"
+#include "lib/stringinfo.h"
+#include "executor/spi.h"
+}
+
+#include "pgduckdb/pg/explain.hpp"
+
+namespace pgduckdb {
+const char *
+ExplainPGQuery(const char *query_str) {
+	StringInfo explain_query_si = makeStringInfo();
+	// Must be created before SPI_connect to be in the right context
+	StringInfo explain_result_si = makeStringInfo();
+	appendStringInfo(explain_query_si, "EXPLAIN (%s)", query_str);
+
+	SPI_connect();
+	int ret = SPI_exec(explain_query_si->data, 0);
+	if (ret != SPI_OK_UTILITY) {
+		elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
+	}
+
+	for (uint64_t proc = 0; proc < SPI_processed; ++proc) {
+		HeapTuple tuple = SPI_tuptable->vals[proc];
+		char *row = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 1);
+		appendStringInfo(explain_result_si, "%s\n", row);
+	}
+
+	SPI_finish();
+	return explain_result_si->data;
+}
+} // namespace pgduckdb

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -15,6 +15,7 @@ extern "C" {
 static void DuckdbInitGUC(void);
 
 bool duckdb_force_execution = false;
+bool duckdb_log_pg_subplans = false;
 int duckdb_max_workers_per_postgres_scan = 2;
 int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
@@ -182,4 +183,7 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.motherduck_default_database",
 	                     "Which database in MotherDuck to designate as default (in place of my_db)",
 	                     &duckdb_motherduck_default_database, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
+
+	DefineCustomVariable("duckdb.log_pg_subplans", "Log plan when scanning Postgres relations",
+	                     &duckdb_log_pg_subplans);
 }


### PR DESCRIPTION
When enabled, dump the query and plan executed by PG during DuckDB execution.

Example:

```
y=# SET duckdb.log_pg_subplans = true;
SET
y=# SET duckdb.force_execution = true;
SET
y=# select count(*) from f;
INFO:  Query:
SELECT COUNT(*) FROM public.f
INFO:  Plan:
Aggregate  (cost=1693.00..1693.01 rows=1 width=8)
  ->  Seq Scan on f  (cost=0.00..1443.00 rows=100000 width=0)

 count
--------
 100000
(1 row)
```