### PR TITLE
Do not set max_memory if given the empty string

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -103,7 +103,7 @@ Since any connection that uses DuckDB will have its own DuckDB instance, these s
 
 ### `duckdb.max_memory` / `duckdb.memory_limit`
 
-The maximum memory DuckDB can use within a single Postgres connection. This is somewhat comparable to Postgres its `work_mem` setting.
+The maximum memory DuckDB can use within a single Postgres connection. This is somewhat comparable to Postgres its `work_mem` setting. When set to the empty string, this will use DuckDB its normal default which is 80% of RAM.
 
 Default: `"4GB"`
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -142,7 +142,7 @@ DuckDBManager::Initialize() {
 	SET_DUCKDB_OPTION(autoinstall_known_extensions);
 	SET_DUCKDB_OPTION(autoload_known_extensions);
 
-	if (duckdb_maximum_memory != NULL) {
+	if (duckdb_maximum_memory != NULL && strlen(duckdb_maximum_memory) == 0) {
 		config.options.maximum_memory = duckdb::DBConfig::ParseMemoryLimit(duckdb_maximum_memory);
 		elog(DEBUG2, "[PGDuckDB] Set DuckDB option: 'maximum_memory'=%s", duckdb_maximum_memory);
 	}


### PR DESCRIPTION
This was already the intended behaviour, as the already existing NULL check shows. The value of a GUC is never NULL though, but can be an empty string. This keeps the NULL check for safety purposes.
