### PR TITLE
Add test that runs DuckDB its test_all_types function

### DIFF
--- a/test/regression/expected/test_all_types.out
+++ b/test/regression/expected/test_all_types.out
@@ -1,0 +1,127 @@
+\x on
+SET bytea_output = 'escape';
+SELECT * FROM duckdb.query($$
+FROM test_all_types()
+SELECT * exclude(
+    tinyint, -- PG14 outputs this differently currently
+    varint,
+    TIME,
+    time_tz,
+    bit,
+    small_enum,
+    medium_enum,
+    large_enum,
+    timestamptz_array,
+    struct,
+    struct_of_arrays,
+    array_of_structs,
+    map,
+    "union",
+    fixed_int_array,
+    fixed_varchar_array,
+    fixed_nested_int_array,
+    fixed_nested_varchar_array,
+    fixed_struct_array,
+    struct_of_fixed_array,
+    fixed_array_of_int_list,
+    list_of_fixed_int_array,
+    nested_int_array, -- The nested array has different lengths, which is not possible in PG
+)
+$$)
+-[ RECORD 1 ]---+-------------------------------------------------------------------------------------------------------------------------------------
+bool            | f
+smallint        | -32768
+int             | -2147483648
+bigint          | -9223372036854775808
+hugeint         | 0
+uhugeint        | 0
+utinyint        | 0
+usmallint       | 0
+uint            | 0
+ubigint         | 0
+date            | 07-14-5881580
+timestamp       | Sun Jan 10 08:01:49.551616 294247
+timestamp_s     | Sun Jan 10 08:01:49.551616 294247
+timestamp_ms    | Sun Jan 10 08:01:49.551616 294247
+timestamp_ns    | Wed Sep 22 00:00:00 1677
+timestamp_tz    | Sun Jan 10 00:01:49.551616 294247 PST
+float           | -3.4028235e+38
+double          | -1.7976931348623157e+308
+dec_4_1         | -999.9
+dec_9_4         | -99999.9999
+dec_18_6        | -999999999999.999999
+dec38_10        | -9999999999999999999999999999.9999999999
+uuid            | 00000000-0000-0000-0000-000000000000
+interval        | @ 0
+varchar         | 🦆🦆🦆🦆🦆🦆
+blob            | thisisalongblob\000withnullbytes
+int_array       | {}
+double_array    | {}
+date_array      | {}
+timestamp_array | {}
+varchar_array   | {}
+-[ RECORD 2 ]---+-------------------------------------------------------------------------------------------------------------------------------------
+bool            | t
+smallint        | 32767
+int             | 2147483647
+bigint          | 9223372036854775807
+hugeint         | 170141183460469231731687303715884105727
+uhugeint        | 340282366920938463463374607431768211455
+utinyint        | 255
+usmallint       | 65535
+uint            | 4294967295
+ubigint         | 18446744073709551615
+date            | 07-10-5881580
+timestamp       | Sun Jan 10 04:00:54.775806 294247
+timestamp_s     | Sun Jan 10 04:00:54 294247
+timestamp_ms    | Sun Jan 10 04:00:54.775 294247
+timestamp_ns    | Fri Apr 11 23:47:16.854775 2262
+timestamp_tz    | Sat Jan 09 20:00:54.775806 294247 PST
+float           | 3.4028235e+38
+double          | 1.7976931348623157e+308
+dec_4_1         | 999.9
+dec_9_4         | 99999.9999
+dec_18_6        | 999999999999.999999
+dec38_10        | 9999999999999999999999999999.9999999999
+uuid            | ffffffff-ffff-ffff-ffff-ffffffffffff
+interval        | @ 83 years 3 mons 999 days 16 mins 39.999999 secs
+varchar         | goo
+blob            | \000\000\000a
+int_array       | {42,999,NULL,NULL,-42}
+double_array    | {42,NaN,Infinity,-Infinity,NULL,-42}
+date_array      | {01-01-1970,07-11-5881580,07-13-5881580,NULL,05-12-2022}
+timestamp_array | {"Thu Jan 01 00:00:00 1970","Sun Jan 10 04:00:54.775807 294247","Sun Jan 10 04:00:54.775809 294247",NULL,"Thu May 12 16:23:45 2022"}
+varchar_array   | {🦆🦆🦆🦆🦆🦆,goose,NULL,""}
+-[ RECORD 3 ]---+-------------------------------------------------------------------------------------------------------------------------------------
+bool            | 
+smallint        | 
+int             | 
+bigint          | 
+hugeint         | 
+uhugeint        | 
+utinyint        | 
+usmallint       | 
+uint            | 
+ubigint         | 
+date            | 
+timestamp       | 
+timestamp_s     | 
+timestamp_ms    | 
+timestamp_ns    | 
+timestamp_tz    | 
+float           | 
+double          | 
+dec_4_1         | 
+dec_9_4         | 
+dec_18_6        | 
+dec38_10        | 
+uuid            | 
+interval        | 
+varchar         | 
+blob            | 
+int_array       | 
+double_array    | 
+date_array      | 
+timestamp_array | 
+varchar_array   | 
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -6,6 +6,7 @@ test: execution_error
 test: extensions
 test: type_support
 test: array_type_support
+test: test_all_types
 test: views
 test: non_superuser
 test: projection_pushdown_unsupported_type

--- a/test/regression/sql/test_all_types.sql
+++ b/test/regression/sql/test_all_types.sql
@@ -1,0 +1,30 @@
+\x on
+SET bytea_output = 'escape';
+SELECT * FROM duckdb.query($$
+FROM test_all_types()
+SELECT * exclude(
+    tinyint, -- PG14 outputs this differently currently
+    varint,
+    TIME,
+    time_tz,
+    bit,
+    small_enum,
+    medium_enum,
+    large_enum,
+    timestamptz_array,
+    struct,
+    struct_of_arrays,
+    array_of_structs,
+    map,
+    "union",
+    fixed_int_array,
+    fixed_varchar_array,
+    fixed_nested_int_array,
+    fixed_nested_varchar_array,
+    fixed_struct_array,
+    struct_of_fixed_array,
+    fixed_array_of_int_list,
+    list_of_fixed_int_array,
+    nested_int_array, -- The nested array has different lengths, which is not possible in PG
+)
+$$)


### PR DESCRIPTION
This is an easy way to test conversion from Postgres to DuckDB for types
that don't have an equivalent in Postgres.

It also gives us an easy todo list of types that we don't support yet.
