### PR TITLE
Start supporting DuckDB DDL in transactions

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -2,4 +2,14 @@
 
 Multi-statement transactions are supported in pg_duckdb. There is one important restriction on this though, which is is currently necessary to ensure the expected ACID guarantees: You cannot write to both a Postgres table and a DuckDB table in the same transaction.
 
-Sadly, this restriction also means that running DDL (e.g. `CREATE TABLE ... USING duckdb`) is currently not supported in transactions. This is due to the fact that this requires writing to metadata tables in both Postgres and DuckDB.
+Similarly you are allowed to do DDL (like `CREATE`/`DROP TABLE`) on DuckDB tables inside a transaction, but it's not allowed to combine such statements with DDL involving Postgres objects.
+
+Finally it's possible to disable this restriction completely, and allow writes to both DuckDB and Postgres in the same transaction by setting `duckdb.unsafe_allow_mixed_transactions` to `true`. **This is at your own risk** and can result in the transaction being committed only in DuckDB, but not in Postgres. This can lead to inconsistencies and even data loss. For example the following code might result in deleting the `duckdb_table`, while not copying its contents to `pg_table`:
+
+```sql
+BEGIN;
+SET LOCAL duckdb.unsafe_allow_mixed_transactions TO true;
+CREATE TABLE pg_table AS SELECT * FROM duckdb_table;
+DROP TABLE duckdb_table;
+COMMIT;
+```

