### PR TITLE
Always take the global lock when using PostgresFunctionGuard

### DIFF
--- a/include/pgduckdb/logger.hpp
+++ b/include/pgduckdb/logger.hpp
@@ -46,7 +46,7 @@ namespace pgduckdb {
 		pd_prevent_errno_in_scope();                                                                                   \
 		static_assert(elevel >= DEBUG5 && elevel <= WARNING_CLIENT_ONLY, "Invalid error level");                       \
 		if (message_level_is_interesting(elevel)) {                                                                    \
-			std::lock_guard<std::mutex> lock(pgduckdb::GlobalProcessLock::GetLock());                                  \
+			std::lock_guard<std::recursive_mutex> lock(pgduckdb::GlobalProcessLock::GetLock());                        \
 			if (errstart(elevel, domain))                                                                              \
 				__VA_ARGS__, errfinish(__FILE__, __LINE__, __func__);                                                  \
 		}                                                                                                              \

--- a/include/pgduckdb/pgduckdb_process_lock.hpp
+++ b/include/pgduckdb/pgduckdb_process_lock.hpp
@@ -11,9 +11,9 @@ namespace pgduckdb {
  */
 struct GlobalProcessLock {
 public:
-	static std::mutex &
+	static std::recursive_mutex &
 	GetLock() {
-		static std::mutex lock;
+		static std::recursive_mutex lock;
 		return lock;
 	}
 };

--- a/include/pgduckdb/pgduckdb_utils.hpp
+++ b/include/pgduckdb/pgduckdb_utils.hpp
@@ -81,6 +81,7 @@ struct PostgresScopedStackReset {
 template <typename Func, Func func, typename... FuncArgs>
 typename std::invoke_result<Func, FuncArgs...>::type
 __PostgresFunctionGuard__(const char *func_name, FuncArgs... args) {
+	std::lock_guard<std::recursive_mutex> lk(pgduckdb::GlobalProcessLock::GetLock());
 	MemoryContext ctx = CurrentMemoryContext;
 	ErrorData *edata = nullptr;
 	{ // Scope for PG_END_TRY

--- a/src/catalog/pgduckdb_table.cpp
+++ b/src/catalog/pgduckdb_table.cpp
@@ -20,13 +20,13 @@ PostgresTable::PostgresTable(duckdb::Catalog &_catalog, duckdb::SchemaCatalogEnt
 }
 
 PostgresTable::~PostgresTable() {
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	CloseRelation(rel);
 }
 
 Relation
 PostgresTable::OpenRelation(Oid relid) {
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	return pgduckdb::OpenRelation(relid);
 }
 

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -255,7 +255,7 @@ PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb:
 
 	local_state.output_vector_size = 0;
 
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	for (size_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		TupleTableSlot *slot = local_state.global_state->table_reader_global_state->GetNextTuple();
 		if (pgduckdb::TupleIsNull(slot)) {

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -31,7 +31,7 @@ PostgresTableReader::PostgresTableReader(const char *table_scan_query, bool coun
     : parallel_executor_info(nullptr), parallel_worker_readers(nullptr), nreaders(0), next_parallel_reader(0),
       entered_parallel_mode(false), cleaned_up(false) {
 
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	PostgresScopedStackReset scoped_stack_reset;
 
 	List *raw_parsetree_list = PostgresFunctionGuard(pg_parse_query, table_scan_query);
@@ -123,7 +123,7 @@ PostgresTableReader::~PostgresTableReader() {
 	if (cleaned_up) {
 		return;
 	}
-	std::lock_guard<std::mutex> lock(GlobalProcessLock::GetLock());
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	PostgresTableReaderCleanup();
 }
 


### PR DESCRIPTION
This fixes some really confusing segfaults that were still occurring even after #584. Reverting #584 (while keeping this change) re-introduces other segfaults. So both fixes are necessary.