### PR TITLE
Add support for url_style secret parameter

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -24,7 +24,7 @@ VALUES ('S3', 'access_key_id', 'secret_access_key', 'session_token', 'us-east-1'
 | use_ssl | boolean | no | `true` by default; `false` is principally for use with custom minio configurations |
 | scope | text | no | The URL prefix which applies to this credential. This is used to [select between multiple credentials](scope) for the same service. |
 | connection_string | text | Azure only | Connection string for Azure |
-| url_style | text | no | Either `vhost` or `path`; `path` is principally for use with custom minio configurations |
+| url_style | text | no | Either `vhost` or `path`. Default is `vhost` for S3 and `path` for R2 and GCS. Explicitely setting it to `path` is principally for use with custom minio configurations |
 
 [scope]: https://duckdb.org/docs/configuration/secrets_manager.html#creating-multiple-secrets-for-the-same-service-type
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -24,6 +24,7 @@ VALUES ('S3', 'access_key_id', 'secret_access_key', 'session_token', 'us-east-1'
 | use_ssl | boolean | no | `true` by default; `false` is principally for use with custom minio configurations |
 | scope | text | no | The URL prefix which applies to this credential. This is used to [select between multiple credentials](scope) for the same service. |
 | connection_string | text | Azure only | Connection string for Azure |
+| url_style | text | no | Either `vhost` or `path`; `path` is principally for use with custom minio configurations |
 
 [scope]: https://duckdb.org/docs/configuration/secrets_manager.html#creating-multiple-secrets-for-the-same-service-type
 

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -6,7 +6,7 @@
 namespace pgduckdb {
 
 /* constants for duckdb.secrets */
-#define Natts_duckdb_secret                  11
+#define Natts_duckdb_secret                  12
 #define Anum_duckdb_secret_name              1
 #define Anum_duckdb_secret_type              2
 #define Anum_duckdb_secret_key_id            3
@@ -18,8 +18,10 @@ namespace pgduckdb {
 #define Anum_duckdb_secret_use_ssl           9
 #define Anum_duckdb_secret_scope             10
 #define Anum_duckdb_secret_connection_string 11
+#define Anum_duckdb_secret_url_style		 12
 
 enum SecretType { S3, R2, GCS, AZURE };
+enum UrlStyle { PATH, VIRTUAL_HOST, UNDEFINED };
 
 typedef struct DuckdbSecret {
 	std::string name;
@@ -33,9 +35,11 @@ typedef struct DuckdbSecret {
 	bool use_ssl;
 	std::string scope;
 	std::string connection_string; // Used for Azure
+	UrlStyle url_style;
 } DuckdbSecret;
 
 std::string SecretTypeToString(SecretType type);
+std::string UrlStyleToString(UrlStyle style);
 
 extern std::vector<DuckdbSecret> ReadDuckdbSecrets();
 

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -18,7 +18,7 @@ namespace pgduckdb {
 #define Anum_duckdb_secret_use_ssl           9
 #define Anum_duckdb_secret_scope             10
 #define Anum_duckdb_secret_connection_string 11
-#define Anum_duckdb_secret_url_style		 12
+#define Anum_duckdb_secret_url_style         12
 
 enum SecretType { S3, R2, GCS, AZURE };
 enum UrlStyle { PATH, VIRTUAL_HOST, UNDEFINED };

--- a/sql/pg_duckdb--0.2.0--0.3.0.sql
+++ b/sql/pg_duckdb--0.2.0--0.3.0.sql
@@ -1056,3 +1056,6 @@ GRANT ALL ON FUNCTION duckdb.cache(TEXT, TEXT) TO PUBLIC;
 GRANT ALL ON FUNCTION duckdb.cache_info() TO PUBLIC;
 GRANT ALL ON FUNCTION duckdb.cache_delete(TEXT) TO PUBLIC;
 GRANT ALL ON PROCEDURE duckdb.recycle_ddb() TO PUBLIC;
+
+-- Add "url_style" column to "secrets" table
+ALTER TABLE duckdb.secrets ADD COLUMN url_style TEXT;

--- a/sql/pg_duckdb--0.2.0--0.3.0.sql
+++ b/sql/pg_duckdb--0.2.0--0.3.0.sql
@@ -1056,6 +1056,3 @@ GRANT ALL ON FUNCTION duckdb.cache(TEXT, TEXT) TO PUBLIC;
 GRANT ALL ON FUNCTION duckdb.cache_info() TO PUBLIC;
 GRANT ALL ON FUNCTION duckdb.cache_delete(TEXT) TO PUBLIC;
 GRANT ALL ON PROCEDURE duckdb.recycle_ddb() TO PUBLIC;
-
--- Add "url_style" column to "secrets" table
-ALTER TABLE duckdb.secrets ADD COLUMN url_style TEXT;

--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -1,0 +1,2 @@
+-- Add "url_style" column to "secrets" table
+ALTER TABLE duckdb.secrets ADD COLUMN url_style TEXT;

--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -1,2 +1,0 @@
--- Add "url_style" column to "secrets" table
-ALTER TABLE duckdb.secrets ADD COLUMN url_style TEXT;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -239,6 +239,9 @@ WriteSecretQueryForS3R2OrGCP(const DuckdbSecret &secret, std::ostringstream &que
 	if (secret.scope.length()) {
 		query << ", SCOPE '" << secret.scope << "'";
 	}
+	if (secret.url_style != UrlStyle::UNDEFINED) {
+		query << ", URL_STYLE '" << UrlStyleToString(secret.url_style) << "'";
+	}
 }
 
 void

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -103,6 +103,30 @@ SecretTypeToString(SecretType type) {
 	}
 }
 
+UrlStyle
+StringToUrlStyle(const std::string &style) {
+	auto uc_style = duckdb::StringUtil::Upper(style);
+	if (uc_style == "PATH") {
+		return UrlStyle::PATH;
+	} else if (uc_style == "VHOST") {
+		return UrlStyle::VIRTUAL_HOST;
+	} else {
+		throw std::runtime_error("Invalid URL style: '" + style + "'");
+	}
+}
+
+std::string
+UrlStyleToString(UrlStyle style) {
+	switch (style) {
+	case UrlStyle::PATH:
+		return "path";
+	case UrlStyle::VIRTUAL_HOST:
+		return "vhost";
+	default:
+		throw std::runtime_error("Invalid URL style: '" + std::to_string(style) + "'");
+	}
+}
+
 std::vector<DuckdbSecret>
 ReadDuckdbSecrets() {
 	HeapTuple tuple = NULL;
@@ -156,6 +180,11 @@ ReadDuckdbSecrets() {
 
 		if (!is_null_array[Anum_duckdb_secret_connection_string - 1])
 			secret.connection_string = DatumToString(datum_array[Anum_duckdb_secret_connection_string - 1]);
+
+		if (!is_null_array[Anum_duckdb_secret_url_style - 1])
+			secret.url_style = StringToUrlStyle(DatumToString(datum_array[Anum_duckdb_secret_url_style - 1]));
+		else
+			secret.url_style = UrlStyle::UNDEFINED;
 
 		duckdb_secrets.push_back(secret);
 	}


### PR DESCRIPTION
This adds support for the `URL_STYLE` secret parameter.
Setting this parameter to `path` allows connecting to minio S3 storage.
Setting no value keeps the default behaviour and does not break the current behaviour.

This feature is requested in #151 and #207.

The code is working in my test environment.

As this is my first contribution to this project I would appreciate any feedback. Thank you for this awesome tool.