--- a/include/pgduckdb/pg/transactions.hpp
+++ b/include/pgduckdb/pg/transactions.hpp
@@ -33,7 +33,7 @@ typedef void (*SubXactCallback)(SubXactEvent event, SubTransactionId mySubid, Su
 }
 
 namespace pgduckdb::pg {
-bool DidWalWrites();
+void CommandCounterIncrement();
 CommandId GetCurrentCommandId(bool used = false);
 bool IsInTransactionBlock(bool top_level);
 void PreventInTransactionBlock(bool is_top_level, const char *statement_type);

--- a/include/pgduckdb/pg/transactions.hpp
+++ b/include/pgduckdb/pg/transactions.hpp
@@ -5,6 +5,8 @@
 extern "C" {
 extern bool IsSubTransaction(void);
 
+#define FirstCommandId ((CommandId)0)
+
 /*
  * These enum definitions are vendored in so we can implement a postgres
  * XactCallback in C++. It's not expected that these will ever change.

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -1,6 +1,7 @@
 #pragma once
 
 extern bool duckdb_force_execution;
+extern bool duckdb_unsafe_allow_mixed_transactions;
 extern int duckdb_maximum_threads;
 extern char *duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;

--- a/include/pgduckdb/pgduckdb_xact.hpp
+++ b/include/pgduckdb/pgduckdb_xact.hpp
@@ -1,12 +1,27 @@
+#include "pgduckdb/pg/declarations.hpp"
+
 namespace pgduckdb {
 
 namespace pg {
 bool IsInTransactionBlock();
 void PreventInTransactionBlock(const char *statement_type);
+void SetForceAllowWrites(bool force);
+bool AllowWrites();
 } // namespace pg
 
-void ClaimCurrentCommandId();
+bool MixedWritesAllowed();
+bool DidDisallowedMixedWrites();
+void CheckForDisallowedMixedWrites();
+void RememberCommandId();
+void ClaimCurrentCommandId(bool force = false);
+void ClaimWalWrites();
+bool DidUnclaimedWalWrites();
+void RegisterDuckdbTempTable(Oid relid);
+void UnregisterDuckdbTempTable(Oid relid);
+bool IsDuckdbTempTable(Oid relid);
 void RegisterDuckdbXactCallback();
 void AutocommitSingleStatementQueries();
 void MarkStatementNotTopLevel();
+void SetStatementTopLevel(bool top_level);
+bool IsStatementTopLevel();
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_xact.hpp
+++ b/include/pgduckdb/pgduckdb_xact.hpp
@@ -12,7 +12,6 @@ bool AllowWrites();
 bool MixedWritesAllowed();
 bool DidDisallowedMixedWrites();
 void CheckForDisallowedMixedWrites();
-void RememberCommandId();
 void ClaimCurrentCommandId(bool force = false);
 void ClaimWalWrites();
 bool DidUnclaimedWalWrites();

--- a/src/pg/transactions.cpp
+++ b/src/pg/transactions.cpp
@@ -8,14 +8,14 @@ extern "C" {
 
 namespace pgduckdb::pg {
 
-bool
-DidWalWrites() {
-	return XactLastRecEnd != InvalidXLogRecPtr;
-}
-
 CommandId
 GetCurrentCommandId(bool used = false) {
 	return PostgresFunctionGuard(::GetCurrentCommandId, used);
+}
+
+void
+CommandCounterIncrement() {
+	return PostgresFunctionGuard(::CommandCounterIncrement);
 }
 
 bool

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -15,6 +15,7 @@ extern "C" {
 static void DuckdbInitGUC(void);
 
 bool duckdb_force_execution = false;
+bool duckdb_unsafe_allow_mixed_transactions = false;
 int duckdb_max_workers_per_postgres_scan = 2;
 int duckdb_motherduck_enabled = MotherDuckEnabled::MOTHERDUCK_AUTO;
 char *duckdb_motherduck_token = strdup("");
@@ -128,6 +129,10 @@ static const struct config_enum_entry motherduck_enabled_options[] = {
 static void
 DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution);
+
+	DefineCustomVariable("duckdb.unsafe_allow_mixed_transactions",
+	                     "Allow mixed transactions between DuckDB and Postgres",
+	                     &duckdb_unsafe_allow_mixed_transactions);
 
 	DefineCustomVariable("duckdb.enable_external_access", "Allow the DuckDB to access external state.",
 	                     &duckdb_enable_external_access, PGC_SUSET);

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -155,8 +155,6 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 		return;
 	}
 
-	pgduckdb::RememberCommandId();
-
 	/*
 	 * Time to check for disallowed mixed writes here. The handling for some of
 	 * the DuckDB DDL, marks some some specific mixed writes as allowed. If we

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -1,9 +1,12 @@
 #include "pgduckdb/pgduckdb_planner.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
+#include "pgduckdb/pgduckdb_xact.hpp"
+#include "pgduckdb/pgduckdb_guc.h"
 
 extern "C" {
 #include "postgres.h"
 #include "access/tableam.h"
+#include "access/relation.h"
 #include "catalog/pg_type.h"
 #include "commands/event_trigger.h"
 #include "fmgr.h"
@@ -43,7 +46,6 @@ extern "C" {
  */
 static bool ctas_skip_data = false;
 
-static bool top_level_ddl = true;
 static ProcessUtility_hook_type prev_process_utility_hook = NULL;
 
 /*
@@ -98,6 +100,43 @@ WrapQueryInDuckdbQueryCall(Query *query, List *target_list) {
 #endif
 }
 
+/*
+ * This is a DROP pre-check to check if a DROP TABLE command tries to drop both
+ * DuckDB and Postgres tables. Doing so is not allowed within an explicit
+ * transaction. It also claims the command ID
+ */
+static void
+DropTablePreCheck(DropStmt *stmt) {
+	Assert(stmt->removeType == OBJECT_TABLE);
+	bool dropping_duckdb_tables = false;
+	bool dropping_postgres_tables = false;
+	foreach_node(List, obj, stmt->objects) {
+		/* check if table is duckdb table */
+		RangeVar *rel = makeRangeVarFromNameList(obj);
+		Oid relid = RangeVarGetRelid(rel, AccessShareLock, true);
+		if (!OidIsValid(relid)) {
+			/* Let postgres deal with this. It's possible that this is fine in
+			 * case of DROP ... IF EXISTS */
+			continue;
+		}
+
+		Relation relation = relation_open(relid, AccessShareLock);
+		if (pgduckdb::IsDuckdbTable(relation)) {
+			if (!dropping_duckdb_tables) {
+				pgduckdb::ClaimCurrentCommandId();
+				dropping_duckdb_tables = true;
+			}
+		} else {
+			dropping_postgres_tables = true;
+		}
+		relation_close(relation, NoLock);
+	}
+
+	if (!pgduckdb::MixedWritesAllowed() && dropping_duckdb_tables && dropping_postgres_tables) {
+		elog(ERROR, "Dropping both DuckDB and non-DuckDB tables in the same transaction is not supported");
+	}
+}
+
 static void
 DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo params) {
 	if (!pgduckdb::IsExtensionRegistered()) {
@@ -107,11 +146,38 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 
 	Node *parsetree = pstmt->utilityStmt;
 
-	if (IsA(parsetree, CreateTableAsStmt)) {
+	if (IsA(parsetree, TransactionStmt)) {
+		/*
+		 * Don't do anything for transaction statements, we have the
+		 * transaction XactCallback functions to handle those in
+		 * pgduckdb_xact.cpp
+		 */
+		return;
+	}
+
+	pgduckdb::RememberCommandId();
+
+	/*
+	 * Time to check for disallowed mixed writes here. The handling for some of
+	 * the DuckDB DDL, marks some some specific mixed writes as allowed. If we
+	 * don't check now, we might accidentally also mark disallowed mixed writes
+	 * from before as allowed.
+	 */
+
+	if (IsA(parsetree, CreateStmt)) {
+		auto stmt = castNode(CreateStmt, parsetree);
+		char *access_method = stmt->accessMethod ? stmt->accessMethod : default_table_access_method;
+		bool is_duckdb_table = strcmp(access_method, "duckdb") == 0;
+		if (is_duckdb_table) {
+			pgduckdb::ClaimCurrentCommandId();
+		}
+		return;
+	} else if (IsA(parsetree, CreateTableAsStmt)) {
 		auto stmt = castNode(CreateTableAsStmt, parsetree);
 		char *access_method = stmt->into->accessMethod ? stmt->into->accessMethod : default_table_access_method;
 		bool is_duckdb_table = strcmp(access_method, "duckdb") == 0;
 		if (is_duckdb_table) {
+			pgduckdb::ClaimCurrentCommandId();
 			/*
 			 * Force skipData to false for duckdb tables, so that Postgres does
 			 * not execute the query, and save the original value in ctas_skip_data
@@ -211,6 +277,17 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 			elog(ERROR, "Changing a schema to a ddb$ schema is currently not supported");
 		}
 		return;
+	} else if (IsA(parsetree, DropStmt)) {
+		auto stmt = castNode(DropStmt, parsetree);
+		switch (stmt->removeType) {
+		case OBJECT_TABLE:
+			DropTablePreCheck(stmt);
+			break;
+		default:
+			/* ignore anything else */
+			break;
+		}
+		return;
 	}
 }
 
@@ -233,22 +310,22 @@ DuckdbUtilityHook_Cpp(PlannedStmt *pstmt, const char *query_string, bool read_on
 	}
 
 	/*
-	 * We need this prev_top_level_ddl variable because top_level_ddl because
-	 * its possible that the first DDL command then triggers a second DDL
-	 * command. The first of which is at the top level, but the second of which
-	 * is not. So this way we make sure that the global top_level_ddl
-	 * variable matches whichever level we're currently executing.
+	 * We need this prev_top_level_ddl variable because its possible that the
+	 * first DDL command then triggers a second DDL command. The first of which
+	 * is at the top level, but the second of which is not. So this way we make
+	 * sure that the our top level state is the correct one for the current
+	 * command.
 	 *
 	 * NOTE: We don't care about resetting the global variable in case of an
 	 * error, because we'll set it correctly for the next command anyway.
 	 */
-	bool prev_top_level_ddl = top_level_ddl;
-	top_level_ddl = context == PROCESS_UTILITY_TOPLEVEL;
+	bool prev_top_level_ddl = pgduckdb::IsStatementTopLevel();
+	pgduckdb::SetStatementTopLevel(context == PROCESS_UTILITY_TOPLEVEL);
 
 	DuckdbHandleDDL(pstmt, query_string, params);
 	prev_process_utility_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
 
-	top_level_ddl = prev_top_level_ddl;
+	pgduckdb::SetStatementTopLevel(prev_top_level_ddl);
 }
 
 static void
@@ -301,19 +378,6 @@ CheckOnCommitSupport(OnCommitAction on_commit) {
 }
 
 extern "C" {
-
-/*
- * Stores the oids of temporary DuckDB tables for this backend. We cannot store
- * these Oids in the duckdb.tables table. This is because these tables are
- * automatically dropped when the backend terminates, but for this type of drop
- * no event trigger is fired. So if we would store these Oids in the
- * duckdb.tables table, then the oids of temporary tables would stay in there
- * after the backend terminates (which would be bad, because the table doesn't
- * exist anymore). To solve this, we store the oids in this in-memory set
- * instead, because that memory will automatically be cleared when the current
- * backend terminates.
- */
-static std::unordered_set<Oid> temporary_duckdb_tables;
 
 DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo)) /* internal error */
@@ -394,7 +458,7 @@ DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 	 * temporary_duckdb_tables for more details.
 	 */
 	if (is_temporary) {
-		temporary_duckdb_tables.insert(relid);
+		pgduckdb::RegisterDuckdbTempTable(relid);
 	} else {
 		Oid saved_userid;
 		int sec_context;
@@ -412,11 +476,14 @@ DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 			values[2] = CStringGetTextDatum(pgduckdb::current_motherduck_catalog_version);
 			nulls[2] = ' ';
 		}
+
+		pgduckdb::pg::SetForceAllowWrites(true);
 		ret = SPI_execute_with_args(R"(
 			INSERT INTO duckdb.tables (relid, duckdb_db, motherduck_catalog_version, default_database)
 			VALUES ($1, $2, $3, $4)
 			)",
 		                            lengthof(arg_types), arg_types, values, nulls, false, 0);
