### PR TITLE
Build images on target platforms

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,9 @@
 name: Build Docker
 
+permissions:
+  id-token: write
+  contents: write
+
 on:
   push:
     tags: ["v*"]
@@ -34,6 +38,13 @@ jobs:
           username: pgduckdb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Containers
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
@@ -60,7 +71,7 @@ jobs:
       - name: Attempt to pull previous image
         run: |
           docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
-
+          docker pull ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -78,9 +89,11 @@ jobs:
           set: |
             *.platform=linux/${{ steps.compute_platform.outputs.platform }}
             *.cache-to=type=gha,mode=max
+            *.cache-from=type=registry,ref=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            *.cache-from=type=registry,ref=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
             *.cache-from=type=gha
-            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
-            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            postgres.tags=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
+            postgres.tags=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
 
   docker_merge:
     name: Merge Docker image for Postgres ${{ matrix.postgres }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,12 +40,25 @@ jobs:
       - name: Compute platform
         id: compute_platform
         run: |
+          # Tag is XX-YYYYY-<branch>-latest so 16 + branch name length
+          # since maximum docker tag is 128 characters, we need to truncate the branch name to 112
+          BRANCH=$(echo "${{ github.head_ref || github.ref_name }}" \
+              | sed 's/[^a-zA-Z0-9\-]/-/g' \
+              | cut -c 1-112 | tr '[:upper:]' '[:lower:]' \
+              | sed -e 's/-*$//')
+
+          echo "branch_tag=$BRANCH" >> "$GITHUB_OUTPUT"
           # Set platform depending on which runner we're using
           if [ "${{ matrix.runner }}" = "ubuntu-24.04" ]; then
             echo "platform=amd64" >> "$GITHUB_OUTPUT"
           else
             echo "platform=arm64" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Attempt to pull previous image
+        run: |
+          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
+
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -65,7 +78,7 @@ jobs:
             *.cache-to=type=gha,mode=max
             *.cache-from=type=gha
             postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
-            ${{ !contains(github.ref_name, '/') && format('postgres.tags=pgduckdb/pgduckdb:{0}-${1}-{2}', matrix.postgres, steps.compute_platform.outputs.platform, github.ref_name) || '' }}
+            postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
 
   docker_merge:
     name: Merge Docker image for Postgres ${{ matrix.postgres }}
@@ -84,8 +97,8 @@ jobs:
 
       - name: Pull images
         run: |
-          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }}
-          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+          docker pull --platform linux/amd64 pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }}
+          docker pull --platform linux/arm64 pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
           docker manifest create \
                     pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
             --amend pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }} \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -64,9 +64,7 @@ jobs:
       - name: Attempt to pull previous image
         run: |
           docker pull pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          docker pull moby/buildkit:buildx-stable-1
 
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,6 +25,8 @@ jobs:
     env:
       BUILDKIT_PROGRESS: plain
       POSTGRES_VERSION: ${{ matrix.postgres }}
+    outputs:
+      branch_tag: ${{ steps.compute_platform.outputs.branch_tag }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -99,8 +101,13 @@ jobs:
         run: |
           docker pull --platform linux/amd64 pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }}
           docker pull --platform linux/arm64 pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
-          docker manifest create \
-                    pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
-            --amend pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }} \
-            --amend pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
-          docker manifest push pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}
+
+          BRANCH="${{ needs.docker_build.outputs.branch_tag }}"
+
+          docker buildx imagetools create \
+            --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
+            --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${BRANCH}-latest \
+            pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }} \
+            pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+
+          docker buildx imagetools inspect pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,7 +30,8 @@ jobs:
       BUILDKIT_PROGRESS: plain
       POSTGRES_VERSION: ${{ matrix.postgres }}
     outputs:
