### PR TITLE
Attempt to fix httpfs semantics

### DIFF
--- a/third_party/cached_httpfs/httpfs.cpp
+++ b/third_party/cached_httpfs/httpfs.cpp
@@ -508,7 +508,6 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 			throw InternalException("Cached file not initialized properly");
 		}
 		hfh.cached_file_handle->Read(buffer, nr_bytes, location);
-		hfh.file_offset = location + nr_bytes;
 		return;
 	}
 
@@ -519,22 +518,23 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 	bool skip_buffer = hfh.flags.DirectIO() || hfh.flags.RequireParallelAccess();
 	if (skip_buffer && to_read > 0) {
 		GetRangeRequest(hfh, hfh.path, {}, location, (char *)buffer, to_read);
+
+		std::lock_guard<std::mutex> lck(hfh.mu);
 		hfh.buffer_available = 0;
 		hfh.buffer_idx = 0;
-		hfh.file_offset = location + nr_bytes;
 		return;
 	}
 
 	if (location >= hfh.buffer_start && location < hfh.buffer_end) {
-		hfh.file_offset = location;
 		hfh.buffer_idx = location - hfh.buffer_start;
 		hfh.buffer_available = (hfh.buffer_end - hfh.buffer_start) - hfh.buffer_idx;
 	} else {
 		// reset buffer
 		hfh.buffer_available = 0;
 		hfh.buffer_idx = 0;
-		hfh.file_offset = location;
 	}
+
+	idx_t start_offset = location; // Start file offset to read from.
 	while (to_read > 0) {
 		auto buffer_read_len = MinValue<idx_t>(hfh.buffer_available, to_read);
 		if (buffer_read_len > 0) {
@@ -546,21 +546,21 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 
 			hfh.buffer_idx += buffer_read_len;
 			hfh.buffer_available -= buffer_read_len;
-			hfh.file_offset += buffer_read_len;
+			start_offset += buffer_read_len;
 		}
 
 		if (to_read > 0 && hfh.buffer_available == 0) {
-			auto new_buffer_available = MinValue<idx_t>(hfh.READ_BUFFER_LEN, hfh.length - hfh.file_offset);
+			auto new_buffer_available = MinValue<idx_t>(hfh.READ_BUFFER_LEN, hfh.length - start_offset);
 
 			// Bypass buffer if we read more than buffer size
 			if (to_read > new_buffer_available) {
 				GetRangeRequest(hfh, hfh.path, {}, location + buffer_offset, (char *)buffer + buffer_offset, to_read);
 				hfh.buffer_available = 0;
 				hfh.buffer_idx = 0;
-				hfh.file_offset += to_read;
+				start_offset += to_read;
 				break;
 			} else {
-				GetRangeRequest(hfh, hfh.path, {}, hfh.file_offset, (char *)hfh.read_buffer.get(),
+				GetRangeRequest(hfh, hfh.path, {}, start_offset, (char *)hfh.read_buffer.get(),
 				                new_buffer_available);
 				hfh.buffer_available = new_buffer_available;
 				hfh.buffer_idx = 0;
@@ -572,10 +572,11 @@ void HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, id
 }
 
 int64_t HTTPFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	auto &hfh = (HTTPFileHandle &)handle;
+	auto &hfh = handle.Cast<HTTPFileHandle>();
 	idx_t max_read = hfh.length - hfh.file_offset;
 	nr_bytes = MinValue<idx_t>(max_read, nr_bytes);
 	Read(handle, buffer, nr_bytes, hfh.file_offset);
+	hfh.file_offset += nr_bytes;
 	return nr_bytes;
 }
 

--- a/third_party/cached_httpfs/include/httpfs.hpp
+++ b/third_party/cached_httpfs/include/httpfs.hpp
@@ -9,6 +9,8 @@
 #include "duckdb/main/client_data.hpp"
 #include "http_metadata_cache.hpp"
 
+#include <mutex>
+
 namespace duckdb_httplib_openssl {
 struct Response;
 class Result;
@@ -115,6 +117,9 @@ public:
 	idx_t file_offset;
 	idx_t buffer_start;
 	idx_t buffer_end;
+
+	// Used when file handle created with parallel access flag specified.
+	std::mutex mu;
 
 	// Read buffer
 	duckdb::unique_ptr<data_t[]> read_buffer;


### PR DESCRIPTION
I tried to upstream the fix to duckdb httpfs extension: https://github.com/duckdb/duckdb-httpfs/pull/17 (also contains details for what I try to fix), but unfortunately no reply yet. I know pg_duckdb forks httpfs by source code, the same fix should apply.

Test command and result:
```sql
postgres (pid: 15453) =# SELECT * FROM read_csv('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
-[ RECORD 1 ]--+-----------------------------------------------------------
csvbase_row_id | 1
Continent      | Africa
Country        | Lesotho
Name           | HYBSE
MIC            | 
Last changed   | 2019-03-25
<omit other lines>
postgres (pid: 15453) =# SELECT COUNT(*) FROM read_csv('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
-[ RECORD 1 ]
count | 251
```