### PR TITLE
Update DuckDB to v1.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS += $(subst .c,.o, $(C_SRCS))
 # set to `make` to disable ninja
 DUCKDB_GEN ?= ninja
 # used to know what version of extensions to download
-DUCKDB_VERSION = v1.2.0
+DUCKDB_VERSION = v1.2.1
 # duckdb build tweaks
 DUCKDB_CMAKE_VARS = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 # set to 1 to disable asserts in DuckDB. This is particularly useful in combinition with MotherDuck.
@@ -108,7 +108,7 @@ duckdb: $(FULL_DUCKDB_LIB)
 .git/modules/third_party/duckdb/HEAD:
 	git submodule update --init --recursive
 
-$(FULL_DUCKDB_LIB): .git/modules/third_party/duckdb/HEAD
+$(FULL_DUCKDB_LIB): .git/modules/third_party/duckdb/HEAD third_party/pg_duckdb_extensions.cmake
 	OVERRIDE_GIT_DESCRIBE=$(DUCKDB_VERSION) \
 	GEN=$(DUCKDB_GEN) \
 	CMAKE_VARS="$(DUCKDB_CMAKE_VARS)" \

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -104,10 +104,10 @@ SELECT * FROM duckdb.install_extension('iceberg');
 
 -- We should handle SQL injections carefully though to only allow INSTALL
 SELECT * FROM duckdb.install_extension($$ '; select * from hacky '' $$);
-ERROR:  (PGDuckDB/install_extension_cpp) HTTP Error: Failed to download extension " '; select * from hacky '' " at URL "http://extensions.duckdb.org/v1.2.0/linux_amd64/ '; select * from hacky '' .duckdb_extension.gz" (HTTP 403)
+ERROR:  (PGDuckDB/install_extension_cpp) HTTP Error: Failed to download extension " '; select * from hacky '' " at URL "http://extensions.duckdb.org/v1.2.1/linux_amd64/ '; select * from hacky '' .duckdb_extension.gz" (HTTP 403)
 
 Candidate extensions: "delta", "excel", "sqlite_scanner", "inet", "sqlite"
-For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=v1.2.0&platform=linux_amd64&extension= '; select * from hacky '' 
+For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=v1.2.1&platform=linux_amd64&extension= '; select * from hacky '' 
 INSERT INTO duckdb.extensions (name) VALUES ($$ '; select * from hacky $$);
 SELECT * FROM duckdb.query($$ SELECT 1 $$);
 ERROR:  (PGDuckDB/CreatePlan) Parser Error: unterminated quoted string at or near "'; select * from hacky "

--- a/third_party/pg_duckdb_extensions.cmake
+++ b/third_party/pg_duckdb_extensions.cmake
@@ -2,6 +2,6 @@ duckdb_extension_load(json)
 duckdb_extension_load(icu)
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 85ac4667bcb0d868199e156f8dd918b0278db7b9
+    GIT_TAG cf3584b48ddabdfb58ef69d2649896da2e466405
     INCLUDE_DIR extension/httpfs/include
 )


### PR DESCRIPTION
Also updates httpfs to the latest commit. Finally it also updates our Makefile so that changes to pg_duckdb_extensions.cmake rebuild DuckDB.
