### PR TITLE
Make cpp_wrapper.hpp self contained

### DIFF
--- a/include/pgduckdb/utility/cpp_wrapper.hpp
+++ b/include/pgduckdb/utility/cpp_wrapper.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <duckdb/common/error_data.hpp>
+
 extern "C" {
 #include "postgres.h"
 }


### PR DESCRIPTION
I was seeing errors in my editor when opening this file, because some symbols were undefined. This fixes that by including the necessary DuckDB header.