+		pgduckdb::pg::SetForceAllowWrites(false);
 
 		/* Revert back to original privileges */
 		SetUserIdAndSecContext(saved_userid, sec_context);
@@ -436,11 +503,7 @@ DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 		PG_RETURN_NULL();
 	}
 
-	/*
-	 * For now, we don't support DuckDB DDL queries in transactions,
-	 * because they write to both the Postgres and the DuckDB database.
-	 */
-	PreventInTransactionBlock(top_level_ddl, "DuckDB DDL statements");
+	pgduckdb::ClaimCurrentCommandId(true);
 
 	if (IsA(parsetree, CreateStmt)) {
 		auto stmt = castNode(CreateStmt, parsetree);
@@ -507,6 +570,12 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 		PG_RETURN_NULL();
 	}
 
+	/*
+	 * Save the current top level state, because our next SPI commands will
+	 * cause it to always become true.
+	 */
+	bool is_top_level = pgduckdb::IsStatementTopLevel();
+
 	SPI_connect();
 
 	/*
@@ -539,6 +608,72 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 		}
 	}
 
+	/*
+	 * We don't want to allow DROPs that involve PG objects and DuckDB tables
+	 * in the same transaction. This is not easy to disallow though, because
+	 * when dropping a DuckDB table there are also many other objects that get dropped:
+	 * 1. Each table owns two types:
+	 *	 a. the composite type matching its columns
+	 *	 b. the array of that composite type
+	 * 2. There can also be many implicitely connected things to a table, like sequences/constraints/etc
+	 *
+	 * So here we try to count all the objects that are not connected to a
+	 * table. Sadly at this stage the objects are already deleted, so there's
+	 * no way to know for sure if they were. So we use the fairly crude
+	 * approach simply not counting all the object types that are often
+	 * connected to tables. We might have missed a few, so we can start to
+	 * ignore more if we get bug reports. We also might want to change how wo
+	 * do this completely, but for now this seems to work well enough.
+	 *
+	 * One thing that we at least want to disallow (for now) is removing a
+	 * non-"ddb$" schema and all its DuckDB tables. That way if there are also
+	 * other objects in this schema, we automatically fail the drop. This is
+	 * also up for debate in the future, but it's much easier to decide that we
+	 * want to start allowing this than it is to start disallowing it.
+	 */
+	int ret = SPI_exec(R"(
+		SELECT count(*)::bigint, (count(*) FILTER (WHERE object_type = 'table'))::bigint
+		FROM pg_catalog.pg_event_trigger_dropped_objects()
+		WHERE object_type NOT IN ('type', 'sequence', 'table constraint', 'index', 'default value', 'trigger', 'toast table')
+	)",
+	                   0);
+	if (ret != SPI_OK_SELECT) {
+		elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
+	}
+
+	if (SPI_processed != 1) {
+		elog(ERROR, "expected a single row to be returned, but found %" PRIu64, static_cast<uint64_t>(SPI_processed));
+	}
+
+	int64 total_deleted;
+	int64 deleted_tables;
+
+	{
+		HeapTuple tuple = SPI_tuptable->vals[0];
+		bool isnull;
+		Datum total_deleted_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 1, &isnull);
+		if (isnull) {
+			elog(ERROR, "Expected number of deleted objects but found NULL");
+		}
+		total_deleted = DatumGetInt64(total_deleted_datum);
+
+		Datum deleted_tables_datum = SPI_getbinval(tuple, SPI_tuptable->tupdesc, 2, &isnull);
+		if (isnull) {
+			elog(ERROR, "Expected number of deleted tables but found NULL");
+		}
+		deleted_tables = DatumGetInt64(deleted_tables_datum);
+	}
+
+	if (deleted_tables == 0) {
+		/*
+		 * No tables were deleted at all, thus also no duckdb tables. So no
+		 * need to do anything.
+		 */
+		AtEOXact_GUC(false, save_nestlevel);
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+
 	Oid saved_userid;
 	int sec_context;
 	GetUserIdAndSecContext(&saved_userid, &sec_context);
@@ -554,7 +689,8 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 	 * Here we first handle the non-temporary tables.
 	 */
 
-	int ret = SPI_exec(R"(
+	pgduckdb::pg::SetForceAllowWrites(true);
+	ret = SPI_exec(R"(
 		DELETE FROM duckdb.tables
 		USING (
 			SELECT objid, schema_name, object_name
@@ -564,7 +700,8 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 		WHERE relid = objid
 		RETURNING objs.schema_name, objs.object_name
 		)",
-	                   0);
+	               0);
+	pgduckdb::pg::SetForceAllowWrites(false);
 
 	/* Revert back to original privileges */
 	SetUserIdAndSecContext(saved_userid, sec_context);
@@ -579,6 +716,8 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 	 * regular heap tables in transactions anymore.
 	 */
 	duckdb::Connection *connection = nullptr;
+
+	int64 deleted_duckdb_tables = 0;
 
 	/*
 	 * Now forward the DROP to DuckDB... but only if MotherDuck is actually
@@ -598,12 +737,6 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 	if (pgduckdb::IsMotherDuckEnabled() && !pgduckdb::doing_motherduck_sync) {
 		for (uint64_t proc = 0; proc < SPI_processed; ++proc) {
 			if (!connection) {
-				/*
-				 * For now, we don't support DuckDB DDL queries in
-				 * transactions, because they write to both the Postgres and
-				 * the DuckDB database.
-				 */
-				PreventInTransactionBlock(top_level_ddl, "DuckDB DDL statements");
 				/* We're going to run multiple queries in DuckDB, so we need to
 				 * start a transaction to ensure ACID guarantees hold. */
 				connection = pgduckdb::DuckDBManager::GetConnection(true);
@@ -615,6 +748,8 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 			char *drop_query = psprintf("DROP TABLE %s.%s", pgduckdb_db_and_schema_string(postgres_schema_name, true),
 			                            quote_identifier(table_name));
 			pgduckdb::DuckDBQueryOrThrow(*connection, drop_query);
+
+			deleted_duckdb_tables++;
 		}
 	}
 
