### PR TITLE
Add cast from unresolved_type to bytea

### DIFF
--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -244,6 +244,11 @@ CREATE CAST (duckdb.unresolved_type AS bit)
 CREATE CAST (duckdb.unresolved_type AS bit[])
     WITH INOUT;
 
+CREATE CAST (duckdb.unresolved_type AS bytea)
+    WITH INOUT;
+CREATE CAST (duckdb.unresolved_type AS bytea[])
+    WITH INOUT;
+
 CREATE OPERATOR pg_catalog.~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,


### PR DESCRIPTION
This was a CAST that I missed, when adding most other casts in #531. The missing cast was reported on Discord by someone trying to get the spatial extension working in pg_duckdb.
