### PR TITLE
Build images on dedicated runners

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,38 +15,53 @@ on:
 jobs:
   docker:
     name: Build Docker
-    runs-on: ubuntu-24.04
     strategy:
       matrix:
         postgres: ["14", "15", "16", "17"]
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm"]
 
+    runs-on: ${{ matrix.runner }}
+
+    env:
+      BUILDKIT_PROGRESS: plain
+      POSTGRES_VERSION: ${{ matrix.postgres }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: pgduckdb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - name: Set env
+      - name: Compute platform
+        id: compute_platform
         run: |
-          echo "POSTGRES_VERSION=${{ matrix.postgres }}" >> $GITHUB_ENV
+          # Set platform depending on which runner we're using
+          if [ "${{ matrix.runner }}" = "ubuntu-24.04" ]; then
+            echo "platform=amd64" >> "$GITHUB_OUTPUT"
+          else
+            echo "platform=arm64" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ steps.compute_platform.outputs.platform }}
+
       - name: docker bake
         uses: docker/bake-action@v5
         with:
           targets: pg_duckdb_${{ matrix.postgres }}
           push: true
           set: |
-            *.platform=linux/amd64,linux/arm64
+            *.platform=linux/${{ steps.compute_platform.outputs.platform }}
             *.cache-to=type=gha,mode=max
             *.cache-from=type=gha
-            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}
-            ${{ !contains(github.ref_name, '/') && format('postgres.tags=pgduckdb/pgduckdb:{0}-{1}', matrix.postgres, github.ref_name) || '' }}
+            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
+            ${{ !contains(github.ref_name, '/') && format('postgres.tags=pgduckdb/pgduckdb:{0}-${1}-{2}', matrix.postgres, steps.compute_platform.outputs.platform, github.ref_name) || '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER postgres
 # Selectively copy the files that we need. Sadly we need separate COPY commands
 # for each directory, because docker puts only the contents of the source
 # directory into the target directory, and not the directory itself too.
-COPY --chown=postgres:postgres Makefile Makefile.global pg_duckdb.control .
+COPY --chown=postgres:postgres Makefile Makefile.global pg_duckdb.control ./
 COPY --chown=postgres:postgres .git/modules/third_party/duckdb/HEAD .git/modules/third_party/duckdb/HEAD
 COPY --chown=postgres:postgres sql sql
 COPY --chown=postgres:postgres src src


### PR DESCRIPTION
Docker build was recently failing because building an image for the ARM64 CPU on an AMD64 runner was prohibitively slow.

In this PR, we build each image on a dedicated runner matching the target platform.

In a following one, we will merge the two images and push them under an unified tag.