@@ -642,16 +777,12 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 			elog(ERROR, "Expected relid to be returned, but found NULL");
 		}
 		Oid relid = DatumGetObjectId(relid_datum);
-		if (temporary_duckdb_tables.count(relid) == 0) {
+		if (!pgduckdb::IsDuckdbTempTable(relid)) {
 			/* It was a regular temporary table, so this DROP is allowed */
 			continue;
 		}
+
 		if (!connection) {
-			/*
-			 * For now, we don't support DuckDB DDL queries in transactions,
-			 * because they write to both the Postgres and the DuckDB database.
-			 */
-			PreventInTransactionBlock(top_level_ddl, "DuckDB DDL statements");
 			/* We're going to run multiple queries in DuckDB, so we need to
 			 * start a transaction to ensure ACID guarantees hold. */
 			connection = pgduckdb::DuckDBManager::GetConnection(true);
@@ -659,7 +790,28 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 		char *table_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 2);
 		pgduckdb::DuckDBQueryOrThrow(*connection,
 		                             std::string("DROP TABLE pg_temp.main.") + quote_identifier(table_name));
-		temporary_duckdb_tables.erase(relid);
+		pgduckdb::UnregisterDuckdbTempTable(relid);
+		deleted_duckdb_tables++;
+	}
+
+	/*
+	 * Restore "top level" state, because by running SPI commands it's now
+	 * always set to false.
+	 */
+	pgduckdb::SetStatementTopLevel(is_top_level);
+
+	if (!pgduckdb::MixedWritesAllowed() && deleted_duckdb_tables > 0) {
+		if (deleted_duckdb_tables < deleted_tables) {
+			elog(ERROR, "Dropping both DuckDB and non-DuckDB tables in the same transaction is not supported");
+		}
+
+		if (deleted_duckdb_tables < total_deleted) {
+			elog(ERROR, "Dropping both DuckDB tables and non-DuckDB objects in the same transaction is not supported");
+		}
+	}
+
+	if (deleted_duckdb_tables > 0) {
+		pgduckdb::ClaimCurrentCommandId(true);
 	}
 
 	AtEOXact_GUC(false, save_nestlevel);
