### PR TITLE
Fix issue with too long schema names breaking MotherDuck sync

### DIFF
--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -818,7 +818,7 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 		 */
 		schema_oid = get_namespace_oid(postgres_schema_name, true);
 		if (schema_oid == InvalidOid) {
-			elog(WARNING, "Failed to create schema %s for unknown reason, skipping sync", postgres_schema_name);
+			elog(WARNING, "Failed to create schema '%s' for unknown reason, skipping sync", postgres_schema_name);
 			RollbackAndReleaseCurrentSubTransaction();
 			return false;
 		}

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -737,7 +737,7 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 	/* -1 is for the NULL terminator */
 	if (strlen(postgres_schema_name) > NAMEDATALEN - 1) {
 		ereport(WARNING,
-		        (errmsg("Skipping sync of MotherDuck schema %s because its name is too long", postgres_schema_name),
+		        (errmsg("Skipping sync of MotherDuck schema '%s' because its name is too long", postgres_schema_name),
 		         errhint("The maximum length of a schema name is %d characters", NAMEDATALEN - 1)));
 		return false;
 	}


### PR DESCRIPTION
If you have a database+schema that would result in a `ddb$` schema with
more than 63 characters it would completely break the MotherDuck
background syncing, due to an error-restart-loop. This changes the code
to skip that schema.

It also codes a bit more defensively in the place where it was also
previously throwing the error continuously. If the schema cannot be found
when we try to add a dependency for it, we say that we failed to create
the schema and skip it instead of getting into this error loop.
