### PR TITLE
Add Support for Duckdb Map type

### DIFF
--- a/include/pgduckdb/pgduckdb_metadata_cache.hpp
+++ b/include/pgduckdb/pgduckdb_metadata_cache.hpp
@@ -11,6 +11,7 @@ Oid SchemaOid();
 Oid DuckdbRowOid();
 Oid DuckdbUnresolvedTypeOid();
 Oid DuckdbUnionOid();
+Oid DuckdbMapOid();
 Oid DuckdbJsonOid();
 Oid DuckdbTableAmOid();
 Oid IsDuckdbTable(Form_pg_class relation);

--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -513,3 +513,12 @@ CREATE FUNCTION duckdb.enable_motherduck(TEXT DEFAULT '::FROM_ENV::', TEXT DEFAU
 RETURNS bool
 SET search_path = pg_catalog, pg_temp
 LANGUAGE C AS 'MODULE_PATHNAME', 'pgduckdb_enable_motherduck';
+
+CREATE TYPE duckdb.map;
+CREATE FUNCTION duckdb.map_in(cstring) RETURNS duckdb.map AS 'MODULE_PATHNAME', 'duckdb_map_in' LANGUAGE C IMMUTABLE STRICT;
+CREATE FUNCTION duckdb.map_out(duckdb.map) RETURNS cstring AS 'MODULE_PATHNAME', 'duckdb_map_out' LANGUAGE C IMMUTABLE STRICT;
+CREATE TYPE duckdb.map(
+    INTERNALLENGTH = VARIABLE,
+    INPUT = duckdb.map_in,
+    OUTPUT = duckdb.map_out
+);

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -70,6 +70,8 @@ struct {
 	Oid unresolved_type_oid;
 	/* The OID of the duckdb.union type */
 	Oid union_oid;
+	/* The OID of the duckdb.map type */
+	Oid map_oid;
 	/* The OID of the duckdb.json */
 	Oid json_oid;
 	/* The OID of the duckdb Table Access Method */
@@ -250,6 +252,8 @@ IsExtensionRegistered() {
 
 		cache.union_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("union"), cache.schema_oid);
 
+		cache.map_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("map"), cache.schema_oid);
+
 		cache.json_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("json"), cache.schema_oid);
 
 		if (duckdb_postgres_role[0] != '\0') {
@@ -322,6 +326,12 @@ Oid
 DuckdbUnionOid() {
 	Assert(cache.valid);
 	return cache.union_oid;
+}
+
+Oid
+DuckdbMapOid() {
+	Assert(cache.valid);
+	return cache.map_oid;
 }
 
 Oid

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -622,4 +622,12 @@ DECLARE_PG_FUNCTION(duckdb_union_out) {
 	return textout(fcinfo);
 }
 
+DECLARE_PG_FUNCTION(duckdb_map_in) {
+	elog(ERROR, "Creating the duckdb.map type is not supported");
+}
+
+DECLARE_PG_FUNCTION(duckdb_map_out) {
+	return textout(fcinfo);
+}
+
 } // extern "C"

--- a/test/regression/expected/test_all_types.out
+++ b/test/regression/expected/test_all_types.out
@@ -10,7 +10,6 @@ SELECT * exclude(
     struct,
     struct_of_arrays,
     array_of_structs,
-    map,
     fixed_nested_int_array,
     fixed_nested_varchar_array,
     fixed_struct_array,
@@ -57,6 +56,7 @@ date_array          | {}
 timestamp_array     | {}
 timestamptz_array   | {}
 varchar_array       | {}
+map                 | {}
 union               | Frank
 fixed_int_array     | {NULL,2,3}
 fixed_varchar_array | {a,NULL,c}
@@ -91,6 +91,7 @@ date_array          | {01-01-1970,infinity,-infinity,NULL,05-12-2022}
 timestamp_array     | {"Thu Jan 01 00:00:00 1970",infinity,-infinity,NULL,"Thu May 12 16:23:45 2022"}
 timestamptz_array   | {"Wed Dec 31 16:00:00 1969 PST",infinity,-infinity,NULL,"Thu May 12 16:23:45 2022 PDT"}
 varchar_array       | {🦆🦆🦆🦆🦆🦆,goose,NULL,""}
+map                 | {key1=🦆🦆🦆🦆🦆🦆, key2=goose}
 union               | 5
 fixed_int_array     | {4,5,6}
 fixed_varchar_array | {d,e,f}
@@ -125,6 +126,7 @@ date_array          |
 timestamp_array     | 
 timestamptz_array   | 
 varchar_array       | 
+map                 | 
 union               | 
 fixed_int_array     | 
 fixed_varchar_array | 

--- a/test/regression/sql/test_all_types.sql
+++ b/test/regression/sql/test_all_types.sql
@@ -10,7 +10,6 @@ SELECT * exclude(
     struct,
     struct_of_arrays,
     array_of_structs,
-    map,
     fixed_nested_int_array,
     fixed_nested_varchar_array,
     fixed_struct_array,


### PR DESCRIPTION
Resolves https://github.com/duckdb/pg_duckdb/issues/600

Also did not need new subscript functions as unresolved subscript functions already takes care of this. See below
```sql
postgres=# select r['mp'][100] from duckdb.query($$ select mp from tbl1 $$) r;
 r.mp[100] 
-----------
         1
(1 row)

postgres=# select r['mp'][200] from duckdb.query($$ select mp from tbl1 $$) r;
 r.mp[200] 
-----------
         2
(1 row)

postgres=# select r['mp'][1] from duckdb.query($$ select mp from tbl1 $$) r;
 r.mp[1] 
---------
        
(1 row)

postgres=# select * from duckdb.query($$ select mp[100] from tbl1 $$) r;
 mp[100] 
---------
       1
(1 row)

postgres=# select * from duckdb.query($$ select mp[200] from tbl1 $$) r;
 mp[200] 
---------
       2
(1 row)
```
