### PR TITLE
Always enter parallel mode when scanning a table in parallel

### DIFF
--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -87,10 +87,8 @@ PostgresTableReader::PostgresTableReader(const char *table_scan_query, bool coun
 			RESUME_CANCEL_INTERRUPTS();
 		}
 
-		if (!IsInParallelMode()) {
-			EnterParallelMode();
-			entered_parallel_mode = true;
-		}
+		EnterParallelMode();
+		entered_parallel_mode = true;
 
 		ParallelContext *pcxt;
 		parallel_executor_info = PostgresFunctionGuard(ExecInitParallelPlan, table_scan_planstate,


### PR DESCRIPTION
Previously we were only calling `EnterParallelMode()` if we were not already in parallel mode. And then when we were done with that the scan for which we entered parallel mode, we would call `ExitParallelMode()`. This had the problem that if we were doing two scans, we could call ExitParallelMode() before both scans were done:

1. Scan A starts: EnterParallelMode
2. Scan B starts: do nothing
3. Scan A exists: ExitParallelMode
4. Scan B is now running in parallel even though we exited parallel mode.

This was causing an assertion in the Postgres code to fail.

This change fixes that by always calling `EnterParallelMode()` when we do a parallel scan and always calling `ExitParallelMode()` when we are finished with a scan. This works because Postgres internally keeps a counter of the amount of times we entered parallel mode. So now in the above example we would do:

1. Scan A starts: EnterParallelMode(), counter 1, enter parallel mode
1. Scan B starts: EnterParallelMode(), counter 2, do nothing
3. Scan A exists: ExitParallelMode(), counter 1, do nothing
3. Scan B exists: ExitParallelMode(), counter 0, exit parallel mode


Fixes #592
