### PR TITLE
Fix read of uninitialized memory when using duckdb functions

### DIFF
--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -9,7 +9,7 @@ typedef struct StarReconstructionContext {
 } StarReconstructionContext;
 
 char *pgduckdb_relation_name(Oid relid);
-char *pgduckdb_function_name(Oid function_oid);
+char *pgduckdb_function_name(Oid function_oid, bool *use_variadic_p);
 char *pgduckdb_get_querydef(Query *);
 char *pgduckdb_get_tabledef(Oid relation_id);
 bool pgduckdb_is_not_default_expr(Node *node, void *context);

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -34,9 +34,17 @@ extern "C" {
 bool processed_targetlist = false;
 
 char *
-pgduckdb_function_name(Oid function_oid) {
+pgduckdb_function_name(Oid function_oid, bool *use_variadic_p) {
 	if (!pgduckdb::IsDuckdbOnlyFunction(function_oid)) {
 		return nullptr;
+	}
+
+	/*
+	 * DuckDB currently doesn't support variadic functions, so we can just
+	 * always set this pointer to false.
+	 */
+	if (use_variadic_p) {
+		*use_variadic_p = false;
 	}
 
 	auto func_name = get_func_name(function_oid);

--- a/src/vendor/pg_ruleutils_14.c
+++ b/src/vendor/pg_ruleutils_14.c
@@ -11785,7 +11785,7 @@ generate_function_name(Oid funcid, int nargs, List *argnames, Oid *argtypes,
 	Oid		   *p_true_typeids;
 	bool		force_qualify = false;
 
-	result = pgduckdb_function_name(funcid);
+	result = pgduckdb_function_name(funcid, use_variadic_p);
 	if (result)
 		return result;
 

--- a/src/vendor/pg_ruleutils_15.c
+++ b/src/vendor/pg_ruleutils_15.c
@@ -11987,7 +11987,7 @@ generate_function_name(Oid funcid, int nargs, List *argnames, Oid *argtypes,
 	Oid		   *p_true_typeids;
 	bool		force_qualify = false;
 
-	result = pgduckdb_function_name(funcid);
+	result = pgduckdb_function_name(funcid, use_variadic_p);
 	if (result)
 		return result;
 

--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -12196,7 +12196,7 @@ generate_function_name(Oid funcid, int nargs, List *argnames, Oid *argtypes,
 	Oid		   *p_true_typeids;
 	bool		force_qualify = false;
 
-	result = pgduckdb_function_name(funcid);
+	result = pgduckdb_function_name(funcid, use_variadic_p);
 	if (result)
 		return result;
 

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -12855,7 +12855,7 @@ generate_function_name(Oid funcid, int nargs, List *argnames, Oid *argtypes,
 	Oid		   *p_true_typeids;
 	bool		force_qualify = false;
 
-	result = pgduckdb_function_name(funcid);
+	result = pgduckdb_function_name(funcid, use_variadic_p);
 	if (result)
 		return result;
 


### PR DESCRIPTION
We changed the `generate_function_name` function in our vendored in ruleutils to bail out early if it was a duckdb function, but we forgot to set the value of the `use_variadic_p` pointer in that case. This fixes that by always setting it to false.

Fixes #340