@@ -761,7 +913,7 @@ DECLARE_PG_FUNCTION(duckdb_alter_table_trigger) {
 	SPI_finish();
 
 	if (needs_to_check_temporary_set) {
-		if (temporary_duckdb_tables.count(relid) == 0) {
+		if (!pgduckdb::IsDuckdbTempTable(relid)) {
 			/* It was a regular temporary table, so this ALTER is allowed */
 			PG_RETURN_NULL();
 		}

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -187,7 +187,6 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 static PlannedStmt *
 DuckdbPlannerHook_Cpp(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
 	if (pgduckdb::IsExtensionRegistered()) {
-		pgduckdb::RememberCommandId();
 		if (NeedsDuckdbExecution(parse)) {
 			pgduckdb::TriggerActivity();
 			IsAllowedStatement(parse, true);
@@ -300,8 +299,6 @@ DuckdbExecutorStartHook(QueryDesc *queryDesc, int eflags) {
 		prev_executor_start_hook(queryDesc, eflags);
 		return;
 	}
-
-	pgduckdb::RememberCommandId();
 
 	prev_executor_start_hook(queryDesc, eflags);
 	InvokeCPPFunc(DuckdbExecutorStartHook_Cpp, queryDesc);

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -164,11 +164,9 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 			elog(elevel, "DuckDB does not support modififying Postgres tables");
 			return false;
 		}
-		if (pgduckdb::pg::IsInTransactionBlock(true)) {
-			if (pgduckdb::pg::DidWalWrites()) {
-				elog(elevel, "Writing to DuckDB and Postgres tables in the same transaction block is not supported");
-				return false;
-			}
+		if (pgduckdb::DidDisallowedMixedWrites()) {
+			elog(elevel, "Writing to DuckDB and Postgres tables in the same transaction block is not supported");
+			return false;
 		}
 	}
 
@@ -189,6 +187,7 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 static PlannedStmt *
 DuckdbPlannerHook_Cpp(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
 	if (pgduckdb::IsExtensionRegistered()) {
+		pgduckdb::RememberCommandId();
 		if (NeedsDuckdbExecution(parse)) {
 			pgduckdb::TriggerActivity();
 			IsAllowedStatement(parse, true);
@@ -202,8 +201,7 @@ DuckdbPlannerHook_Cpp(Query *parse, const char *query_string, int cursor_options
 			}
 			/* If we can't create a plan, we'll fall back to Postgres */
 		}
-		if (parse->commandType != CMD_SELECT && pgduckdb::ddb::DidWrites() &&
-		    pgduckdb::pg::IsInTransactionBlock(true)) {
+		if (parse->commandType != CMD_SELECT && !pgduckdb::pg::AllowWrites()) {
 			elog(ERROR, "Writing to DuckDB and Postgres tables in the same transaction block is not supported");
 		}
 	}
@@ -302,6 +300,8 @@ DuckdbExecutorStartHook(QueryDesc *queryDesc, int eflags) {
 		prev_executor_start_hook(queryDesc, eflags);
 		return;
 	}
+
+	pgduckdb::RememberCommandId();
 
 	prev_executor_start_hook(queryDesc, eflags);
 	InvokeCPPFunc(DuckdbExecutorStartHook_Cpp, queryDesc);

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -68,16 +68,14 @@ SELECT * FROM t2 ORDER BY a;
 BEGIN;
     INSERT INTO t2 VALUES (1), (2), (3);
 END;
--- We shouldn't be able to run DuckDB DDL in transactions (yet).
+-- We should be able to run DuckDB DDL in transactions
 BEGIN;
     CREATE TEMP TABLE t3(a int);
-ERROR:  DuckDB DDL statements cannot run inside a transaction block
 END;
 BEGIN;
-    DROP TABLE t2;
-ERROR:  DuckDB DDL statements cannot run inside a transaction block
+    DROP TABLE t3;
 END;
--- But plain postgres DDL and queries should work fine
+-- Plain postgres DDL and queries should work fine too
 BEGIN;
     CREATE TEMP TABLE t4(a int) USING heap;
     INSERT INTO t4 VALUES (1);
@@ -119,7 +117,12 @@ pg_temp	main	CREATE TABLE t2(a INTEGER);
  
 (1 row)
 
-DROP TABLE t, t_heap, t2;
+-- Ensure that we can drop the table with all the supported features inside a
+-- transaction.
+BEGIN;
+DROP TABLE t;
+END;
+DROP TABLE t_heap, t2;
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 NOTICE:  result: database_name	schema_name	sql	
 VARCHAR	VARCHAR	VARCHAR	

--- a/test/regression/expected/transactions.out
+++ b/test/regression/expected/transactions.out
@@ -20,11 +20,24 @@ SELECT * FROM t_ddb ORDER BY a;
 (2 rows)
 
 ROLLBACK;
+-- Executing many write commands is fine
+BEGIN;
+INSERT INTO t_ddb VALUES (2);
+INSERT INTO t_ddb VALUES (3);
+INSERT INTO t_ddb VALUES (4);
+INSERT INTO t_ddb VALUES (5);
+INSERT INTO t_ddb VALUES (6);
+COMMIT;
 SELECT * FROM t_ddb;
  a 
 ---
  1
-(1 row)
+ 2
+ 3
+ 4
+ 5
+ 6
+(6 rows)
 
 -- Writing to PG and DDB tables in the same transaction is not supported. We
 -- fail early for simple DML (no matter the order).
@@ -36,8 +49,19 @@ ROLLBACK;
 BEGIN;
 INSERT INTO t VALUES (2);
 INSERT INTO t_ddb VALUES (2);
-ERROR:  Writing to DuckDB and Postgres tables in the same transaction block is not supported
+ERROR:  (PGDuckDB/DuckdbExecutorStartHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
 ROLLBACK;
+-- Unless users explicitely opt-in
+BEGIN;
+SET LOCAL duckdb.unsafe_allow_mixed_transactions = true;
+INSERT INTO t_ddb VALUES (4);
+INSERT INTO t VALUES (4);
+COMMIT;
+BEGIN;
+SET LOCAL duckdb.unsafe_allow_mixed_transactions = true;
+INSERT INTO t VALUES (5);
+INSERT INTO t_ddb VALUES (5);
+COMMIT;
 -- And for other writes that are not easy to detect, such as CREATE TABLE, we
 -- fail on COMMIT.
 BEGIN;
@@ -70,7 +94,7 @@ SAVEPOINT my_savepoint;
 SELECT count(*) FROM t;
  count 
 -------
-     2
+     4
 (1 row)
 
 RELEASE SAVEPOINT my_savepoint;
@@ -100,7 +124,14 @@ SELECT * FROM t_ddb ORDER BY a;
 ---
  1
  2
-(2 rows)
+ 2
+ 3
+ 4
+ 4
+ 5
+ 5
+ 6
+(9 rows)
 
 -- But if the function succeeds we should see the new value
 SELECT * FROM f(false);
@@ -114,28 +145,169 @@ SELECT * FROM t_ddb ORDER BY a;
 ---
  1
  2
+ 2
+ 3
+ 4
+ 4
+ 5
+ 5
+ 6
  8
-(3 rows)
+(10 rows)
 
--- DuckDB DDL in transactions is not allowed for now
+-- DuckDB DDL in transactions is allowed
 BEGIN;
-    CREATE TABLE t_ddb2(a int) USING duckdb;
-ERROR:  DuckDB DDL statements cannot run inside a transaction block
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1;
+    DROP TABLE t_ddb3;
 END;
--- Neither is DDL in functions
+DROP TABLE t_ddb2;
+-- Similarly is DDL in functions
 CREATE OR REPLACE FUNCTION f2() RETURNS void
     LANGUAGE plpgsql
     RETURNS NULL ON NULL INPUT
     AS
 $$
 BEGIN
-    CREATE TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1;
+    DROP TABLE t_ddb3;
 END;
 $$;
 SELECT * FROM f2();
-ERROR:  DuckDB DDL statements cannot be executed from a function
-CONTEXT:  SQL statement "CREATE TABLE t_ddb2(a int) USING duckdb"
-PL/pgSQL function f2() line 3 at SQL statement
+ f2 
+----
+ 
+(1 row)
+
+DROP TABLE t_ddb2;
+-- ...unless there's also PG only changes happing in the same transaction (no matter the order of statements).
+BEGIN;
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TABLE t_x(a int);
+END;
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+BEGIN;
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+    CREATE TABLE t_x(a int);
+END;
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+-- And again the same for functions
+CREATE OR REPLACE FUNCTION f2() RETURNS void
+    LANGUAGE plpgsql
+    RETURNS NULL ON NULL INPUT
+    AS
+$$
+BEGIN
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+END;
+$$;
+SELECT * FROM f2();
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb2(a int) USING duckdb"
+PL/pgSQL function f2() line 4 at SQL statement
+CREATE OR REPLACE FUNCTION f2() RETURNS void
+    LANGUAGE plpgsql
+    RETURNS NULL ON NULL INPUT
+    AS
+$$
+BEGIN
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+END;
+$$;
+SELECT * FROM f2();
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb2(a int) USING duckdb"
+PL/pgSQL function f2() line 4 at SQL statement
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+    CREATE TABLE t_x(a int);
+    DROP TABLE t_ddb;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+BEGIN;
+    DROP TABLE t_ddb;
+    CREATE TABLE t_x(a int);
+END;
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+BEGIN;
+    CREATE TABLE t_x(a int);
+    DROP TABLE t_ddb;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+-- Dropping both duckdb tables and postgres tables in the same command is
+-- disallowed in a transaction.
+BEGIN;
+    DROP TABLE t, t_ddb;
+ERROR:  Dropping both DuckDB and non-DuckDB tables in the same transaction is not supported
+END;
+-- Dropping both duckdb tables and postgres tables in the same command is
+-- disallowed in a transaction.
+BEGIN;
+    DROP TABLE t, t_ddb;
+ERROR:  Dropping both DuckDB and non-DuckDB tables in the same transaction is not supported
+END;
+-- In separate commands it's also not allowed
+BEGIN;
+    DROP TABLE t;
+    DROP TABLE t_ddb;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+-- ...in any order
+-- BEGIN;
+--     DROP TABLE t_ddb;
+--     DROP TABLE t;
+-- END;
+-- Non-existing tables should be allowed to be dropped in a transaction
+-- together with DuckDB.
+BEGIN;
+    DROP TABLE IF EXISTS t_ddb, t_doesnotexist;
+NOTICE:  table "t_doesnotexist" does not exist, skipping
+END;
+CREATE TEMP TABLE t_ddb(a int) USING duckdb;
+-- It should also not be allowed to drop duckdb and postgres tables in the same
+-- transaction if it's implicitely done using a DROP SCHEMA ... CASCADE.
+CREATE SCHEMA mixed;
+CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+-- Insert a row into pg_depend to make t_ddb depend on the mixed schema. We do
+-- this because wo cannot insert TEMP tables in a schema. This is meant to
+-- emulate a MotherDuck table in the mixed schema. To be clear, this is a
+-- pretty big hack. Normally you're not supposed to manually mess with
+-- pg_depend, but it's the easiest way to test this.
+-- NOTE: 1259 is the oid for pg_class, and 2615 is the oid for pg_namespace. These
+-- are not expected to change.
+INSERT INTO pg_depend(classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype) SELECT 1259, 't_ddb2'::regclass, 0, 2615, 'mixed'::regnamespace, 0, 'n';
+BEGIN;
+    DROP SCHEMA mixed CASCADE;
+NOTICE:  drop cascades to table t_ddb2
+ERROR:  Dropping both DuckDB tables and non-DuckDB objects in the same transaction is not supported
+END;
+-- We have a special message for tables
+CREATE TABLE mixed.t(a int);
+BEGIN;
+    DROP SCHEMA mixed CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table t_ddb2
+drop cascades to table mixed.t
+ERROR:  Dropping both DuckDB and non-DuckDB tables in the same transaction is not supported
+END;
+-- It should work outside of a transaction though.
+DROP SCHEMA mixed CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table t_ddb2
+drop cascades to table mixed.t
 TRUNCATE t_ddb;
 INSERT INTO t_ddb VALUES (1);
 BEGIN;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -46,16 +46,16 @@ BEGIN;
     INSERT INTO t2 VALUES (1), (2), (3);
 END;
 
--- We shouldn't be able to run DuckDB DDL in transactions (yet).
+-- We should be able to run DuckDB DDL in transactions
 BEGIN;
     CREATE TEMP TABLE t3(a int);
 END;
 
 BEGIN;
-    DROP TABLE t2;
+    DROP TABLE t3;
 END;
 
--- But plain postgres DDL and queries should work fine
+-- Plain postgres DDL and queries should work fine too
 BEGIN;
     CREATE TEMP TABLE t4(a int) USING heap;
     INSERT INTO t4 VALUES (1);
@@ -79,7 +79,13 @@ ANALYZE t;
 
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 
-DROP TABLE t, t_heap, t2;
+-- Ensure that we can drop the table with all the supported features inside a
+-- transaction.
+BEGIN;
+DROP TABLE t;
+END;
+
+DROP TABLE t_heap, t2;
 
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 

--- a/test/regression/sql/transactions.sql
+++ b/test/regression/sql/transactions.sql
@@ -12,6 +12,15 @@ INSERT INTO t_ddb VALUES (2);
 SELECT * FROM t_ddb ORDER BY a;
 ROLLBACK;
 
+-- Executing many write commands is fine
+BEGIN;
+INSERT INTO t_ddb VALUES (2);
+INSERT INTO t_ddb VALUES (3);
+INSERT INTO t_ddb VALUES (4);
+INSERT INTO t_ddb VALUES (5);
+INSERT INTO t_ddb VALUES (6);
+COMMIT;
+
 SELECT * FROM t_ddb;
 
 -- Writing to PG and DDB tables in the same transaction is not supported. We
@@ -25,6 +34,19 @@ BEGIN;
 INSERT INTO t VALUES (2);
 INSERT INTO t_ddb VALUES (2);
 ROLLBACK;
+
+-- Unless users explicitely opt-in
+BEGIN;
+SET LOCAL duckdb.unsafe_allow_mixed_transactions = true;
+INSERT INTO t_ddb VALUES (4);
+INSERT INTO t VALUES (4);
+COMMIT;
+
+BEGIN;
+SET LOCAL duckdb.unsafe_allow_mixed_transactions = true;
+INSERT INTO t VALUES (5);
+INSERT INTO t_ddb VALUES (5);
+COMMIT;
 
 -- And for other writes that are not easy to detect, such as CREATE TABLE, we
 -- fail on COMMIT.
@@ -85,12 +107,16 @@ SELECT * FROM t_ddb ORDER BY a;
 SELECT * FROM f(false);
 SELECT * FROM t_ddb ORDER BY a;
 
--- DuckDB DDL in transactions is not allowed for now
+-- DuckDB DDL in transactions is allowed
 BEGIN;
-    CREATE TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1;
+    DROP TABLE t_ddb3;
 END;
 
--- Neither is DDL in functions
+DROP TABLE t_ddb2;
+
+-- Similarly is DDL in functions
 
 CREATE OR REPLACE FUNCTION f2() RETURNS void
     LANGUAGE plpgsql
@@ -98,11 +124,137 @@ CREATE OR REPLACE FUNCTION f2() RETURNS void
     AS
 $$
 BEGIN
-    CREATE TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1;
+    DROP TABLE t_ddb3;
 END;
 $$;
 
 SELECT * FROM f2();
+
+DROP TABLE t_ddb2;
+
+-- ...unless there's also PG only changes happing in the same transaction (no matter the order of statements).
+BEGIN;
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+END;
+
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+    CREATE TABLE t_x(a int);
+END;
+
+BEGIN;
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+END;
+
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+    CREATE TABLE t_x(a int);
+END;
+
+-- And again the same for functions
+
+CREATE OR REPLACE FUNCTION f2() RETURNS void
+    LANGUAGE plpgsql
+    RETURNS NULL ON NULL INPUT
+    AS
+$$
+BEGIN
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+END;
+$$;
+
+SELECT * FROM f2();
+
+CREATE OR REPLACE FUNCTION f2() RETURNS void
+    LANGUAGE plpgsql
+    RETURNS NULL ON NULL INPUT
+    AS
+$$
+BEGIN
+    CREATE TABLE t_x(a int);
+    CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+END;
+$$;
+
+SELECT * FROM f2();
+
+BEGIN;
+    CREATE TEMP TABLE t_ddb2(a) USING duckdb AS SELECT 1;
+    CREATE TABLE t_x(a int);
+    DROP TABLE t_ddb;
+END;
+
+BEGIN;
+    DROP TABLE t_ddb;
+    CREATE TABLE t_x(a int);
+END;
+
+BEGIN;
+    CREATE TABLE t_x(a int);
+    DROP TABLE t_ddb;
+END;
+
+-- Dropping both duckdb tables and postgres tables in the same command is
+-- disallowed in a transaction.
+BEGIN;
+    DROP TABLE t, t_ddb;
+END;
+
+-- Dropping both duckdb tables and postgres tables in the same command is
+-- disallowed in a transaction.
+BEGIN;
+    DROP TABLE t, t_ddb;
+END;
+
+-- In separate commands it's also not allowed
+BEGIN;
+    DROP TABLE t;
+    DROP TABLE t_ddb;
+END;
+
+-- ...in any order
+-- BEGIN;
+--     DROP TABLE t_ddb;
+--     DROP TABLE t;
+-- END;
+
+-- Non-existing tables should be allowed to be dropped in a transaction
+-- together with DuckDB.
+BEGIN;
+    DROP TABLE IF EXISTS t_ddb, t_doesnotexist;
+END;
+CREATE TEMP TABLE t_ddb(a int) USING duckdb;
+
+
+-- It should also not be allowed to drop duckdb and postgres tables in the same
+-- transaction if it's implicitely done using a DROP SCHEMA ... CASCADE.
+CREATE SCHEMA mixed;
+CREATE TEMP TABLE t_ddb2(a int) USING duckdb;
+-- Insert a row into pg_depend to make t_ddb depend on the mixed schema. We do
+-- this because wo cannot insert TEMP tables in a schema. This is meant to
+-- emulate a MotherDuck table in the mixed schema. To be clear, this is a
+-- pretty big hack. Normally you're not supposed to manually mess with
+-- pg_depend, but it's the easiest way to test this.
+-- NOTE: 1259 is the oid for pg_class, and 2615 is the oid for pg_namespace. These
+-- are not expected to change.
+INSERT INTO pg_depend(classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype) SELECT 1259, 't_ddb2'::regclass, 0, 2615, 'mixed'::regnamespace, 0, 'n';
+BEGIN;
+    DROP SCHEMA mixed CASCADE;
+END;
+
+-- We have a special message for tables
+CREATE TABLE mixed.t(a int);
+BEGIN;
+    DROP SCHEMA mixed CASCADE;
+END;
+
+-- It should work outside of a transaction though.
+DROP SCHEMA mixed CASCADE;
 
 TRUNCATE t_ddb;
 INSERT INTO t_ddb VALUES (1);


### PR DESCRIPTION
This starts supporting DuckDB DDL in transactions. There are still some limitations, but the most common use cases should now work as expected. For the cases that are disallowed, it's possible to disable the mixed-writes detection by setting `duckdb.unsafe_allow_mixed_transactions` to `true`. This is not recommended for most usage, but it is a useful escape hatch for cases where people cannot manually control the transaction end/start.

A major change this does in the detection is that it starts to completely rely on CommandId for detecting Postgres writes. Previously we also looked at WAL, but it turns out that is very unreliable, because even read queries can trigger WAL writes (e.g. to update hint bits).