### PR TITLE
Ignore env folder for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ compile_commands.json
 *.bc
 *.dylib
 *.pyc
+
+env/


### PR DESCRIPTION
From [contributing](https://github.com/duckdb/pg_duckdb/blob/main/CONTRIBUTING.md#python-dependencies) doc,
- provided instructions will create an `env` folder
- python related commands assume we're under project root folder

I would prefer to ignore `env` folder when doing git operations, let me know if you guys think it makes sense.