### PR TITLE
Fix MacOS Compilation

### DIFF
--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -261,7 +261,7 @@ IsDuckdbOnlyFunction(Oid function_oid) {
 	return false;
 }
 
-uint64
+uint64_t
 CacheVersion() {
 	Assert(cache.valid);
 	return cache.version;


### PR DESCRIPTION
Compilation on MacOS was failing with:
```
src/pgduckdb_metadata_cache.cpp:281:1: error: functions that differ only in their return type cannot be overloaded
  280 | uint64
      | ~~~~~~
  281 | CacheVersion() {
      | ^
include/pgduckdb/pgduckdb_metadata_cache.hpp:8:10: note: previous declaration is here
    8 | uint64_t CacheVersion();
      | ~~~~~~~~ ^
1 error generated.