### PR TITLE
[easy] [no-op] Suppress compiler warning

### DIFF
--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -52,7 +52,7 @@ PglzDecompressDatum(const struct varlena *value) {
 struct varlena *
 Lz4DecompresDatum(const struct varlena *value) {
 #ifndef USE_LZ4
-	(void) value; /* keep compiler quiet */
+	(void)value; /* keep compiler quiet */
 	return NULL;
 #else
 	struct varlena *result = (struct varlena *)duckdb_malloc(VARDATA_COMPRESSED_GET_EXTSIZE(value) + VARHDRSZ);

--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -52,7 +52,8 @@ PglzDecompressDatum(const struct varlena *value) {
 struct varlena *
 Lz4DecompresDatum(const struct varlena *value) {
 #ifndef USE_LZ4
-	return NULL; /* keep compiler quiet */
+	(void) value; /* keep compiler quiet */
+	return NULL;
 #else
 	struct varlena *result = (struct varlena *)duckdb_malloc(VARDATA_COMPRESSED_GET_EXTSIZE(value) + VARHDRSZ);
 


### PR DESCRIPTION
... otherwise have compiler warning
```
[4/492] Building CXX object src/planner/binder...query_node.dir/ub_duckdb_bind_query_node.cpp.osrc/pgduckdb_detoast.cpp: In function 'varlena* pgduckdb::Lz4DecompresDatum(const varlena*)':
src/pgduckdb_detoast.cpp:53:41: warning: unused parameter 'value' [-Wunused-parameter]
   53 | Lz4DecompresDatum(const struct varlena *value) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~^~~~~
```