### PR TITLE
Fix server crash when EXPLAINing a prepared statement

### DIFF
--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -12,4 +12,4 @@ extern bool duckdb_explain_ctas;
 
 PlannedStmt *DuckdbPlanNode(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params,
                             bool throw_error);
-duckdb::unique_ptr<duckdb::PreparedStatement> DuckdbPrepare(const Query *query, bool allow_explain);
+duckdb::unique_ptr<duckdb::PreparedStatement> DuckdbPrepare(const Query *query, const char *explain_prefix = NULL);

--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -8,6 +8,7 @@
 #include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 extern bool duckdb_explain_analyze;
+extern bool duckdb_explain_ctas;
 
 PlannedStmt *DuckdbPlanNode(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params,
                             bool throw_error);

--- a/include/pgduckdb/pgduckdb_planner.hpp
+++ b/include/pgduckdb/pgduckdb_planner.hpp
@@ -11,4 +11,4 @@ extern bool duckdb_explain_analyze;
 
 PlannedStmt *DuckdbPlanNode(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params,
                             bool throw_error);
-duckdb::unique_ptr<duckdb::PreparedStatement> DuckdbPrepare(const Query *query);
+duckdb::unique_ptr<duckdb::PreparedStatement> DuckdbPrepare(const Query *query, bool allow_explain);

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -350,6 +350,7 @@ DuckdbExplainOneQueryHook(Query *query, int cursorOptions, IntoClause *into, Exp
 	 * standard_ExplainOneQuery).
 	 */
 	duckdb_explain_analyze = es->analyze;
