### PR TITLE
Fixes bugs an quality of life issues in MotherDuck support

### DIFF
--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -559,8 +559,8 @@ GrantAccessToSchema(const char *postgres_schema_name) {
 	}
 
 	/* Grant access to the schema to the current user */
-	const char *grant_query =
-	    psprintf("GRANT ALL ON SCHEMA %s TO %s", postgres_schema_name, quote_identifier(duckdb_postgres_role));
+	const char *grant_query = psprintf("GRANT ALL ON SCHEMA %s TO %s", quote_identifier(postgres_schema_name),
+	                                   quote_identifier(duckdb_postgres_role));
 	if (!SPI_run_utility_command(grant_query)) {
 		ereport(WARNING,
 		        (errmsg("Failed to grant access to MotherDuck schema %s", postgres_schema_name),

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -606,7 +606,7 @@ pgduckdb_get_tabledef(Oid relation_oid) {
 	} else if (!pgduckdb::IsMotherDuckPostgresDatabase()) {
 		elog(ERROR, "MotherDuck tables must be created in the duckb.motherduck_postgres_database");
 	} else if (relation->rd_rel->relowner != pgduckdb::MotherDuckPostgresUser()) {
-		elog(ERROR, "MotherDuck tables must be created by the duckb.motherduck_postgres_user");
+		elog(ERROR, "MotherDuck tables must be owned by the duckb.postgres_role");
 	}
 
 	appendStringInfo(&buffer, "TABLE %s (", relation_name);

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -3,6 +3,7 @@
 #include "pgduckdb/pgduckdb_guc.h"
 #include "pgduckdb/pgduckdb_xact.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
+#include "pgduckdb/pgduckdb_background_worker.hpp"
 
 #include "pgduckdb/pg/transactions.hpp"
 #include "pgduckdb/utility/cpp_wrapper.hpp"
@@ -71,7 +72,8 @@ AllowWrites() {
 
 bool
 MixedWritesAllowed() {
-	return !pg::IsInTransactionBlock() || duckdb_unsafe_allow_mixed_transactions || pg::force_allow_writes;
+	return !pg::IsInTransactionBlock() || duckdb_unsafe_allow_mixed_transactions || pg::force_allow_writes ||
+	       pgduckdb::doing_motherduck_sync;
 }
 
 bool


### PR DESCRIPTION
This fixes a handful of issues with MotherDuck tables that I ran into while
implementing automated testing for MotherDuck integration:

1. When creating a table in a `ddb$` schema, default that table to be an MD table.
2. Do not allow creating non-MD tables in `ddb$` schemas when explicitly specifying another Table AM (like `heap`).
3. When creating MD tables, automatically make them owned by `duckdb.postgres_role`
4. Fix syncing of MotherDuck tables. This was broken by #632
5. Fix escaping of a MotherDuck schema name when syncing schema names
