### PR TITLE
Avoid copy for VARCHAR type conversion

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -192,9 +192,9 @@ ConvertInt8Datum(const duckdb::Value &value) {
 
 static Datum
 ConvertVarCharDatum(const duckdb::Value &value) {
-	auto str = value.GetValue<duckdb::string>();
-	auto varchar = str.c_str();
-	auto varchar_len = str.size();
+	auto str = value.GetValueUnsafe<duckdb::string_t>();
+	auto varchar = str.GetDataUnsafe();
+	auto varchar_len = str.GetSize();
 
 	text *result = (text *)palloc0(varchar_len + VARHDRSZ);
 	SET_VARSIZE(result, varchar_len + VARHDRSZ);


### PR DESCRIPTION
If I don't read it wrong, the actual content inside of `VARCHAR` will be mem-copied into `result`, so we could use fat-pointer here (as long as there's no tricky padding issues like VARBIT).

How I tested:
- I build with `make install -j32`
- I tested with `make installcheck`