### PR TITLE
Fix MacOS build

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -239,7 +239,7 @@ ConvertTimestampDatum(const duckdb::Value &value) {
 		break;
 	default:
 		// Since we don't want to handle anything here
-		rawValue = rawValue;
+		break;
 	}
 	return rawValue - pgduckdb::PGDUCKDB_DUCK_TIMESTAMP_OFFSET;
 }


### PR DESCRIPTION
Fix MacOS compilation error:
```
src/pgduckdb_types.cpp:242:12: error: explicitly assigning value of variable of type 'int64_t' (aka 'long long') to itself [-Werror,-Wself-assign]
  242 |                 rawValue = rawValue;
      |                 ~~~~~~~~ ^ ~~~~~~~~
1 error generated.
make: *** [src/pgduckdb_types.o] Error 1
make: *** Waiting for unfinished jobs....
```