### PR TITLE
Better COPY support

### DIFF
--- a/include/pgduckdb/pgduckdb_hooks.hpp
+++ b/include/pgduckdb/pgduckdb_hooks.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "pgduckdb/pg/declarations.hpp"
+
+namespace pgduckdb {
+bool IsAllowedStatement(Query *query, bool throw_error = false);
+bool IsCatalogTable(Relation rel);
+} // namespace pgduckdb

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -53,7 +53,7 @@ ContainsCatalogTable(List *rtes) {
 
 		if (rte->relid) {
 			Relation rel = RelationIdGetRelation(rte->relid);
-			auto is_catalog_table = pgduckdb::IsCatalogTable(rel);
+			bool is_catalog_table = pgduckdb::IsCatalogTable(rel);
 			RelationClose(rel);
 			if (is_catalog_table) {
 				return true;
@@ -156,6 +156,7 @@ IsCatalogTable(Relation rel) {
 	auto namespace_oid = RelationGetNamespace(rel);
 	return namespace_oid == PG_CATALOG_NAMESPACE || namespace_oid == PG_TOAST_NAMESPACE;
 }
+
 bool
 IsAllowedStatement(Query *query, bool throw_error) {
 	int elevel = throw_error ? ERROR : DEBUG4;

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -3,6 +3,7 @@
 #include "pgduckdb/pgduckdb_planner.hpp"
 #include "pgduckdb/pg/transactions.hpp"
 #include "pgduckdb/pgduckdb_xact.hpp"
+#include "pgduckdb/pgduckdb_hooks.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
 
 extern "C" {
@@ -51,10 +52,10 @@ ContainsCatalogTable(List *rtes) {
 		}
 
 		if (rte->relid) {
-			auto rel = RelationIdGetRelation(rte->relid);
-			auto namespace_oid = RelationGetNamespace(rel);
+			Relation rel = RelationIdGetRelation(rte->relid);
+			auto is_catalog_table = pgduckdb::IsCatalogTable(rel);
 			RelationClose(rel);
-			if (namespace_oid == PG_CATALOG_NAMESPACE || namespace_oid == PG_TOAST_NAMESPACE) {
+			if (is_catalog_table) {
 				return true;
 			}
 		}
@@ -148,8 +149,15 @@ ContainsFromClause(Query *query) {
 	return query->rtable;
 }
 
-static bool
-IsAllowedStatement(Query *query, bool throw_error = false) {
+namespace pgduckdb {
+
+bool
+IsCatalogTable(Relation rel) {
+	auto namespace_oid = RelationGetNamespace(rel);
+	return namespace_oid == PG_CATALOG_NAMESPACE || namespace_oid == PG_TOAST_NAMESPACE;
+}
+bool
+IsAllowedStatement(Query *query, bool throw_error) {
 	int elevel = throw_error ? ERROR : DEBUG4;
 	/* DuckDB does not support modifying CTEs INSERT/UPDATE/DELETE */
 	if (query->hasModifyingCTE) {
@@ -160,7 +168,7 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 	/* We don't support modifying statements on Postgres tables yet */
 	if (query->commandType != CMD_SELECT) {
 		RangeTblEntry *resultRte = list_nth_node(RangeTblEntry, query->rtable, query->resultRelation - 1);
-		if (!IsDuckdbTable(resultRte->relid)) {
+		if (!::IsDuckdbTable(resultRte->relid)) {
 			elog(elevel, "DuckDB does not support modififying Postgres tables");
 			return false;
 		}
@@ -183,16 +191,17 @@ IsAllowedStatement(Query *query, bool throw_error = false) {
 	/* Anything else is hopefully fine... */
 	return true;
 }
+} // namespace pgduckdb
 
 static PlannedStmt *
 DuckdbPlannerHook_Cpp(Query *parse, const char *query_string, int cursor_options, ParamListInfo bound_params) {
 	if (pgduckdb::IsExtensionRegistered()) {
 		if (NeedsDuckdbExecution(parse)) {
 			pgduckdb::TriggerActivity();
-			IsAllowedStatement(parse, true);
+			pgduckdb::IsAllowedStatement(parse, true);
 
 			return DuckdbPlanNode(parse, query_string, cursor_options, bound_params, true);
-		} else if (duckdb_force_execution && IsAllowedStatement(parse) && ContainsFromClause(parse)) {
+		} else if (duckdb_force_execution && pgduckdb::IsAllowedStatement(parse) && ContainsFromClause(parse)) {
 			pgduckdb::TriggerActivity();
 			PlannedStmt *duckdbPlan = DuckdbPlanNode(parse, query_string, cursor_options, bound_params, false);
 			if (duckdbPlan) {

--- a/test/pycheck/copy_test.py
+++ b/test/pycheck/copy_test.py
@@ -1,0 +1,200 @@
+from .utils import Cursor
+
+import pytest
+import psycopg.errors
+from pathlib import Path
+import json
+
+
+def test_copy_to_local(cur: Cursor, tmp_path: Path):
+    # Create a sample table and insert data
+    cur.sql("CREATE TEMP TABLE test_table (id INT, name TEXT)")
+    cur.sql("INSERT INTO test_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+    # Define the local file path
+    csv_path = tmp_path / "test_copy.csv"
+
+    # Use COPY command to copy data to a local file
+    cur.sql(f"COPY test_table TO '{csv_path}' WITH (FORMAT CSV)")
+
+    # Verify the local file content
+    with open(csv_path, "r") as file:
+        content = file.read()
+        expected_content = "id,name\n1,Alice\n2,Bob\n"
+        assert (
+            content == expected_content
+        ), f"Expected: {expected_content}, but got: {content}"
+
+    # The above was using duckdb exection because duckdb.force_execution is
+    # true by default in our tests. We can validate that by looking at the
+    # error message.
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match='Binder Error: Unrecognized option CSV writer "unknown_option"',
+    ):
+        cur.sql(
+            f"COPY test_table TO '{csv_path}' WITH (FORMAT CSV, UNKNOWN_OPTION true)"
+        )
+
+    # Disabling duckdb.force_execution makes the query fail with a different
+    # error.
+    cur.sql("SET duckdb.force_execution = false")
+    with pytest.raises(
+        psycopg.errors.SyntaxError,
+        match='option "unknown_option" not recognized',
+    ):
+        cur.sql(
+            f"COPY test_table TO '{csv_path}' WITH (FORMAT CSV, UNKNOWN_OPTION true)"
+        )
+
+    parquet_path = tmp_path / "test_copy.parquet"
+
+    # Use COPY command to copy data to a local file
+    cur.sql(f"COPY test_table TO '{parquet_path}' WITH (FORMAT PARQUET)")
+    assert cur.sql(f"select * from read_parquet('{parquet_path}')") == [
+        (1, "Alice"),
+        (2, "Bob"),
+    ]
+
+    # We can copy the result of a DuckDB query using Postgres its COPY logic
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{csv_path}'"
+    )
+    assert cur.sql(f"select * from read_csv('{csv_path}')") == 123
+
+    # And we can do the same with the duckdb writer
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{parquet_path}' (FORMAT PARQUET)"
+    )
+    assert cur.sql(f"select * from read_parquet('{parquet_path}')") == 123
+
+    # We don't even need to specify the format, just the file extension will work
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{parquet_path}'"
+    )
+    assert cur.sql(f"select * from read_parquet('{parquet_path}')") == 123
+
+    # We don't even need to specify the format, just the file extension will work
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{parquet_path}'"
+    )
+    assert cur.sql(f"select * from read_parquet('{parquet_path}')") == 123
+
+    json_path = tmp_path / "test_copy.jsonl"
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{json_path}'"
+    )
+    assert cur.sql(f"select * from read_json('{json_path}')") == 123
+    assert json.loads(json_path.read_text()) == {"xyz": 123}
+
+    json_path = tmp_path / "test_copy.json"
+    cur.sql(
+        f"COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO '{json_path}' (ARRAY true)"
+    )
+    assert cur.sql(f"select * from read_json('{json_path}')") == 123
+    assert json.loads(json_path.read_text()) == [{"xyz": 123}]
+
+    # We cannot read postgres system catalogs though
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="DuckDB does not support querying PG catalog tables",
+    ):
+        cur.sql(f"COPY (SELECT * FROM pg_proc) TO '{json_path}'")
+
+    # Also not directly
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="DuckDB does not support querying PG catalog tables",
+    ):
+        cur.sql(f"COPY pg_proc TO '{json_path}'")
+
+
+def test_copy_to_stdout(cur: Cursor):
+    # We can COPY the result from a DuckDB query to STDOUT
+    with cur.copy(
+        "COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO STDOUT"
+    ) as copy:
+        for row in copy.rows():
+            assert row == ("123",)
+
+    # ... but only in formats that Postgres supports
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="COPY ... TO STDOUT/FROM STDIN is not supported by DuckDB",
+    ):
+        with cur.copy(
+            "COPY (select * from duckdb.query($$ select 123 as xyz $$)) TO STDOUT (FORMAT PARQUET)"
+        ) as copy:
+            for row in copy.rows():
+                assert row == ("123",)
+
+    cur.sql("CREATE TEMP TABLE pg_table (id INT, name TEXT)")
+    cur.sql("INSERT INTO pg_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+    # We can COPY the result from a DuckDB query to STDOUT
+    with cur.copy("COPY pg_table TO STDOUT") as copy:
+        rows = list(copy.rows())
+        assert rows == [("1", "Alice"), ("2", "Bob")]
+
+    # ... but only in formats that Postgres supports
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="COPY ... TO STDOUT/FROM STDIN is not supported by DuckDB",
+    ):
+        with cur.sql("COPY pg_table TO STDOUT (FORMAT PARQUET)"):
+            pass
+
+    cur.sql("CREATE TEMP TABLE duck_table (id INT, name TEXT) USING duckdb")
+    cur.sql("INSERT INTO duck_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+    # We cannot copy a DuckDB table to STDOUT
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="COPY ... TO STDOUT/FROM STDIN is not supported by DuckDB",
+    ):
+        with cur.copy("COPY duck_table TO STDOUT"):
+            pass
+
+    # ... and definitely not in formats that Postgres doesn't support
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="COPY ... TO STDOUT/FROM STDIN is not supported by DuckDB",
+    ):
+        with cur.copy("COPY duck_table TO STDOUT (FORMAT PARQUET)"):
+            pass
+
+
+def test_copy_from_local(cur: Cursor, tmp_path: Path):
+    cur.sql("CREATE TEMP TABLE pg_table (id INT, name TEXT)")
+    cur.sql("INSERT INTO pg_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+
+    # Create two files that we can load data from
+    csv_path = tmp_path / "test_copy.csv"
+    parquet_path = tmp_path / "test_copy.parquet"
+    cur.sql(f"COPY pg_table TO '{csv_path}' WITH (FORMAT CSV)")
+    cur.sql(f"COPY pg_table TO '{parquet_path}' WITH (FORMAT PARQUET)")
+    cur.sql("TRUNCATE pg_table")
+
+    cur.sql("CREATE TEMP TABLE duck_table (id INT, name TEXT) USING duckdb")
+
+    # We can copy into a DuckDB table from a local csv file
+    cur.sql(f"COPY duck_table FROM '{csv_path}'")
+    assert cur.sql("SELECT * FROM duck_table") == [(1, "Alice"), (2, "Bob")]
+    cur.sql("TRUNCATE duck_table")
+
+    # We can copy into a DuckDB table from a local csv file
+    cur.sql(f"COPY duck_table FROM '{parquet_path}'")
+    assert cur.sql("SELECT * FROM duck_table") == [(1, "Alice"), (2, "Bob")]
+    cur.sql("TRUNCATE duck_table")
+
+    # We can copy into a Postgres table from a local csv file
+    cur.sql(f"COPY pg_table FROM '{csv_path}' WITH (FORMAT CSV, HEADER true)")
+    assert cur.sql("SELECT * FROM pg_table") == [(1, "Alice"), (2, "Bob")]
+    cur.sql("TRUNCATE pg_table")
+
+    # ... but parquet files are not supported
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match="pg_duckdb does not support COPY ... FROM ... yet for Postgres tables",
+    ):
+        cur.sql(f"COPY pg_table FROM '{parquet_path}' WITH (FORMAT PARQUET)")


### PR DESCRIPTION
This adds various improvements to our COPY support:
1. Adds the ability to `COPY ... TO`/COPY ... FROM` tables backed by
   DuckDB.
2. Allow copying to the local filesystem using duckdb its COPY
   functionality. Just like for regular queries DuckDB is only used when
   it's detected that it's needed for execution of the query. Or when
   you configure `duckdb.force_execution`. The way it detects if it it's
   necessary is based on:
   a. `FORMAT PARQUET/JSON` and other options that are only supported by
      DuckDB its COPY implementation.
   b. File extensions like `.parquet`, `.json`, `.parquet.zstd` etc.
   c. Files starting with `s3://`, `gs://` and `r2://`
3. Adds test for COPY support, currently this does not test support for
   blob storage yet.


Fixes #460
Fixes #265
