### PR TITLE
Add configurable max_temp_directory_size parameter

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -14,3 +14,4 @@ extern bool duckdb_autoload_known_extensions;
 extern int duckdb_max_workers_per_postgres_scan;
 extern char *duckdb_postgres_role;
 extern char *duckdb_motherduck_session_hint;
+extern char *duckdb_max_temp_directory_size;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -22,6 +22,7 @@ bool duckdb_log_pg_explain = false;
 int duckdb_max_workers_per_postgres_scan = 2;
 char *duckdb_motherduck_session_hint = strdup("");
 char *duckdb_postgres_role = strdup("");
+char *duckdb_max_temp_directory_size = strdup("");
 
 int duckdb_maximum_threads = -1;
 char *duckdb_maximum_memory = strdup("4GB");
@@ -117,6 +118,10 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.allow_unsigned_extensions",
 	                     "Allow DuckDB to load extensions with invalid or missing signatures",
 	                     &duckdb_allow_unsigned_extensions, PGC_SUSET);
+
+	DefineCustomVariable("duckdb.max_temp_directory_size",
+	                     "The maximum size DuckDB's temporary directory can grow to (e.g. '10GB', '90%')",
+	                     &duckdb_max_temp_directory_size, PGC_SUSET);
 
 	DefineCustomVariable(
 	    "duckdb.autoinstall_known_extensions",

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -159,6 +159,11 @@ DuckDBManager::Initialize() {
 		elog(DEBUG2, "[PGDuckDB] Set DuckDB option: 'maximum_memory'=%s", duckdb_maximum_memory);
 	}
 
+	if (duckdb_max_temp_directory_size != NULL && strlen(duckdb_max_temp_directory_size) != 0) {
+		config.SetOption("max_temp_directory_size", duckdb_max_temp_directory_size);
+		elog(DEBUG2, "[PGDuckDB] Set DuckDB option: 'max_temp_directory_size'=%s", duckdb_max_temp_directory_size);
+	}
+
 	if (duckdb_maximum_threads > -1) {
 		SET_DUCKDB_OPTION(maximum_threads);
 	}


### PR DESCRIPTION
## Description

This PR adds support for configuring DuckDB's maximum temporary directory size through the PostgreSQL GUC system. Users can now limit the amount of disk space DuckDB is allowed to use for temporary files, addressing issue #685.

### Implementation details:
- Added new GUC parameter `duckdb.max_temp_directory_size`
- Parameter accepts values in the format of absolute sizes ('10GB') or percentages ('50%')
- Default value is empty string (uses DuckDB's default of 90% disk space)
- Parameter can only be modified by superusers (PGC_SUSET)
