### PR TITLE
Fix MacOS compilation

### DIFF
--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -446,7 +446,8 @@ DatumGetTimeTz(Datum value) {
 	TimeTzADT *tzt = static_cast<TimeTzADT *>(DatumGetTimeTzADTP(value));
 	// pg and duckdb stores timezone with different signs, for example, for TIMETZ 01:02:03+05, duckdb stores offset =
 	// 18000, while pg stores zone = -18000.
-	const uint64_t bits = duckdb::dtime_tz_t::encode_micros(tzt->time) | duckdb::dtime_tz_t::encode_offset(-tzt->zone);
+	const uint64_t bits = duckdb::dtime_tz_t::encode_micros(static_cast<int64_t>(tzt->time)) |
+	                      duckdb::dtime_tz_t::encode_offset(-tzt->zone);
 	const duckdb::dtime_tz_t duck_time_tz {bits};
 	return duck_time_tz;
 }


### PR DESCRIPTION
Avoid error like:
```
/bin/sh build/lib/pgxs/src/makefiles/../../config/install-sh -c -d 'build/lib'
/bin/sh build/lib/pgxs/src/makefiles/../../config/install-sh -c -d 'build/share/extension'
/bin/sh build/lib/pgxs/src/makefiles/../../config/install-sh -c -d 'build/share/extension'
src/pgduckdb_types.cpp:449:24: error: call to 'encode_micros' is ambiguous
  449 |         const uint64_t bits = duckdb::dtime_tz_t::encode_micros(tzt->time) | duckdb::dtime_tz_t::encode_offset(-tzt->zone);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third_party/duckdb/src/include/duckdb/common/types/datetime.hpp:110:25: note: candidate function
  110 |         static inline uint64_t encode_micros(int64_t micros) { // NOLINT
      |                                ^
third_party/duckdb/src/include/duckdb/common/types/datetime.hpp:113:25: note: candidate function
  113 |         static inline uint64_t encode_micros(uint64_t micros) { // NOLINT
      |                                ^
1 error generated.
make: *** [src/pgduckdb_types.o] Error 1
make: *** Waiting for unfinished jobs....
```