### PR TITLE
Print function name rather than caller

### DIFF
--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -102,7 +102,7 @@ __PostgresFunctionGuard__(const char *func_name, FuncArgs... args) {
 }
 
 #define PostgresFunctionGuard(FUNC, ...)                                                                               \
-	pgduckdb::__PostgresFunctionGuard__<decltype(&FUNC), &FUNC>(__func__, ##__VA_ARGS__)
+	pgduckdb::__PostgresFunctionGuard__<decltype(&FUNC), &FUNC>(#FUNC, ##__VA_ARGS__)
 
 duckdb::unique_ptr<duckdb::QueryResult> DuckDBQueryOrThrow(duckdb::ClientContext &context, const std::string &query);
 

--- a/include/pgduckdb/utility/cpp_wrapper.hpp
+++ b/include/pgduckdb/utility/cpp_wrapper.hpp
@@ -30,7 +30,7 @@ __CPPFunctionGuard__(const char *func_name, FuncArgs... args) {
 
 } // namespace pgduckdb
 
-#define InvokeCPPFunc(FUNC, ...) pgduckdb::__CPPFunctionGuard__<decltype(&FUNC), &FUNC>(__FUNCTION__, ##__VA_ARGS__)
+#define InvokeCPPFunc(FUNC, ...) pgduckdb::__CPPFunctionGuard__<decltype(&FUNC), &FUNC>(#FUNC, ##__VA_ARGS__)
 
 // Wrappers
 

--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -34,7 +34,7 @@ INSERT INTO int_array_2d VALUES
     ('{{11, 12, 13}, {14, 15, 16}}'),
     ('{{17, 18}, {19, 20}}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains more dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (single dimensional data, two dimensionsal type)
 CREATE TABLE int_array_2d(a INT[][]);
@@ -44,7 +44,7 @@ INSERT INTO int_array_2d VALUES
     ('{11, 12, 13}'),
     ('{17, 18}');
 SELECT * FROM int_array_2d;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Invalid Input Error: Dimensionality of the schema and the data does not match, data contains fewer dimensions than the amount of dimensions specified by the schema
 drop table int_array_2d;
 -- INT4 (two dimensional data and type)
 CREATE TABLE int_array_2d(a INT[][]);

--- a/test/regression/expected/duckdb_recycle.out
+++ b/test/regression/expected/duckdb_recycle.out
@@ -50,7 +50,7 @@ EXPLAIN SELECT count(*) FROM ta;
 -- Not allowed in a transaction
 BEGIN;
 CALL duckdb.recycle_ddb();
-ERROR:  (PGDuckDB/pgduckdb_recycle_ddb) Executor Error: (PGDuckDB/PreventInTransactionBlock) duckdb.recycle_ddb() cannot run inside a transaction block
+ERROR:  (PGDuckDB/pgduckdb_recycle_ddb_cpp) Executor Error: (PGDuckDB/::PreventInTransactionBlock) duckdb.recycle_ddb() cannot run inside a transaction block
 END;
 -- Nor in a function
 CREATE OR REPLACE FUNCTION f() RETURNS void
@@ -64,7 +64,7 @@ END;
 $$;
 SET duckdb.force_execution = false;
 SELECT * FROM f();
-ERROR:  (PGDuckDB/pgduckdb_recycle_ddb) Executor Error: (PGDuckDB/PreventInTransactionBlock) duckdb.recycle_ddb() cannot be executed from a function
+ERROR:  (PGDuckDB/pgduckdb_recycle_ddb_cpp) Executor Error: (PGDuckDB/::PreventInTransactionBlock) duckdb.recycle_ddb() cannot be executed from a function
 CONTEXT:  SQL statement "CALL duckdb.recycle_ddb()"
 PL/pgSQL function f() line 3 at CALL
 DROP TABLE ta;

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -4,7 +4,7 @@ INSERT INTO int_as_varchar SELECT * from (
 		('abc')
 ) t(a);
 SELECT a::INTEGER FROM int_as_varchar;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Conversion Error: Could not convert string 'abc' to INT32
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Conversion Error: Could not convert string 'abc' to INT32
 
 LINE 1: SELECT (a)::integer AS a FROM pgduckdb.public.int_as_varchar
                   ^

--- a/test/regression/expected/json_functions_duckdb.out
+++ b/test/regression/expected/json_functions_duckdb.out
@@ -213,7 +213,7 @@ SELECT public.json_keys('{"key1": {"a": "b", "c": 123}, "key2": {"abc": 567, "xy
 -- NOTE: This fails due to not Postgres only supporting multi-dimensional arrays
 -- when the dimensions are of the same size.
 SELECT public.json_keys('{"key1": {"a": "b", "c": 123}, "key2": {"abc": 567}}', ARRAY['key1', 'key2']);
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Expected 2 values in list at dimension 1, found 1 instead
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Invalid Input Error: Expected 2 values in list at dimension 1, found 1 instead
 -- </JSON_Keys>
 -- <JSON_STRUCTURE>
 -- Test 1: Consistent structure (simple nested JSON object)
@@ -387,7 +387,7 @@ SELECT res['family'] family FROM (
 SELECT res['family'] family, res['coolness'] coolness FROM (
     SELECT public.json_transform_strict(j, '{"family": "TINYINT", "coolness": "DOUBLE"}') res FROM example2
 ) q;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Failed to cast value to numerical: "canidae"
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Invalid Input Error: Failed to cast value to numerical: "canidae"
 SELECT res['family'] family FROM (
     SELECT public.from_json_strict(j, '{"family": "VARCHAR"}') res FROM example2
 ) q;
@@ -400,5 +400,5 @@ SELECT res['family'] family FROM (
 SELECT res['family'] family, res['coolness'] coolness FROM (
     SELECT public.from_json_strict(j, '{"family": "TINYINT", "coolness": "DOUBLE"}') res FROM example2
 ) q;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Invalid Input Error: Failed to cast value to numerical: "canidae"
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Invalid Input Error: Failed to cast value to numerical: "canidae"
 -- -- </JSON_TRANSFORM_STRICT>

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -26,7 +26,7 @@ ERROR:  permission denied for table extensions
 -- permissions checked even if it happens straight from DuckDB.
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.raw_query($$ SELECT * FROM pgduckdb.public.t $$);
-ERROR:  (PGDuckDB/pgduckdb_raw_query) Executor Error: (PGDuckDB/PostgresTableReader) permission denied for table t
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Executor Error: (PGDuckDB/ExecutorStart) permission denied for table t
 SET duckdb.force_execution = true;
 -- read_csv from the local filesystem should be disallowed
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
@@ -78,7 +78,7 @@ SELECT public.approx_count_distinct(a) FROM t;
 ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.raw_query($$ SELECT * FROM pgduckdb.public.t $$);
-ERROR:  (PGDuckDB/pgduckdb_raw_query) Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
 SET duckdb.force_execution = true;
 -- Extension installation
 SET duckdb.force_execution = false;
@@ -87,7 +87,7 @@ SELECT * FROM duckdb.install_extension('iceberg');
 ERROR:  permission denied for function install_extension
 -- Similarly when trying using raw duckdb commands
 SELECT * FROM duckdb.raw_query($$ INSTALL someextension $$);
-ERROR:  (PGDuckDB/pgduckdb_raw_query) Permission Error: File system LocalFileSystem has been disabled by configuration
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Permission Error: File system LocalFileSystem has been disabled by configuration
 SET duckdb.force_execution = true;
 -- It should be possible to install extensions as non-superuser after the
 -- following grants.
@@ -108,13 +108,13 @@ SELECT * FROM duckdb.install_extension('iceberg');
 
 -- We should handle SQL injections carefully though to only allow INSTALL
 SELECT * FROM duckdb.install_extension($$ '; select * from hacky '' $$);
-ERROR:  (PGDuckDB/install_extension) HTTP Error: Failed to download extension " '; select * from hacky '' " at URL "http://extensions.duckdb.org/v1.2.0/linux_amd64/ '; select * from hacky '' .duckdb_extension.gz" (HTTP 403)
+ERROR:  (PGDuckDB/install_extension_cpp) HTTP Error: Failed to download extension " '; select * from hacky '' " at URL "http://extensions.duckdb.org/v1.2.0/linux_amd64/ '; select * from hacky '' .duckdb_extension.gz" (HTTP 403)
 
 Candidate extensions: "delta", "excel", "sqlite_scanner", "inet", "sqlite"
 For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=v1.2.0&platform=linux_amd64&extension= '; select * from hacky '' 
 INSERT INTO duckdb.extensions (name) VALUES ($$ '; select * from hacky $$);
 SELECT * FROM duckdb.query($$ SELECT 1 $$);
-ERROR:  (PGDuckDB/DuckdbPlanNode) Parser Error: unterminated quoted string at or near "'; select * from hacky "
+ERROR:  (PGDuckDB/CreatePlan) Parser Error: unterminated quoted string at or near "'; select * from hacky "
 
 LINE 1: LOAD  '; select * from hacky 
               ^

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -463,7 +463,7 @@ SELECT * FROM tc;
 -- Set Returning Function
 TRUNCATE TABLE ta;
 INSERT INTO ta (a) SELECT generate_series(1, 3); -- failed. DuckDB expects this "INSERT INTO ta (a) FROM generate_series(1, 3)"
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Conversion Error: Unimplemented type for cast (BIGINT[] -> INTEGER)
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Conversion Error: Unimplemented type for cast (BIGINT[] -> INTEGER)
 
 LINE 1: INSERT INTO pg_temp.main.ta (a) SELECT generate_series(1, 3) AS generate_series
                                                ^

--- a/test/regression/expected/transaction_errors.out
+++ b/test/regression/expected/transaction_errors.out
@@ -1,6 +1,6 @@
 CREATE TABLE foo AS SELECT 'bar'::text AS t;
 BEGIN; SET duckdb.force_execution = true; SELECT t::integer AS t1 FROM foo; ROLLBACK;
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan) Conversion Error: Could not convert string 'bar' to INT32
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Conversion Error: Could not convert string 'bar' to INT32
 
 LINE 1: SELECT (t)::integer AS t1 FROM pgduckdb.public.foo
                   ^

--- a/test/regression/expected/transactions.out
+++ b/test/regression/expected/transactions.out
@@ -44,7 +44,7 @@ BEGIN;
 INSERT INTO t_ddb VALUES (2);
 CREATE TABLE t2(a int);
 COMMIT;
-ERROR:  (PGDuckDB/DuckdbXactCallback) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
 -- Savepoints in PG-only transactions should still work
 BEGIN;
 INSERT INTO t VALUES (2);
@@ -56,13 +56,13 @@ COMMIT;
 BEGIN;
 INSERT INTO t_ddb VALUES (2);
 SAVEPOINT my_savepoint;
-ERROR:  (PGDuckDB/DuckdbSubXactCallback) Not implemented Error: SAVEPOINT is not supported in DuckDB
+ERROR:  (PGDuckDB/DuckdbSubXactCallback_Cpp) Not implemented Error: SAVEPOINT is not supported in DuckDB
 ROLLBACK;;
 -- Also not already started ones
 BEGIN;
 SAVEPOINT my_savepoint;
 INSERT INTO t_ddb VALUES (2);
-ERROR:  (PGDuckDB/DuckdbPlanNode) Not implemented Error: SAVEPOINT and subtransactions are not supported in DuckDB
+ERROR:  (PGDuckDB/CreatePlan) Not implemented Error: SAVEPOINT and subtransactions are not supported in DuckDB
 ROLLBACK;;
 -- Unless the subtransaction is already completed
 BEGIN;


### PR DESCRIPTION
When an error is raised, we used to print the `__func__` string, which contains the current function name where the macro is placed, hence the actual "caller" of the function being wrapped.

This PR replaces the caller name with the name of the function being wrapped.

In an initial version I was displaying both, but found it to be redundant.

An alternative would be to check if caller name contains the function name (or vice-versa) which happens often when we have functions such as `TopLevelFunc` and `TopLevelFunc_cpp`, and:
* if true, only display one
* if false, display both

But that sounds a bit much.

Happy to hear some feedback :-)