### PR TITLE
Add boundary check for converting duckdb date to PG dates

### DIFF
--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -15,6 +15,17 @@ constexpr int32_t PGDUCKDB_DUCK_DATE_OFFSET = 10957;
 constexpr int64_t PGDUCKDB_DUCK_TIMESTAMP_OFFSET =
     static_cast<int64_t>(PGDUCKDB_DUCK_DATE_OFFSET) * static_cast<int64_t>(86400000000) /* USECS_PER_DAY */;
 
+// Check from regress/sql/date.sql
+#define PG_MINYEAR (-4713)
+#define PG_MINMONTH (11)
+#define PG_MINDAY (24)
+#define PG_MAXYEAR (5874897)
+#define PG_MAXMONTH (12)
+#define PG_MAXDAY (31)
+
+const duckdb::date_t PGDUCKDB_PG_MIN_DATE_VALUE = duckdb::Date::FromDate(PG_MINYEAR,PG_MINMONTH,PG_MINDAY);
+const duckdb::date_t PGDUCKDB_PG_MAX_DATE_VALUE = duckdb::Date::FromDate(PG_MAXYEAR,PG_MAXMONTH,PG_MAXDAY);
+
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(const duckdb::LogicalType &type);
 int32_t GetPostgresDuckDBTypemod(const duckdb::LogicalType &type);


### PR DESCRIPTION
Postgres Only Supports date specific date range But DuckDb can return values outside this range , we should detect this and Either error out or pass boundary values.

Fixes https://github.com/duckdb/pg_duckdb/issues/595