### PR TITLE
Update contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ We have several python dependencies for testing and formatting code.
 You can install these dependencies like this:
 ```bash
 # Needed only once
-pip -m venv env
+python -m venv env
 # Needed every time you open a new terminal
 source env/bin/activate
 # Needed only once, or when dependencies change


### PR DESCRIPTION
When I'm setting up the python dependency, I found existing command doesn't work on my end.

Error message is
```
[/workspaces/pg_duckdb] (hjiang/support-interval-type-2) 
postgres@dd042a1658a0$ pip3 -m venv

Usage:   
  pip3 <command> [options]

no such option: -m
[/workspaces/pg_duckdb] (hjiang/support-interval-type-2) 
postgres@dd042a1658a0$ pip -m venv

Usage:   
  pip <command> [options]

no such option: -m
```
Instead, `python -m venv env` seems to be the correct command
```
[/workspaces/pg_duckdb] (hjiang/support-interval-type-2) 
postgres@dd042a1658a0$ python3 -m venv env
[/workspaces/pg_duckdb] (hjiang/support-interval-type-2) 
postgres@dd042a1658a0$ echo $?
0
```