### PR TITLE
Don't sync MotherDuck metadata forever

### DIFF
--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-void DuckdbInitBackgroundWorker(void);
-
 namespace pgduckdb {
 
-void SyncMotherDuckCatalogsWithPg(bool drop_with_cascade);
+void InitBackgroundWorker(void);
+void TriggerActivity(void);
+
+extern bool is_background_worker;
 extern bool doing_motherduck_sync;
 extern char *current_duckdb_database_name;
 extern char *current_motherduck_catalog_version;

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -15,3 +15,4 @@ extern int duckdb_motherduck_enabled;
 extern char *duckdb_motherduck_token;
 extern char *duckdb_postgres_role;
 extern char *duckdb_motherduck_default_database;
+extern char *duckdb_motherduck_background_catalog_refresh_inactivity_timeout;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -20,6 +20,7 @@ int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
 char *duckdb_motherduck_postgres_database = strdup("postgres");
 char *duckdb_motherduck_default_database = strdup("");
+char *duckdb_motherduck_background_catalog_refresh_inactivity_timeout = strdup("5 minutes");
 char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;
@@ -44,7 +45,7 @@ _PG_init(void) {
 	DuckdbInitGUC();
 	DuckdbInitHooks();
 	DuckdbInitNode();
-	DuckdbInitBackgroundWorker();
+	pgduckdb::InitBackgroundWorker();
 	pgduckdb::RegisterDuckdbXactCallback();
 }
 } // extern "C"
@@ -186,4 +187,9 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.motherduck_default_database",
 	                     "Which database in MotherDuck to designate as default (in place of my_db)",
 	                     &duckdb_motherduck_default_database, PGC_POSTMASTER, GUC_SUPERUSER_ONLY);
+
+	DefineCustomVariable("duckdb.motherduck_background_catalog_refresh_inactivity_timeout",
+	                     "When to stop syncing of the motherduck catalog when no activity has taken place",
+	                     &duckdb_motherduck_background_catalog_refresh_inactivity_timeout, PGC_POSTMASTER,
+	                     GUC_SUPERUSER_ONLY);
 }

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -20,7 +20,7 @@ int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
 char *duckdb_motherduck_postgres_database = strdup("postgres");
 char *duckdb_motherduck_default_database = strdup("");
-char *duckdb_motherduck_background_catalog_refresh_inactivity_timeout = strdup("5 minutes");
+char *duckdb_motherduck_background_catalog_refresh_inactivity_timeout = strdup("");
 char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -169,7 +169,9 @@ force_motherduck_sync(PG_FUNCTION_ARGS) {
 }
 
 namespace pgduckdb {
+#if PG_VERSION_NUM >= 150000
 static shmem_request_hook_type prev_shmem_request_hook = NULL;
+#endif
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 /*
@@ -178,8 +180,10 @@ static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
  */
 static void
 ShmemRequest(void) {
+#if PG_VERSION_NUM >= 150000
 	if (prev_shmem_request_hook)
 		prev_shmem_request_hook();
+#endif
 
 	RequestAddinShmemSpace(sizeof(BackgoundWorkerShmemStruct));
 }
@@ -237,8 +241,12 @@ InitBackgroundWorker(void) {
 	RegisterBackgroundWorker(&worker);
 
 	/* Set up the shared memory hooks */
+#if PG_VERSION_NUM >= 150000
 	prev_shmem_request_hook = shmem_request_hook;
 	shmem_request_hook = ShmemRequest;
+#else
+	ShmemRequest();
+#endif
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = ShmemStartup;
 }

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -191,7 +191,8 @@ DuckDBManager::Initialize() {
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 
-	if (pgduckdb::IsMotherDuckEnabled()) {
+	if (pgduckdb::IsMotherDuckEnabled() &&
+	    strlen(duckdb_motherduck_background_catalog_refresh_inactivity_timeout) > 0) {
 		pgduckdb::DuckDBQueryOrThrow(context, "SET motherduck_background_catalog_refresh_inactivity_timeout=" +
 		                                          duckdb::KeywordHelper::WriteQuoted(
 		                                              duckdb_motherduck_background_catalog_refresh_inactivity_timeout));

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
+#include "pgduckdb/pgduckdb_background_worker.hpp"
 #include "pgduckdb/catalog/pgduckdb_storage.hpp"
 #include "pgduckdb/scan/postgres_scan.hpp"
 #include "pgduckdb/pg/transactions.hpp"
@@ -191,14 +192,9 @@ DuckDBManager::Initialize() {
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 
 	if (pgduckdb::IsMotherDuckEnabled()) {
-		/*
-		 * Workaround for MotherDuck catalog sync that turns off automatically,
-		 * in case of no queries being sent to MotherDuck. Since the background
-		 * worker never sends any query to MotherDuck we need to turn this off.
-		 * So we set the timeout to an arbitrary very large value.
-		 */
-		pgduckdb::DuckDBQueryOrThrow(context,
-		                             "SET motherduck_background_catalog_refresh_inactivity_timeout='99 years'");
+		pgduckdb::DuckDBQueryOrThrow(context, "SET motherduck_background_catalog_refresh_inactivity_timeout=" +
+		                                          duckdb::KeywordHelper::WriteQuoted(
+		                                              duckdb_motherduck_background_catalog_refresh_inactivity_timeout));
 	}
 
 	LoadFunctions(context);

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -358,14 +358,9 @@ DuckdbExplainOneQueryHook(Query *query, int cursorOptions, IntoClause *into, Exp
 
 static bool
 IsOutdatedMotherduckCatalogErrcode(int error_code) {
-	switch (error_code) {
-	case ERRCODE_UNDEFINED_COLUMN:
-	case ERRCODE_UNDEFINED_SCHEMA:
-	case ERRCODE_UNDEFINED_TABLE:
-		return true;
-	default:
-		return false;
-	}
+  return error_code == ERRCODE_UNDEFINED_COLUMN ||
+         error_code == ERRCODE_UNDEFINED_SCHEMA ||
+         error_code == ERRCODE_UNDEFINED_TABLE
 }
 
 static void

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -358,9 +358,14 @@ DuckdbExplainOneQueryHook(Query *query, int cursorOptions, IntoClause *into, Exp
 
 static bool
 IsOutdatedMotherduckCatalogErrcode(int error_code) {
-  return error_code == ERRCODE_UNDEFINED_COLUMN ||
-         error_code == ERRCODE_UNDEFINED_SCHEMA ||
-         error_code == ERRCODE_UNDEFINED_TABLE
+	switch (error_code) {
+	case ERRCODE_UNDEFINED_COLUMN:
+	case ERRCODE_UNDEFINED_SCHEMA:
+	case ERRCODE_UNDEFINED_TABLE:
+		return true;
+	default:
+		return false;
+	}
 }
 
 static void


### PR DESCRIPTION
Keeping a connection open to MotherDuck forever is undesirable from a resourcing perspective. This changes that to behave similarly to the DuckDB CLI: After 5 minutes (by default) syncing will stop. The main difficulty is to restart the syncing. In the DuckDB CLI the syncing will start again after some activity is detected, but the background worker never triggers activity. So instead we need to make sure that activity in other connections triggers a restart of the syncing in the background worker. This is done using some very simple IPC in shared memory.
