### PR TITLE
Fix case insensitivity issues

### DIFF
--- a/include/pgduckdb/catalog/pgduckdb_transaction.hpp
+++ b/include/pgduckdb/catalog/pgduckdb_transaction.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/transaction/transaction.hpp"
 #include "pgduckdb/pg/declarations.hpp"
 
@@ -26,12 +27,12 @@ public:
 private:
 	duckdb::string name;
 	duckdb::unique_ptr<PostgresSchema> schema;
-	duckdb::case_insensitive_map_t<duckdb::unique_ptr<PostgresTable>> tables;
+	duckdb::unordered_map<duckdb::string, duckdb::unique_ptr<PostgresTable>> tables;
 };
 
 class PostgresContextState : public duckdb::ClientContextState {
 public:
-	duckdb::case_insensitive_map_t<SchemaItems> schemas;
+	duckdb::unordered_map<duckdb::string, SchemaItems> schemas;
 	void QueryEnd() override;
 };
 

--- a/test/regression/expected/case_insensitivity.out
+++ b/test/regression/expected/case_insensitivity.out
@@ -1,0 +1,23 @@
+CREATE TABLE a(b int);
+CREATE TABLE "A"(c int);
+INSERT INTO a VALUES(1);
+SELECT * FROM a, "A" as aa;
+ b | c 
+---+---
+(0 rows)
+
+CREATE SCHEMA b;
+CREATE SCHEMA "B";
+CREATE TABLE b.a(d int);
+CREATE TABLE "B".a(e int);
+INSERT INTO b.a VALUES(1);
+SELECT * FROM b.a, "B".a as aa;
+ d | e 
+---+---
+(0 rows)
+
+DROP TABLE a, "A";
+DROP SCHEMA CASCADE b, "B";
+ERROR:  syntax error at or near "b"
+LINE 1: DROP SCHEMA CASCADE b, "B";
+                            ^

--- a/test/regression/sql/case_insensitivity.sql
+++ b/test/regression/sql/case_insensitivity.sql
@@ -1,0 +1,34 @@
+CREATE TABLE a(b int);
+CREATE TABLE "A"(c int);
+INSERT INTO a VALUES(1);
+INSERT INTO "A" VALUES(2);
+
+-- BUG: This fails because DuckDB considers the aliasses "a" and "A" to be
+-- equivalent. This is something that can probably be fixed most easily in
+-- DuckDB by having a mode in which aliases are case-sensitive.
+SELECT * FROM a, "A";
+-- Luckily there's an easy workaround for that
+SELECT * FROM a, "A" as a2;
+
+CREATE SCHEMA b;
+CREATE SCHEMA "B";
+
+CREATE TABLE b.a(d int);
+CREATE TABLE "B".a(e int);
+
+INSERT INTO b.a VALUES(3);
+INSERT INTO "B".a VALUES(4);
+
+-- This actually succeeds, in contrast to the similar query above. because the
+-- tables have the same casing in Postgres too, so Postgres will give them
+-- unique automatic aliases.
+SELECT * FROM b.a, "B".a;
+-- We can make it fail in the same way with an explicit alias though.
+SELECT * FROM b.a, "B".a as "A";
+-- With different explicit aliases it should obviously succeed too..
+SELECT * FROM b.a, "B".a as a2;
+
+set client_min_messages TO WARNING;
+DROP TABLE a, "A";
+DROP SCHEMA b, "B" CASCADE;
+


### PR DESCRIPTION
Without this change it's impossible to reference two Postgres tables in the same query that only differ in casing. This fixes that by not using a `case_insentive_map` to track the Postgres table and schema names. While this doesn't completely fix all issues caused by case insentivity mismatch between Postgres and DuckDB it does fix the major one described in #116.

Fixes #116
