### PR TITLE
Return TEXT instead of VARCHAR columns

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1351,7 +1351,7 @@ GetPostgresArrayDuckDBType(const duckdb::LogicalType &type) {
 	case duckdb::LogicalTypeId::UINTEGER:
 		return INT8ARRAYOID;
 	case duckdb::LogicalTypeId::VARCHAR:
-		return type.IsJSONType() ? JSONARRAYOID : VARCHARARRAYOID;
+		return type.IsJSONType() ? JSONARRAYOID : TEXTARRAYOID;
 	case duckdb::LogicalTypeId::DATE:
 		return DATEARRAYOID;
 	case duckdb::LogicalTypeId::TIMESTAMP:
@@ -1408,7 +1408,7 @@ GetPostgresDuckDBType(const duckdb::LogicalType &type) {
 	case duckdb::LogicalTypeId::UINTEGER:
 		return INT8OID;
 	case duckdb::LogicalTypeId::VARCHAR:
-		return type.IsJSONType() ? JSONOID : VARCHAROID;
+		return type.IsJSONType() ? JSONOID : TEXTOID;
 	case duckdb::LogicalTypeId::DATE:
 		return DATEOID;
 	case duckdb::LogicalTypeId::TIMESTAMP:

--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -28,11 +28,17 @@ def test_md_duckdb_version(ddb, md_cur: Cursor):
 
 
 def test_md_create_table(md_cur: Cursor, ddb):
-    ddb.sql("CREATE TABLE t1(a int)")
-    ddb.sql("INSERT INTO t1 VALUES (1)")
+    ddb.sql("CREATE TABLE t1(a int, b varchar)")
+    ddb.sql("INSERT INTO t1 VALUES (1, 'abc')")
     md_cur.wait_until_table_exists("t1")
 
-    assert md_cur.sql("SELECT * FROM t1") == 1
+    assert md_cur.sql("SELECT * FROM t1") == (1, "abc")
+    assert md_cur.sql(
+        "SELECT attname, atttypid::regtype FROM pg_attribute WHERE attrelid = 't1'::regclass AND attnum > 0"
+    ) == [
+        ("a", "integer"),
+        ("b", "text"),
+    ]
     md_cur.sql("CREATE TABLE t2(a int) USING duckdb")
     md_cur.sql("INSERT INTO t2 VALUES (2)")
     assert md_cur.sql("SELECT * FROM t2") == 2

--- a/test/regression/expected/create_table_as.out
+++ b/test/regression/expected/create_table_as.out
@@ -13,6 +13,14 @@ select count(*) from webpages;
     60
 (1 row)
 
+SELECT attname, atttypid::regtype FROM pg_attribute WHERE attrelid = 'webpages'::regclass AND attname in ('column00', 'column01', 'column02') ORDER BY attname;
+ attname  | atttypid 
+----------+----------
+ column00 | bigint
+ column01 | text
+ column02 | date
+(3 rows)
+
 CREATE TEMP TABLE t_jsonb(data jsonb);
 INSERT INTO t_jsonb VALUES ('{"a": 1, "b": 2}');
 CREATE TEMP TABLE t_json AS SELECT * FROM t_jsonb WITH NO DATA;

--- a/test/regression/sql/create_table_as.sql
+++ b/test/regression/sql/create_table_as.sql
@@ -3,6 +3,7 @@ CREATE TABLE webpages AS SELECT r['column00'], r['column01'], r['column02'] FROM
 
 select * from webpages order by column00 limit 2;
 select count(*) from webpages;
+SELECT attname, atttypid::regtype FROM pg_attribute WHERE attrelid = 'webpages'::regclass AND attname in ('column00', 'column01', 'column02') ORDER BY attname;
 
 CREATE TEMP TABLE t_jsonb(data jsonb);
 INSERT INTO t_jsonb VALUES ('{"a": 1, "b": 2}');


### PR DESCRIPTION
In DuckDB the canonical name for an unlimited size text column is `VARCHAR`[1], in Postgres this is `TEXT`[2]. In DuckDB `TEXT` is simply an alias for `VARCHAR` type, and there's no way to know what was provided by the user. In Postgres these types are actually distinct, although behave exactly the same for unlimited length. Basically everyone uses `TEXT` instead of `VARCHAR`.

Currently we convert the DuckDB type to a Postgres `VARCHAR`. In many cases this doesn't really matter, because pretty much all clients handle `VARCHAR` and `TEXT` the same too. There are a few places where this leaks through though: DDL coming from a query. For example if you do a CTAS with a DuckDB query the resulting table columns will be of type `character varying` instead of `text`[3]. Similarly when creating a MotherDuck table each also `character varying` will be displayed as the type instead of `text`. In both cases that looks pretty strange to a Postgres user, and overly long. So this starts using `text` as the PG equivalent type for the DuckDB `VARCHAR` type.


[1]: https://duckdb.org/docs/sql/data_types/text.html
[2]: https://www.postgresql.org/docs/current/datatype-character.html
[3]: https://github.com/duckdb/pg_duckdb/issues/556#issuecomment-2646365871
