### PR TITLE
Add additional functionality for the duckdb.unresolved_type

### DIFF
--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -1,2 +1,197 @@
 -- Add "url_style" column to "secrets" table
 ALTER TABLE duckdb.secrets ADD COLUMN url_style TEXT;
+
+-- The min aggregate was somehow missing from the list of aggregates in 0.3.0
+CREATE AGGREGATE @extschema@.min(duckdb.unresolved_type) (
+    SFUNC = duckdb_unresolved_type_state_trans,
+    STYPE = duckdb.unresolved_type,
+    FINALFUNC = duckdb_unresolved_type_final
+);
+
+CREATE FUNCTION @extschema@.strftime(date, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strftime(timestamp, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strftime(timestamptz, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strftime(duckdb.unresolved_type, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strptime(text, text) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strptime(duckdb.unresolved_type, text) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strptime(text, text[]) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.strptime(duckdb.unresolved_type, text[]) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.date_trunc(text, duckdb.unresolved_type) RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.length(duckdb.unresolved_type) RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.regexp_replace(duckdb.unresolved_type, text, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.regexp_replace(duckdb.unresolved_type, text, text, text) RETURNS text
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE CAST (duckdb.unresolved_type AS interval)
+    WITH INOUT;
+CREATE CAST (duckdb.unresolved_type AS interval[])
+    WITH INOUT;
+
+CREATE CAST (duckdb.unresolved_type AS time)
+    WITH INOUT;
+CREATE CAST (duckdb.unresolved_type AS time[])
+    WITH INOUT;
+
+CREATE CAST (duckdb.unresolved_type AS timetz)
+    WITH INOUT;
+CREATE CAST (duckdb.unresolved_type AS timetz[])
+    WITH INOUT;
+
+CREATE CAST (duckdb.unresolved_type AS bit)
+    WITH INOUT;
+CREATE CAST (duckdb.unresolved_type AS bit[])
+    WITH INOUT;
+
+CREATE OPERATOR pg_catalog.~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~ (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~ (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~ (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~* (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~* (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.~~* (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~ (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~ (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~* (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~* (
+    LEFTARG = duckdb.unresolved_type,
+    RIGHTARG = "any",
+    FUNCTION = duckdb_unresolved_type_operator
+);
+
+CREATE OPERATOR pg_catalog.!~~* (
+    LEFTARG = "any",
+    RIGHTARG = duckdb.unresolved_type,
+    FUNCTION = duckdb_unresolved_type_operator
+);

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -143,7 +143,9 @@ BuildDuckdbOnlyFunctions() {
 	                                "from_json",
 	                                "json_transform_strict",
 	                                "from_json_strict",
-	                                "json_value"};
+	                                "json_value",
+	                                "strftime",
+	                                "strptime"};
 
 	for (uint32_t i = 0; i < lengthof(function_names); i++) {
 		CatCList *catlist = SearchSysCacheList1(PROCNAMEARGSNSP, CStringGetDatum(function_names[i]));

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -1,0 +1,113 @@
+-- All functions should automatically use duckdb
+set duckdb.execution = false;
+select r['a'] ~ 'a.*' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+select r['a'] !~ 'x.*' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+select r['a'] LIKE '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+select r['a'] NOT LIKE '%x%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+select r['a'] ILIKE '%B%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+select r['a'] NOT ILIKE '%X%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Currently not working, we need to add the similar_to_escape function to
+-- DuckDB to make this work.
+select r['a'] SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
+Did you mean "list_sem"?
+
+LINE 1: SELECT (r.a ~ similar_to_escape('%b%'::text)) AS "?column?" FROM (FROM...
+                      ^
+select r['a'] NOT SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
+Did you mean "list_sem"?
+
+LINE 1: SELECT (r.a !~ similar_to_escape('%b%'::text)) AS "?column?" FROM (FROM...
+                       ^
+select length(r['a']) from duckdb.query($$ SELECT 'abc' a $$) r;
+ length 
+--------
+      3
+(1 row)
+
+select regexp_replace(r['a'], 'a', 'x') from duckdb.query($$ SELECT 'abc' a $$) r;
+ regexp_replace 
+----------------
+ xbc
+(1 row)
+
+select regexp_replace(r['a'], 'A', 'x', 'i') from duckdb.query($$ SELECT 'abc' a $$) r;
+ regexp_replace 
+----------------
+ xbc
+(1 row)
+
+select date_trunc('year', r['ts']) from duckdb.query($$ SELECT '2024-08-04 12:34:56'::timestamp ts $$) r;
+ date_trunc 
+------------
+ 01-01-2024
+(1 row)
+
+-- select extract(CENTURY FROM r['ts']) from duckdb.query($$ SELECT '2024-08-04 12:34:56'::timestamp ts $$) r;
+select strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p');
+         strptime         
+--------------------------
+ Wed Jan 01 20:38:40 1992
+(1 row)
+
+select strptime('4/15/2023 10:56:00', ARRAY['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S']);
+         strptime         
+--------------------------
+ Sat Apr 15 10:56:00 2023
+(1 row)
+
+select strftime(date '1992-01-01', '%a, %-d %B %Y - %I:%M:%S %p');
+             strftime              
+-----------------------------------
+ Wed, 1 January 1992 - 12:00:00 AM
+(1 row)
+
+select strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
+             strftime              
+-----------------------------------
+ Wed, 1 January 1992 - 08:38:40 PM
+(1 row)
+
+select strftime(timestamptz '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
+             strftime              
+-----------------------------------
+ Thu, 2 January 1992 - 05:38:40 AM
+(1 row)
+
+select strftime(r['ts'], '%a, %-d %B %Y - %I:%M:%S %p') from duckdb.query($$ SELECT timestamp '1992-01-01 20:38:40' ts $$) r;
+             strftime              
+-----------------------------------
+ Wed, 1 January 1992 - 08:38:40 PM
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -31,4 +31,5 @@ test: function
 test: timestamp_with_interval
 test: approx_count_distinct
 test: scan_postgres_tables
+test: unresolved_type
 test: json_functions_duckdb

--- a/test/regression/sql/unresolved_type.sql
+++ b/test/regression/sql/unresolved_type.sql
@@ -1,0 +1,24 @@
+-- All functions should automatically use duckdb
+set duckdb.execution = false;
+select r['a'] ~ 'a.*' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] !~ 'x.*' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] LIKE '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] NOT LIKE '%x%' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] ILIKE '%B%' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] NOT ILIKE '%X%' from duckdb.query($$ SELECT 'abc' a $$) r;
+-- Currently not working, we need to add the similar_to_escape function to
+-- DuckDB to make this work.
+select r['a'] SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+select r['a'] NOT SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
+select length(r['a']) from duckdb.query($$ SELECT 'abc' a $$) r;
+select regexp_replace(r['a'], 'a', 'x') from duckdb.query($$ SELECT 'abc' a $$) r;
+select regexp_replace(r['a'], 'A', 'x', 'i') from duckdb.query($$ SELECT 'abc' a $$) r;
+select date_trunc('year', r['ts']) from duckdb.query($$ SELECT '2024-08-04 12:34:56'::timestamp ts $$) r;
+-- select extract(CENTURY FROM r['ts']) from duckdb.query($$ SELECT '2024-08-04 12:34:56'::timestamp ts $$) r;
+
+select strptime('Wed, 1 January 1992 - 08:38:40 PM', '%a, %-d %B %Y - %I:%M:%S %p');
+select strptime('4/15/2023 10:56:00', ARRAY['%d/%m/%Y %H:%M:%S', '%m/%d/%Y %H:%M:%S']);
+select strftime(date '1992-01-01', '%a, %-d %B %Y - %I:%M:%S %p');
+select strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
+select strftime(timestamptz '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
+select strftime(r['ts'], '%a, %-d %B %Y - %I:%M:%S %p') from duckdb.query($$ SELECT timestamp '1992-01-01 20:38:40' ts $$) r;


### PR DESCRIPTION
In 0.3.0 we added the `duckdb.unresolved_type` type and implemented a bunch of
operators, aggregates and functions for it. Of course the list will always be
incomplete and casts to actual types might always be necessary in some cases.
But for usability we should still try to implement the most commonly used
functionality. So this adds a bunch of additional things that I ran into over
the past weeks:

1. The `min` aggregate, this was not present in 0.3.0 by accident.
   Probably because DuckDB has two `min` aggregates.
2. Casts to `time`, `timetz`, `interval` and `bit`
3. Support for `date_trunc`, `length` and `regexp_replace`
4. Add general support for the `strftime` and `strptime` functions. This
   is useful even for already resolved/casted `timestamp`/`date` values
   because Postgres its date formatting functions like `to_char` are not
   available in DuckDB.
