### PR TITLE
Fix configuration of DuckDB memory

### DIFF
--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -143,7 +143,7 @@ DuckDBManager::Initialize() {
 	SET_DUCKDB_OPTION(autoinstall_known_extensions);
 	SET_DUCKDB_OPTION(autoload_known_extensions);
 
-	if (duckdb_maximum_memory != NULL && strlen(duckdb_maximum_memory) == 0) {
+	if (duckdb_maximum_memory != NULL && strlen(duckdb_maximum_memory) != 0) {
 		config.options.maximum_memory = duckdb::DBConfig::ParseMemoryLimit(duckdb_maximum_memory);
 		elog(DEBUG2, "[PGDuckDB] Set DuckDB option: 'maximum_memory'=%s", duckdb_maximum_memory);
 	}

--- a/test/regression/expected/gucs.out
+++ b/test/regression/expected/gucs.out
@@ -1,0 +1,28 @@
+show duckdb.memory_limit;
+ duckdb.memory_limit 
+---------------------
+ 4GB
+(1 row)
+
+select * from duckdb.query($$ select current_setting('memory_limit') == '3.7 GiB' $$);
+ (current_setting('memory_limit') = '3.7 GiB') 
+-----------------------------------------------
+ t
+(1 row)
+
+set duckdb.memory_limit = '1GiB';
+CALL duckdb.recycle_ddb();
+select * from duckdb.query($$ select current_setting('memory_limit') $$);
+ current_setting('memory_limit') 
+---------------------------------
+ 1.0 GiB
+(1 row)
+
+set duckdb.memory_limit = '';
+CALL duckdb.recycle_ddb();
+select * from duckdb.query($$ select current_setting('memory_limit') != '3.7 GiB' $$);
+ (current_setting('memory_limit') != '3.7 GiB') 
+------------------------------------------------
+ t
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -27,6 +27,7 @@ test: transactions
 test: transaction_errors
 test: secrets
 test: prepare
+test: gucs
 test: function
 test: issue_410
 test: timestamp_with_interval

--- a/test/regression/sql/gucs.sql
+++ b/test/regression/sql/gucs.sql
@@ -1,0 +1,10 @@
+show duckdb.memory_limit;
+select * from duckdb.query($$ select current_setting('memory_limit') == '3.7 GiB' $$);
+
+set duckdb.memory_limit = '1GiB';
+CALL duckdb.recycle_ddb();
+select * from duckdb.query($$ select current_setting('memory_limit') $$);
+
+set duckdb.memory_limit = '';
+CALL duckdb.recycle_ddb();
+select * from duckdb.query($$ select current_setting('memory_limit') != '3.7 GiB' $$);


### PR DESCRIPTION
I made dumb mistake in #614. I accidentally checked the opposite of what
intended to check. This fixes that and adds a test to confirm that the
new behaviour is now correct.