-      branch_tag: ${{ steps.compute_platform.outputs.branch_tag }}
+      branch_tag: ${{ steps.params.outputs.branch_tag }}
+      target_repo: ${{ steps.params.outputs.target_repo }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -43,33 +44,45 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Compute platform
-        id: compute_platform
+      - name: Compute job parameters
+        id: params
         run: |
           # Tag is XX-YYYYY-<branch>-latest so 16 + branch name length
           # since maximum docker tag is 128 characters, we need to truncate the branch name to 112
           BRANCH=$(echo "${{ github.head_ref || github.ref_name }}" \
-              | sed 's/[^a-zA-Z0-9\-]/-/g' \
+              | sed 's/[^a-zA-Z0-9\-\.]/-/g' \
               | cut -c 1-112 | tr '[:upper:]' '[:lower:]' \
               | sed -e 's/-*$//')
 
-          echo "branch_tag=$BRANCH" >> "$GITHUB_OUTPUT"
           # Set platform depending on which runner we're using
           if [ "${{ matrix.runner }}" = "ubuntu-24.04" ]; then
-            echo "platform=amd64" >> "$GITHUB_OUTPUT"
+            PLATFORM=amd64
           else
-            echo "platform=arm64" >> "$GITHUB_OUTPUT"
+            PLATFORM=arm64
           fi
+
+          # If main or tag, then push to `pgduckdb/pgduckdb`
+          git fetch --tags
+          if [ "$BRANCH" = "main" ] || git rev-parse --verify $BRANCH^{tag} > /dev/null 2>&1; then
+            TARGET_REPO='pgduckdb/pgduckdb'
+          else
+            TARGET_REPO='pgduckdb/ci-builds'
+          fi
+
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target_repo=$TARGET_REPO" >> "$GITHUB_OUTPUT"
+          echo "latest_image=pgduckdb/ci-builds:${{ matrix.postgres }}-${PLATFORM}-${BRANCH}-latest" >> "$GITHUB_OUTPUT"
 
       - name: Attempt to pull previous image
         run: |
-          docker pull pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
+          docker pull ${{ steps.params.outputs.latest_image }} || true
           docker pull moby/buildkit:buildx-stable-1
 
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/${{ steps.compute_platform.outputs.platform }}
+          platforms: linux/${{ steps.params.outputs.platform }}
 
       - name: docker bake
         uses: docker/bake-action@v5
@@ -77,12 +90,12 @@ jobs:
           targets: pg_duckdb_${{ matrix.postgres }}
           push: true
           set: |
-            *.platform=linux/${{ steps.compute_platform.outputs.platform }}
-            *.cache-from=type=registry,ref=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            *.platform=linux/${{ steps.params.outputs.platform }}
+            *.cache-from=type=registry,ref=${{ steps.params.outputs.latest_image }}
             *.cache-from=type=gha,scope=${{ github.workflow }}
             *.cache-to=type=gha,mode=max,scope=${{ github.workflow }}
-            postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
-            postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.params.outputs.platform }}-${{ github.sha }}
+            postgres.tags=${{ steps.params.outputs.latest_image }}
 
   docker_merge:
     name: Merge Docker image for Postgres ${{ matrix.postgres }}
@@ -105,19 +118,13 @@ jobs:
           docker pull --platform linux/arm64 pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
           BRANCH="${{ needs.docker_build.outputs.branch_tag }}"
-
-          # If main or tag, then push to `pgduckdb/pgduckdb`
-          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "v"* ]; then
-            TARGET_REPO='pgduckdb/pgduckdb'
-          else
-            TARGET_REPO='pgduckdb/ci-builds'
-            SHA_TAG="--tag ${TARGET_REPO}:${{ matrix.postgres }}-${{ github.sha }}"
-          fi
+          TARGET_REPO="${{ needs.docker_build.outputs.target_repo }}"
 
           echo "Will push merged image to '${TARGET_REPO}'."
-          docker buildx imagetools create ${SHA_TAG} \
-            --tag ${TARGET_REPO}:${{ matrix.postgres }}-${BRANCH} \
+          docker buildx imagetools create \
+            --tag     ${TARGET_REPO}:${{ matrix.postgres }}-${BRANCH}         \
+            --tag pgduckdb/ci-builds:${{ matrix.postgres }}-${{ github.sha }} \
             pgduckdb/ci-builds:${{ matrix.postgres }}-amd64-${{ github.sha }} \
             pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
-          docker buildx imagetools inspect ${TARGET_REPO}:${{ matrix.postgres }}-${{ github.sha }}
+          docker buildx imagetools inspect pgduckdb/ci-builds:${{ matrix.postgres }}-${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -80,9 +80,9 @@ jobs:
           push: true
           set: |
             *.platform=linux/${{ steps.compute_platform.outputs.platform }}
-            *.cache-to=type=gha,mode=max
             *.cache-from=type=registry,ref=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
-            *.cache-from=type=gha
+            *.cache-from=type=gha,scope=${{ github.workflow }}
+            *.cache-to=type=gha,mode=max,scope=${{ github.workflow }}
             postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
             postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker:
-    name: Build Docker
+  docker_build:
+    name: Build Docker image for Postgres ${{ matrix.postgres }} on ${{ matrix.runner }}
     strategy:
       matrix:
         postgres: ["14", "15", "16", "17"]
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
       - name: Compute platform
         id: compute_platform
         run: |
@@ -65,3 +66,28 @@ jobs:
             *.cache-from=type=gha
             postgres.tags=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
             ${{ !contains(github.ref_name, '/') && format('postgres.tags=pgduckdb/pgduckdb:{0}-${1}-{2}', matrix.postgres, steps.compute_platform.outputs.platform, github.ref_name) || '' }}
+
+  docker_merge:
+    name: Merge Docker image for Postgres ${{ matrix.postgres }}
+    strategy:
+      matrix:
+        postgres: ["14", "15", "16", "17"]
+
+    runs-on: ubuntu-24.04
+    needs: docker_build
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: pgduckdb
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull images
+        run: |
+          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }}
+          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+          docker manifest create \
+                    pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
+            --amend pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }} \
+            --amend pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+          docker manifest push pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,13 +38,6 @@ jobs:
           username: pgduckdb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GitHub Containers
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
-
       - name: Checkout pg_duckdb extension code
         uses: actions/checkout@v4
         with:
@@ -71,7 +64,7 @@ jobs:
       - name: Attempt to pull previous image
         run: |
           docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
-          docker pull ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
+          docker pull pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -90,10 +83,10 @@ jobs:
             *.platform=linux/${{ steps.compute_platform.outputs.platform }}
             *.cache-to=type=gha,mode=max
             *.cache-from=type=registry,ref=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
-            *.cache-from=type=registry,ref=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            *.cache-from=type=registry,ref=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
             *.cache-from=type=gha
-            postgres.tags=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
-            postgres.tags=ghcr.io/duckdb/pg_duckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
+            postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
+            postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
 
   docker_merge:
     name: Merge Docker image for Postgres ${{ matrix.postgres }}
@@ -112,15 +105,15 @@ jobs:
 
       - name: Pull images
         run: |
-          docker pull --platform linux/amd64 pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }}
-          docker pull --platform linux/arm64 pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+          docker pull --platform linux/amd64 pgduckdb/ci-builds:${{ matrix.postgres }}-amd64-${{ github.sha }}
+          docker pull --platform linux/arm64 pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
           BRANCH="${{ needs.docker_build.outputs.branch_tag }}"
 
           docker buildx imagetools create \
             --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
             --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${BRANCH}-latest \
-            pgduckdb/pgduckdb:${{ matrix.postgres }}-amd64-${{ github.sha }} \
-            pgduckdb/pgduckdb:${{ matrix.postgres }}-arm64-${{ github.sha }}
+            pgduckdb/ci-builds:${{ matrix.postgres }}-amd64-${{ github.sha }} \
+            pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
           docker buildx imagetools inspect pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Attempt to pull previous image
         run: |
-          docker pull pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
           docker pull pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest || true
 
       - name: Set up QEMU
@@ -82,7 +81,6 @@ jobs:
           set: |
             *.platform=linux/${{ steps.compute_platform.outputs.platform }}
             *.cache-to=type=gha,mode=max
-            *.cache-from=type=registry,ref=pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
             *.cache-from=type=registry,ref=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ steps.compute_platform.outputs.branch_tag }}-latest
             *.cache-from=type=gha
             postgres.tags=pgduckdb/ci-builds:${{ matrix.postgres }}-${{ steps.compute_platform.outputs.platform }}-${{ github.sha }}
@@ -103,17 +101,25 @@ jobs:
           username: pgduckdb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull images
+      - name: Merge images
         run: |
           docker pull --platform linux/amd64 pgduckdb/ci-builds:${{ matrix.postgres }}-amd64-${{ github.sha }}
           docker pull --platform linux/arm64 pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
           BRANCH="${{ needs.docker_build.outputs.branch_tag }}"
 
-          docker buildx imagetools create \
-            --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }} \
-            --tag pgduckdb/pgduckdb:${{ matrix.postgres }}-${BRANCH}-latest \
+          # If main or tag, then push to `pgduckdb/pgduckdb`
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "v"* ]; then
+            TARGET_REPO='pgduckdb/pgduckdb'
+          else
+            TARGET_REPO='pgduckdb/ci-builds'
+            SHA_TAG="--tag ${TARGET_REPO}:${{ matrix.postgres }}-${{ github.sha }}"
+          fi
+
+          echo "Will push merged image to '${TARGET_REPO}'."
+          docker buildx imagetools create ${SHA_TAG} \
+            --tag ${TARGET_REPO}:${{ matrix.postgres }}-${BRANCH} \
             pgduckdb/ci-builds:${{ matrix.postgres }}-amd64-${{ github.sha }} \
             pgduckdb/ci-builds:${{ matrix.postgres }}-arm64-${{ github.sha }}
 
-          docker buildx imagetools inspect pgduckdb/pgduckdb:${{ matrix.postgres }}-${{ github.sha }}
+          docker buildx imagetools inspect ${TARGET_REPO}:${{ matrix.postgres }}-${{ github.sha }}


### PR DESCRIPTION
* Build one image per {platform, PG version} and push it to `pgduckdb/ci-builds`
* For each PG version, pull both image built for each version and merge it in a single one
* push it to:
  * `pgduckdb/pgduckdb` if `main` or a tag (release)
  * `pgduckdb/ci-builds` otherwise