+	duckdb_explain_ctas = into != NULL;
 	prev_explain_one_query_hook(query, cursorOptions, into, es, queryString, params, queryEnv);
 }
 

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -206,6 +206,11 @@ Duckdb_ExecCustomScan_Cpp(CustomScanState *node) {
 	TupleTableSlot *slot = duckdb_scan_state->css.ss.ss_ScanTupleSlot;
 	MemoryContext old_context;
 
+	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
+		ExecClearTuple(slot);
+		return slot;
+	}
+
 	bool already_executed = duckdb_scan_state->is_executed;
 	if (!already_executed) {
 		ExecuteQuery(duckdb_scan_state);

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -73,7 +73,7 @@ Duckdb_CreateCustomScanState(CustomScan *cscan) {
 void
 Duckdb_BeginCustomScan_Cpp(CustomScanState *cscanstate, EState *estate, int /*eflags*/) {
 	DuckdbScanState *duckdb_scan_state = (DuckdbScanState *)cscanstate;
-	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(duckdb_scan_state->query);
+	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(duckdb_scan_state->query, true);
 
 	if (prepared_query->HasError()) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR,

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -18,6 +18,9 @@ extern "C" {
 #include "pgduckdb/pgduckdb_duckdb.hpp"
 #include "pgduckdb/utility/cpp_wrapper.hpp"
 
+bool duckdb_explain_analyze = false;
+bool duckdb_explain_ctas = false;
+
 /* global variables */
 CustomScanMethods duckdb_scan_scan_methods;
 
@@ -73,7 +76,24 @@ Duckdb_CreateCustomScanState(CustomScan *cscan) {
 void
 Duckdb_BeginCustomScan_Cpp(CustomScanState *cscanstate, EState *estate, int /*eflags*/) {
 	DuckdbScanState *duckdb_scan_state = (DuckdbScanState *)cscanstate;
-	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(duckdb_scan_state->query, true);
+
+	const char *explain_prefix = NULL;
+
+	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
+		if (duckdb_explain_analyze) {
+			if (duckdb_explain_ctas) {
+				throw duckdb::NotImplementedException(
+				    "Cannot use EXPLAIN ANALYZE with CREATE TABLE ... AS when using DuckDB execution");
+			}
+
+			explain_prefix = "EXPLAIN ANALYZE";
+		} else {
+			explain_prefix = "EXPLAIN";
+		}
+	}
+
+	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query =
+	    DuckdbPrepare(duckdb_scan_state->query, explain_prefix);
 
 	if (prepared_query->HasError()) {
 		throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR,

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -32,11 +32,11 @@ extern "C" {
 bool duckdb_explain_analyze = false;
 
 duckdb::unique_ptr<duckdb::PreparedStatement>
-DuckdbPrepare(const Query *query) {
+DuckdbPrepare(const Query *query, bool allow_explain) {
 	Query *copied_query = (Query *)copyObjectImpl(query);
 	const char *query_string = pgduckdb_get_querydef(copied_query);
 
-	if (ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
+	if (allow_explain && ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
 		if (duckdb_explain_analyze) {
 			query_string = psprintf("EXPLAIN ANALYZE %s", query_string);
 		} else {
@@ -57,7 +57,7 @@ CreatePlan(Query *query, bool throw_error) {
 	 * Prepare the query, se we can get the returned types and column names.
 	 */
 
-	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(query);
+	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(query, false);
 
 	if (prepared_query->HasError()) {
 		elog(elevel, "(PGDuckDB/CreatePlan) Prepared query returned an error: '%s", prepared_query->GetError().c_str());

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -5,6 +5,7 @@
 #include "pgduckdb/catalog/pgduckdb_transaction.hpp"
 #include "pgduckdb/scan/postgres_scan.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
+#include "pgduckdb/pgduckdb_planner.hpp"
 
 extern "C" {
 #include "postgres.h"
@@ -29,25 +30,12 @@ extern "C" {
 #include "pgduckdb/utility/cpp_wrapper.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
 
-bool duckdb_explain_analyze = false;
-bool duckdb_explain_ctas = false;
-
 duckdb::unique_ptr<duckdb::PreparedStatement>
-DuckdbPrepare(const Query *query, bool allow_explain) {
+DuckdbPrepare(const Query *query, const char *explain_prefix) {
 	Query *copied_query = (Query *)copyObjectImpl(query);
 	const char *query_string = pgduckdb_get_querydef(copied_query);
-
-	if (allow_explain && ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
-		if (duckdb_explain_analyze) {
-			if (duckdb_explain_ctas) {
-				throw duckdb::NotImplementedException(
-				    "Cannot use EXPLAIN ANALYZE with CREATE TABLE ... AS when using DuckDB execution");
-			}
-
-			query_string = psprintf("EXPLAIN ANALYZE %s", query_string);
-		} else {
-			query_string = psprintf("EXPLAIN %s", query_string);
-		}
+	if (explain_prefix) {
+		query_string = psprintf("%s %s", explain_prefix, query_string);
 	}
 
 	elog(DEBUG2, "(PGDuckDB/DuckdbPrepare) Preparing: %s", query_string);
@@ -63,7 +51,7 @@ CreatePlan(Query *query, bool throw_error) {
 	 * Prepare the query, se we can get the returned types and column names.
 	 */
 
-	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(query, false);
+	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(query);
 
 	if (prepared_query->HasError()) {
 		elog(elevel, "(PGDuckDB/CreatePlan) Prepared query returned an error: '%s", prepared_query->GetError().c_str());

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "pgduckdb/pgduckdb_types.hpp"
 
 bool duckdb_explain_analyze = false;
+bool duckdb_explain_ctas = false;
 
 duckdb::unique_ptr<duckdb::PreparedStatement>
 DuckdbPrepare(const Query *query, bool allow_explain) {
@@ -38,6 +39,11 @@ DuckdbPrepare(const Query *query, bool allow_explain) {
 
 	if (allow_explain && ActivePortal && ActivePortal->commandTag == CMDTAG_EXPLAIN) {
 		if (duckdb_explain_analyze) {
+			if (duckdb_explain_ctas) {
+				throw duckdb::NotImplementedException(
+				    "Cannot use EXPLAIN ANALYZE with CREATE TABLE ... AS when using DuckDB execution");
+			}
+
 			query_string = psprintf("EXPLAIN ANALYZE %s", query_string);
 		} else {
 			query_string = psprintf("EXPLAIN %s", query_string);

--- a/test/regression/expected/issue_410.out
+++ b/test/regression/expected/issue_410.out
@@ -1,0 +1,39 @@
+-- In the past (see #410) we could cache the plan for the EXPLAIN query which
+-- returns text columns. Instead of caching the plan of the actual query. This
+-- is a regression test to make sure that this stays fixed.
+SET duckdb.force_execution = ON;
+CREATE TABLE t (a INT);
+PREPARE f (INT) AS SELECT count(*) FROM t WHERE a = $1;
+SET plan_cache_mode TO force_generic_plan;
+EXPLAIN (COSTS OFF) EXECUTE f(2);
+          QUERY PLAN           
+-------------------------------
+ Custom Scan (DuckDBScan)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │    UNGROUPED_AGGREGATE    │
+ │    ────────────────────   │
+ │        Aggregates:        │
+ │        count_star()       │
+ └─────────────┬─────────────┘
+ ┌─────────────┴─────────────┐
+ │  PGDUCKDB_POSTGRES_SCAN   │
+ │    ────────────────────   │
+ │          Table: t         │
+ │        Filters: a=2       │
+ │                           │
+ │         ~510 Rows         │
+ └───────────────────────────┘
+ 
+ 
+(19 rows)
+
+EXECUTE f(1); -- crash
+ count 
+-------
+     0
+(1 row)
+
+-- cleanup
+DROP TABLE t;

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -407,10 +407,10 @@ SELECT count(*) FROM td;
 
 TRUNCATE TABLE tc;
 EXPLAIN VERBOSE INSERT INTO tc(c) SELECT md5('ta');
-                          QUERY PLAN                          
---------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
-   Output: duckdb_scan.explain_key, duckdb_scan.explain_value
+   Output: duckdb_scan."Count"
    DuckDB Execution Plan: 
  
  ┌───────────────────────────┐
@@ -432,10 +432,10 @@ EXPLAIN VERBOSE INSERT INTO tc(c) SELECT md5('ta');
 
 INSERT INTO tc(c) SELECT md5('ta');
 EXPLAIN VERBOSE INSERT INTO tc(d) SELECT md5('test');
-                          QUERY PLAN                          
---------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (DuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
-   Output: duckdb_scan.explain_key, duckdb_scan.explain_value
+   Output: duckdb_scan."Count"
    DuckDB Execution Plan: 
  
  ┌───────────────────────────┐

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -28,6 +28,7 @@ test: transaction_errors
 test: secrets
 test: prepare
 test: function
+test: issue_410
 test: timestamp_with_interval
 test: approx_count_distinct
 test: scan_postgres_tables

--- a/test/regression/sql/issue_410.sql
+++ b/test/regression/sql/issue_410.sql
@@ -1,0 +1,11 @@
+-- In the past (see #410) we could cache the plan for the EXPLAIN query which
+-- returns text columns. Instead of caching the plan of the actual query. This
+-- is a regression test to make sure that this stays fixed.
+SET duckdb.force_execution = ON;
+CREATE TABLE t (a INT);
+PREPARE f (INT) AS SELECT count(*) FROM t WHERE a = $1;
+SET plan_cache_mode TO force_generic_plan;
+EXPLAIN (COSTS OFF) EXECUTE f(2);
+EXECUTE f(1); -- crash
+-- cleanup
+DROP TABLE t;


### PR DESCRIPTION
With a specific query order it was possible that Postgres would cache the plan for the EXPLAINed version of a query instead of the plan for the actual query. This fixes that by only ever adding EXPLAIN to a query when actually executing the query, not also when only planning it. This way the plan that will be cached is always the actual query plan, but at execution time that might be changed in case the query is EXPLAINed.

This also fixes two bugs involving EXPLAIN ANALYZE:
1. EXPLAIN ANALYZE + CTAS into a Postgres table is now disallowed when using DuckDB execution. Before it was putting the plan into the table... Not the result of the query.
2. Don't execute the EXPLAIN ANALYZE twice in DuckDB. For read-only queries this would result in the query taking twice as long, while only reporting the runtime for one of the queries. When using EXPLAIN ANALYZE on DML statements this would actually matter a lot, because those would have the side-effect twice, i.e. data would be inserted twice.

Fixes #410
