### PR TITLE
Start one background worker on first DuckDB query

### DIFF
--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -2,6 +2,7 @@
 
 namespace pgduckdb {
 
+void InitBackgroundWorkersShmem(void);
 void StartBackgroundWorkerIfNeeded(void);
 void TriggerActivity(void);
 

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -2,7 +2,7 @@
 
 namespace pgduckdb {
 
-void InitBackgroundWorker(void);
+void StartBackgroundWorkerIfNeeded(void);
 void TriggerActivity(void);
 
 extern bool is_background_worker;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -46,6 +46,7 @@ _PG_init(void) {
 	DuckdbInitGUC();
 	DuckdbInitHooks();
 	DuckdbInitNode();
+	pgduckdb::InitBackgroundWorkersShmem();
 	pgduckdb::RegisterDuckdbXactCallback();
 }
 } // extern "C"

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -46,7 +46,6 @@ _PG_init(void) {
 	DuckdbInitGUC();
 	DuckdbInitHooks();
 	DuckdbInitNode();
-	pgduckdb::InitBackgroundWorker();
 	pgduckdb::RegisterDuckdbXactCallback();
 }
 } // extern "C"

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -279,12 +279,12 @@ CanTakeLockForDatabase(Oid database_oid) {
 	auto fd = open(lock_file_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		auto err = strerror(errno);
-		elog(ERROR, "Could not take lock on file '%s': %s", lock_file_name, err);
+		elog(ERROR, "Could not open file '%s': %s", lock_file_name, err);
 	}
 
 	// Take exclusive lock on the file
 	auto ret = flock(fd, LOCK_EX | LOCK_NB);
-	if (ret == EWOULDBLOCK) {
+	if (ret == EWOULDBLOCK || ret == EAGAIN) {
 		return false;
 	}
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -94,7 +94,7 @@ BackgroundWorkerCheck(duckdb::Connection *connection, int64 *last_activity_count
 	pgduckdb::SyncMotherDuckCatalogsWithPg_Cpp(false, connection->context.get());
 }
 
-bool CanTakeLockForDatabase(Oid database_oid);
+bool CanTakeBgwLockForDatabase(Oid database_oid);
 
 } // namespace pgduckdb
 
@@ -103,7 +103,7 @@ extern "C" {
 PGDLLEXPORT void
 pgduckdb_background_worker_main(Datum /* main_arg */) {
 	elog(LOG, "started pg_duckdb background worker");
-	if (!pgduckdb::CanTakeLockForDatabase(0)) {
+	if (!pgduckdb::CanTakeBgwLockForDatabase(0)) {
 		elog(LOG, "pg_duckdb background worker: could not take lock for database '%u'. Will exit.", 0);
 		return;
 	}
@@ -274,7 +274,7 @@ Attempts to take a lock on a file named 'pgduckdb_worker_<database_oid>.lock'
 If the lock is taken, the function returns true. If the lock is not taken, the function returns false.
 */
 bool
-CanTakeLockForDatabase(Oid database_oid) {
+CanTakeBgwLockForDatabase(Oid database_oid) {
 	char lock_file_name[MAXPGPATH];
 	snprintf(lock_file_name, MAXPGPATH, "%s/%s.pgduckdb_worker.%d", DataDir, PG_TEMP_FILE_PREFIX, database_oid);
 

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -346,8 +346,6 @@ StartBackgroundWorkerIfNeeded(void) {
 
 void
 TriggerActivity(void) {
-	// The lock may not be initialized yet since we lazily start the BGW
-	// It is fine to skip it then because we force a check on the first iteration
 	if (!IsMotherDuckEnabled()) {
 		return;
 	}

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -299,6 +299,14 @@ CanTakeLockForDatabase(Oid database_oid) {
 
 void
 InitBackgroundWorkersShmem(void) {
+	/* Set up the shared memory hooks */
+#if PG_VERSION_NUM >= 150000
+	prev_shmem_request_hook = shmem_request_hook;
+	shmem_request_hook = ShmemRequest;
+#else
+	ShmemRequest();
+#endif
+
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = ShmemStartup;
 }
@@ -333,14 +341,6 @@ StartBackgroundWorkerIfNeeded(void) {
 
 	// Register the worker
 	RegisterDynamicBackgroundWorker(&worker, NULL);
-
-	/* Set up the shared memory hooks */
-#if PG_VERSION_NUM >= 150000
-	prev_shmem_request_hook = shmem_request_hook;
-	shmem_request_hook = ShmemRequest;
-#else
-	ShmemRequest();
-#endif
 }
 
 void

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -296,6 +296,12 @@ CanTakeLockForDatabase(Oid database_oid) {
 	return true;
 }
 
+void
+InitBackgroundWorkersShmem(void) {
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = ShmemStartup;
+}
+
 /*
 Will start the background worker if:
 - MotherDuck is enabled (TODO: should be database-specific)
@@ -334,8 +340,6 @@ StartBackgroundWorkerIfNeeded(void) {
 #else
 	ShmemRequest();
 #endif
-	prev_shmem_startup_hook = shmem_startup_hook;
-	shmem_startup_hook = ShmemStartup;
 }
 
 void

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "pgduckdb/pgduckdb.h"
 #include "pgduckdb/vendor/pg_list.hpp"
 #include "pgduckdb/pgduckdb_metadata_cache.hpp"
+#include "pgduckdb/pgduckdb_background_worker.hpp"
 #include "pgduckdb/pgduckdb_guc.h"
 
 namespace pgduckdb {
@@ -87,9 +88,11 @@ InvalidateCaches(Datum /*arg*/, int /*cache_id*/, uint32 hash_value) {
 	if (hash_value != schema_hash_value) {
 		return;
 	}
+
 	if (!cache.valid) {
 		return;
 	}
+
 	cache.valid = false;
 	if (cache.installed) {
 		list_free(cache.duckdb_only_functions);
@@ -211,6 +214,9 @@ IsExtensionRegistered() {
 	if (cache.installed) {
 		/* If the extension is installed we can build the rest of the cache */
 		BuildDuckdbOnlyFunctions();
+
+		StartBackgroundWorkerIfNeeded();
+
 		cache.table_am_oid = GetSysCacheOid1(AMNAME, Anum_pg_am_oid, CStringGetDatum("duckdb"));
 
 		cache.schema_oid = get_namespace_oid("duckdb", false);


### PR DESCRIPTION
Up until now, we were starting the background worker as part of the extension.

The problem with this approach is that it imposes a unique worker, and thus cannot updated multiple database.

In preparation to have one BGW per database, this PR triggers the start of a background worker when `IsExtensionRegistered` is called and the cache is populated.

We've prevented potential race conditions that would cause two bgw to start by checking a lock on a temporary file.

Note: a [following PR](https://github.com/duckdb/pg_duckdb/pull/545) will actually start one BGW per database