### PR TITLE
Add automated tests for MotherDuck integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ recommended because they might cause conflicts with other projects.
 * Try to test unexpected/incorrect usage as well, instead of only the happy path.
 * Make sure **all** unit tests pass before sending a PR.
 * pg_duckdb uses GitHub Actions as its continuous integration (CI) tool. You also have the option to run GitHub Actions on your forked repository. For detailed instructions, you can refer to the [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).
+* To run the MotherDuck tests you need to set the `MOTHERDUCK_TEST_TOKEN` environment variable to a valid token and run `make pycheck`. Be sure to use a test token and not a production token, the tests CREATE and DROP databases and tables.
 
 ## Formatting
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest-timeout
 pytest-xdist
 psycopg
 filelock
+duckdb

--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -40,7 +40,7 @@ def test_md_create_table(md_cur: Cursor, ddb):
 
 
 def test_md_ctas(md_cur: Cursor, ddb):
-    ddb.execute("CREATE TABLE t1 AS SELECT 1 a")
+    ddb.sql("CREATE TABLE t1 AS SELECT 1 a")
     md_cur.wait_until_table_exists("t1")
 
     assert md_cur.sql("SELECT * FROM t1") == 1

--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -1,0 +1,61 @@
+"""Tests for MotherDuck
+
+These tests are using Python because we want to test the table metadata
+syncing, so we need to be able to use make changes to the metadata from a
+different client that pg_duckdb. By using python we can use the DuckDB python
+library for that purpose.
+"""
+
+import os
+
+from .utils import Cursor, MOTHERDUCK
+
+import pytest
+import psycopg.errors
+
+
+if not MOTHERDUCK:
+    pytestmark = pytest.mark.skip(reason="Skipping all motherduck tests")
+
+
+def test_md_create_table(md_cur: Cursor, ddb):
+    ddb.sql("CREATE TABLE t1(a int)")
+    ddb.sql("INSERT INTO t1 VALUES (1)")
+    md_cur.wait_until_table_exists("t1")
+
+    assert md_cur.sql("SELECT * FROM t1") == 1
+    md_cur.sql("CREATE TABLE t2(a int) USING duckdb")
+    md_cur.sql("INSERT INTO t2 VALUES (2)")
+    assert md_cur.sql("SELECT * FROM t2") == 2
+    assert ddb.sql("SELECT * FROM t2") == 2
+
+    md_cur.sql("CREATE TABLE t3(a int)")
+    md_cur.sql("INSERT INTO t3 VALUES (3)")
+    assert md_cur.sql("SELECT * FROM t3") == 3
+    assert ddb.sql("SELECT * FROM t3") == 3
+
+    with pytest.raises(
+        psycopg.errors.InvalidTableDefinition,
+        match=r"Creating a non-DuckDB table in a ddb\$ schema is not supported",
+    ):
+        md_cur.sql("CREATE TABLE t4(a int) USING heap")
+
+
+def test_md_ctas(md_cur: Cursor, ddb):
+    ddb.execute("CREATE TABLE t1 AS SELECT 1 a")
+    md_cur.wait_until_table_exists("t1")
+
+    assert md_cur.sql("SELECT * FROM t1") == 1
+    md_cur.sql("CREATE TABLE t2(b) USING duckdb AS SELECT 2 a")
+    assert md_cur.sql("SELECT * FROM t2") == 2
+    assert ddb.sql("SELECT * FROM t2") == 2
+
+    md_cur.sql("CREATE TABLE t3(b) AS SELECT 3 a")
+    assert md_cur.sql("SELECT * FROM t3") == 3
+    assert ddb.sql("SELECT * FROM t3") == 3
+
+    with pytest.raises(
+        psycopg.errors.InvalidTableDefinition,
+        match=r"Creating a non-DuckDB table in a ddb\$ schema is not supported",
+    ):
+        md_cur.sql("CREATE TABLE t4(b) USING heap AS SELECT 4 a")

--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -6,8 +6,6 @@ different client that pg_duckdb. By using python we can use the DuckDB python
 library for that purpose.
 """
 
-import os
-
 from .utils import Cursor, MOTHERDUCK
 
 import pytest

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -289,8 +289,8 @@ class Cursor:
         return self.sql(f"SELECT * FROM duckdb.query($ddb$ {query} $ddb$)", **kwargs)
 
     def wait_until_table_exists(self, table_name, timeout=5):
-        start = time.time()
-        while time.time() < start + timeout:
+        end = time.time() + timeout
+        while time.time() < end:
             try:
                 self.sql("SELECT %s::regclass", (table_name,))
                 return

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -281,6 +281,7 @@ class Cursor:
             return simplify_query_results(self.fetchall())
         except psycopg.ProgrammingError as e:
             if "the last operation didn't produce a result" == str(e):
+                # This happens when the query is a DDL statement
                 return NoResult
             raise
 
@@ -317,6 +318,7 @@ class AsyncCursor:
             return simplify_query_results(await self.fetchall())
         except psycopg.ProgrammingError as e:
             if "the last operation didn't produce a result" == str(e):
+                # This happens when the query is a DDL statement
                 return NoResult
             raise
 

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -254,12 +254,7 @@ class Duckdb:
 
     def sql(self, query, params=None, **kwargs):
         self.execute(query, params, **kwargs)
-        try:
-            return simplify_query_results(self.fetchall())
-        except psycopg.ProgrammingError as e:
-            if "the last operation didn't produce a result" == str(e):
-                return NoResult
-            raise
+        return simplify_query_results(self.fetchall())
 
     def __getattr__(self, name):
         return getattr(self.ddb, name)


### PR DESCRIPTION
This adds some basic infrastructure to be able to test the MotherDuck integration of pg_duckdb. It also includes a few very basic tests. For now these tests are not run in CI yet, we can do that in a follow-up PR. But at least you can manually run these tests from your own machine now.