### PR TITLE
Fix docker build by adding git to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && \
     postgresql-server-dev-${POSTGRES_VERSION} \
     build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
     libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev \
-    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache ninja-build && \
+    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache ninja-build git && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build


### PR DESCRIPTION
Since #644 we need to have git installed to build our custom DuckDB.
Our docker build container didn't have that so our nightly Docker builds
were broken for the past few days.
