### PR TITLE
Make pgduckdb_metadata_cache.hpp self contained

### DIFF
--- a/include/pgduckdb/pgduckdb_metadata_cache.hpp
+++ b/include/pgduckdb/pgduckdb_metadata_cache.hpp
@@ -5,7 +5,7 @@
 namespace pgduckdb {
 bool IsExtensionRegistered();
 bool IsDuckdbOnlyFunction(Oid function_oid);
-uint64 CacheVersion();
+uint64_t CacheVersion();
 Oid ExtensionOid();
 Oid SchemaOid();
 Oid DuckdbRowOid();


### PR DESCRIPTION
Previously it had required including "postgres.h" before this header because it was using Postgres its uint64 type. This changes that to uint64_t to not make that necessary anymore.

This issue was reported on Discord.
