### PR TITLE
Add postgres version check in makefile

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -6,7 +6,8 @@ ifeq ($(shell expr "$(PG_MIN_VER)" \<=  "$(PG_VER)"), 0)
 $(error Minimum version of PostgreSQL required is $(PG_MIN_VER) (but have $(PG_VER)))
 endif
 
-PG_MAX_VER = 17
+# If you want to test with an unsupported PG version you can pass a different value to make
+PG_MAX_VER ?= 17
 ifeq ($(shell expr "$(PG_MAX_VER)" \>=  "$(PG_VER)"), 0)
 $(error maximum version of PostgreSQL required is $(PG_MAX_VER) (but have $(PG_VER)))
 endif

--- a/Makefile.global
+++ b/Makefile.global
@@ -1,5 +1,16 @@
 PG_CONFIG ?= pg_config
 
+PG_MIN_VER = 14
+PG_VER = $(shell $(PG_CONFIG) --version | sed "s/^[^ ]* \([0-9]*\).*$$/\1/" 2>/dev/null)
+ifeq ($(shell expr "$(PG_MIN_VER)" \<=  "$(PG_VER)"), 0)
+$(error Minimum version of PostgreSQL required is $(PG_MIN_VER) (but have $(PG_VER)))
+endif
+
+PG_MAX_VER = 17
+ifeq ($(shell expr "$(PG_MAX_VER)" \>=  "$(PG_VER)"), 0)
+$(error maximum version of PostgreSQL required is $(PG_MAX_VER) (but have $(PG_VER)))
+endif
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 PG_LIB := $(shell $(PG_CONFIG) --pkglibdir)
 PG_LIBDIR := $(shell $(PG_CONFIG) --libdir)

--- a/Makefile.global
+++ b/Makefile.global
@@ -9,7 +9,7 @@ endif
 # If you want to test with an unsupported PG version you can pass a different value to make
 PG_MAX_VER ?= 17
 ifeq ($(shell expr "$(PG_MAX_VER)" \>=  "$(PG_VER)"), 0)
-$(error maximum version of PostgreSQL required is $(PG_MAX_VER) (but have $(PG_VER)))
+$(error Maximum supported version of PostgreSQL is $(PG_MAX_VER) (but have $(PG_VER)))
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
This PR adds a version check to the makefile. I know the versions are specified in the docs but is a bit more user friendly to have the build failed with an error message.

Behavior with this patch
```console
$ PATH=/path/to/postgres/18/bin:$PATH make
Makefile.global:11: *** maximum version of PostgreSQL required is 17 (but have 18).  Stop.
```

Behavior without this patch
```bash
$ PATH=path/to/pg18/bin:$PATH make
g++ -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -O2 -std=c++17  -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -Wno-register -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Iinclude -isystem third_party/duckdb/src/include -isystem third_party/duckdb/third_party/re2 -isystem path/to/pg18/include/server -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -I. -I./ -Ipath/to/pg18/include/server -Ipath/to/pg18/include/internal  -D_GNU_SOURCE   -c -o src/pgduckdb_background_worker.o src/pgduckdb_background_worker.cpp -MMD -MP -MF .deps/pgduckdb_background_worker.Po
g++ -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -O2 -std=c++17  -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -Wno-register -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Iinclude -isystem third_party/duckdb/src/include -isystem third_party/duckdb/third_party/re2 -isystem path/to/pg18/include/server -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -I. -I./ -Ipath/to/pg18/include/server -Ipath/to/pg18/include/internal  -D_GNU_SOURCE   -c -o src/pgduckdb.o src/pgduckdb.cpp -MMD -MP -MF .deps/pgduckdb.Po
g++ -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -O2 -std=c++17  -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -Wno-register -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Iinclude -isystem third_party/duckdb/src/include -isystem third_party/duckdb/third_party/re2 -isystem path/to/pg18/include/server -Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra  -I. -I./ -Ipath/to/pg18/include/server -Ipath/to/pg18/include/internal  -D_GNU_SOURCE   -c -o src/pgduckdb_ddl.o src/pgduckdb_ddl.cpp -MMD -MP -MF .deps/pgduckdb_ddl.Po
src/pgduckdb_ddl.cpp: In function ‘void DuckdbHandleDDL(PlannedStmt*, const char*, ParamListInfo)’:
src/pgduckdb_ddl.cpp:186:49: error: cannot convert ‘Node*’ to ‘Query*’ in assignment
  186 |                         stmt->into->viewQuery = (Node *)copyObjectImpl(stmt->query);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 Node*
make: *** [Makefile.global:38: src/pgduckdb_ddl.o] Error 1

```