### PR TITLE
Rename PostgresScanTableFunction

### DIFF
--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -203,7 +203,8 @@ PostgresScanFunctionData::~PostgresScanFunctionData() {
 //
 
 PostgresScanTableFunction::PostgresScanTableFunction()
-    : TableFunction("postgres_scan", {}, PostgresScanFunction, nullptr, PostgresScanInitGlobal, PostgresScanInitLocal) {
+    : TableFunction("pgduckdb_postgres_scan", {}, PostgresScanFunction, nullptr, PostgresScanInitGlobal,
+                    PostgresScanInitLocal) {
 	named_parameters["cardinality"] = duckdb::LogicalType::UBIGINT;
 	named_parameters["relid"] = duckdb::LogicalType::UINTEGER;
 	named_parameters["snapshot"] = duckdb::LogicalType::POINTER;

--- a/test/regression/expected/duckdb_recycle.out
+++ b/test/regression/expected/duckdb_recycle.out
@@ -13,7 +13,7 @@ EXPLAIN SELECT count(*) FROM ta;
  │        count_star()       │
  └─────────────┬─────────────┘
  ┌─────────────┴─────────────┐
- │       POSTGRES_SCAN       │
+ │  PGDUCKDB_POSTGRES_SCAN   │
  │    ────────────────────   │
  │         Table: ta         │
  │                           │
@@ -37,7 +37,7 @@ EXPLAIN SELECT count(*) FROM ta;
  │        count_star()       │
  └─────────────┬─────────────┘
  ┌─────────────┴─────────────┐
- │       POSTGRES_SCAN       │
+ │  PGDUCKDB_POSTGRES_SCAN   │
  │    ────────────────────   │
  │         Table: ta         │
  │                           │


### PR DESCRIPTION
Because this can conflict with DuckDB's `postgres` extension which check scanner by name eg. https://github.com/duckdb/duckdb-postgres/blob/8461ed8b6f726564934e9c831cdc88d431e3148f/src/storage/postgres_insert.cpp#L193-L195

When `postgres` extension was loaded, the optimizer would try to then [cast](https://github.com/duckdb/duckdb-postgres/blob/8461ed8b6f726564934e9c831cdc88d431e3148f/src/storage/postgres_optimizer.cpp#L23) our `BindData` as its own, creating obvious problems :-)

Fixes #567 #547 