### PR TITLE
Date Underflow Truncate

### DIFF
--- a/date-check.cpp
+++ b/date-check.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <sstream>
+
+std::string
+FormatDate(const std::string &old_date) { // formats date from MM-DD-YYYY to YYYY-MM-DD for comparison
+	int month, day, year;                 // integers for month, day, and year
+	char sep;                             // holds the dash as the separator in each date
+
+	std::istringstream input(old_date);          // input string stream that takes the date as input
+	input >> month >> sep >> day >> sep >> year; // puts everything from old_date into input, using '-' as a separator
+
+	if (month > 12 or month < 1) { // invalid month
+		return "-1";
+	}
+	if (month == 2 and (year % 4 != 0 or (year % 100 == 0 or year % 400 != 0) and day > 28)) { // invalid leap day
+		return "-1";
+	}
+
+	std::ostringstream new_date; // out string stream to hold the correctly formatted date
+	new_date.fill('0'); // if a one-number day/month is entered, pad it with a 0 at the front (i.e. 3 becomes 03)
+	new_date.width(4);
+	new_date << year << "-";
+	new_date.width(2);
+	new_date << month << "-";
+	new_date.width(2);
+	new_date << day;
+
+	return new_date.str();
+}
+
+std::string
+VerifyDate(const std::string &date) {
+	std::string formatted = FormatDate(date); // gets the correctly formatted date for comparison
+	if (formatted == "-1") {                  // catches an error in the date before truncating
+		return "Error in date";
+	}
+
+	// setting minimum and maximum dates for comparison in YYYY-MM-DD format
+	std::string min_postgres_date = "-4712-01-01";   // lowest Postgres date in ISO format
+	std::string max_postgres_date = "5874897-12-31"; // largest Postgres date in ISO format
+
+	if (formatted < min_postgres_date) {
+		return min_postgres_date;
+	}
+	if (formatted > max_postgres_date) {
+		return max_postgres_date;
+	}
+
+	return formatted;
+}


### PR DESCRIPTION
Proposed change to resolve issue #595 

The proposed code will first convert a date to ISO8601 format, then check if it is lower than 4713 BC, the lowest date representable in Postgres (in ISO8601, the 4713 BC is -4712-01-01). If the date is lower, it will automatically truncate to the -4712-01-01. Truncating to the highest Postgres date was also included if the user-entered date was larger than the highest Postgres value