### PR TITLE
Change DatumToString to avoid valgrind error

### DIFF
--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -59,11 +59,7 @@ ExtensionsTableRelationId(void) {
 
 static std::string
 DatumToString(Datum datum) {
-	std::string column_value;
-	text *datum_text = DatumGetTextPP(datum);
-	column_value = VARDATA_ANY(datum_text);
-	column_value.resize(VARSIZE_ANY_EXHDR(datum_text));
-	return column_value;
+	return std::string(text_to_cstring(DatumGetTextPP(datum)));
 }
 
 bool


### PR DESCRIPTION
Fixes this valgrind error:

```
==00:00:30:55.325 28566== Invalid read of size 1
==00:00:30:55.325 28566==    at 0x484F234: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:30:55.325 28566==    by 0x82916DC: length (char_traits.h:399)
==00:00:30:55.325 28566==    by 0x82916DC: assign (basic_string.h:1684)
==00:00:30:55.325 28566==    by 0x82916DC: operator= (basic_string.h:824)
==00:00:30:55.325 28566==    by 0x82916DC: pgduckdb::DatumToString(unsigned long) (pgduckdb_options.cpp:64)
==00:00:30:55.325 28566==    by 0x829191B: pgduckdb::DuckdbInstallExtension(unsigned long) (pgduckdb_options.cpp:225)
==00:00:30:55.325 28566==    by 0x82961CD: install_extension_cpp (pgduckdb_options.cpp:353)
==00:00:30:55.325 28566==    by 0x82961CD: std::invoke_result<unsigned long (*)(FunctionCallInfoBaseData*), FunctionCallInfoBaseData*>::type pgduckdb::__CPPFunctionGuard__<unsigned long (*)(FunctionCallInfoBaseData*), &install_extension_cpp, FunctionCallInfoBaseData*>(char const*, FunctionCallInfoBaseData*) (pgduckdb_options.cpp:351)
==00:00:30:55.325 28566==    by 0x751D1D: fmgr_security_definer (fmgr.c:747)
==00:00:30:55.325 28566==    by 0x403106: ExecInterpExpr (execExprInterp.c:740)
==00:00:30:55.325 28566==    by 0x3FF025: ExecInterpExprStillValid (execExprInterp.c:1927)
==00:00:30:55.325 28566==    by 0x43F52D: ExecEvalExprSwitchContext (executor.h:356)
==00:00:30:55.325 28566==    by 0x43F57E: ExecProject (executor.h:390)
==00:00:30:55.325 28566==    by 0x43F72E: ExecResult (nodeResult.c:135)
==00:00:30:55.325 28566==    by 0x40FD04: ExecProcNodeFirst (execProcnode.c:464)
==00:00:30:55.325 28566==    by 0x407913: ExecProcNode (executor.h:274)
==00:00:30:55.325 28566==  Address 0x7a07bbf is 6,655 bytes inside a recently re-allocated block of size 8,192 alloc'd
==00:00:30:55.325 28566==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:30:55.325 28566==    by 0x76FDDC: AllocSetContextCreateInternal (aset.c:444)
==00:00:30:55.325 28566==    by 0x54DAC4: PostmasterMain (postmaster.c:526)
==00:00:30:55.325 28566==    by 0x469DB4: main (main.c:199)
==00:00:30:55.325 28566==
{
   <insert_a_suppression_name_here>
   Memcheck:Addr1
   fun:strlen
   fun:length
   fun:assign
   fun:operator=
   fun:_ZN8pgduckdbL13DatumToStringEm
   fun:_ZN8pgduckdbL22DuckdbInstallExtensionEm
   fun:install_extension_cpp
   fun:_ZN8pgduckdb20__CPPFunctionGuard__IPFmP24FunctionCallInfoBaseDataEXadL_Z21install_extension_cppEEJS2_EEENSt13invoke_resultIT_JDpT1_EE4typeEPKcS8_
   fun:fmgr_security_definer
   fun:ExecInterpExpr
   fun:ExecInterpExprStillValid
   fun:ExecEvalExprSwitchContext
   fun:ExecProject
   fun:ExecResult
   fun:ExecProcNodeFirst
   fun:ExecProcNode
}
==00:00:30:55.325 28566==
==00:00:30:55.325 28566== Exit program on first error (--exit-on-first-error=yes)
2025-02-28 14:23:40.961 CET postmaster[19658] LOG:  server process (PID 28566) exited with exit code 1
2025-02-28 14:23:40.961 CET postmaster[19658] DETAIL:  Failed process was running: SELECT duckdb.install_extension('icu');
```
