### PR TITLE
Detoast columns that are needed

### DIFF
--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -126,8 +126,6 @@ ToastFetchDatum(struct varlena *attr) {
 		return result;
 	}
 
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
-
 	if (!PostgresFunctionGuard(table_relation_fetch_toast_slice, toast_pointer, attrsize, result)) {
 		duckdb_free(result);
 		throw duckdb::InternalException("(PGDuckDB/ToastFetchDatum) Error toast relation is NULL");

--- a/test/regression/expected/basic.out
+++ b/test/regression/expected/basic.out
@@ -64,3 +64,13 @@ SELECT * FROM t JOIN s ON a = b;
 
 DROP TABLE t;
 DROP TABLE s;
+-- Check that we are counting detoasted value
+CREATE TABLE t(a INT, b VARCHAR);
+INSERT INTO t SELECT g, repeat('ABCDE', 10000) FROM generate_series(1, 10) g;
+SELECT LENGTH(b) FROM t WHERE a = 5;
+ length 
+--------
+  50000
+(1 row)
+
+DROP TABLE t;

--- a/test/regression/sql/basic.sql
+++ b/test/regression/sql/basic.sql
@@ -47,3 +47,9 @@ CREATE TABLE s (b INT);
 SELECT * FROM t JOIN s ON a = b;
 DROP TABLE t;
 DROP TABLE s;
+
+-- Check that we are counting detoasted value
+CREATE TABLE t(a INT, b VARCHAR);
+INSERT INTO t SELECT g, repeat('ABCDE', 10000) FROM generate_series(1, 10) g;
+SELECT LENGTH(b) FROM t WHERE a = 5;
+DROP TABLE t;


### PR DESCRIPTION
If columns contains value that could not fit into heap page we need to detoast it before passing to duckdb execution.