### PR TITLE
Add DuckDB temp & extension directory GUCs

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -36,7 +36,6 @@ public:
 	void Reset();
 
 private:
-	DuckDBManager();
 	static DuckDBManager manager_instance;
 
 	void Initialize();
@@ -87,7 +86,5 @@ private:
 	duckdb::unique_ptr<duckdb::Connection> connection;
 	std::string default_dbname;
 };
-
-std::string CreateOrGetDirectoryPath(const char *directory_name);
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_guc.h
+++ b/include/pgduckdb/pgduckdb_guc.h
@@ -14,3 +14,6 @@ extern bool duckdb_autoload_known_extensions;
 extern int duckdb_max_workers_per_postgres_scan;
 extern char *duckdb_postgres_role;
 extern char *duckdb_motherduck_session_hint;
+extern char *duckdb_temporary_directory;
+extern char *duckdb_extension_directory;
+extern char *duckdb_max_temp_directory_size;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -16,6 +16,16 @@ extern "C" {
 
 static void DuckdbInitGUC(void);
 
+namespace {
+char *
+MakeDirName(const char *name) {
+	StringInfoData buf;
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "%s/pg_duckdb/%s", DataDir, name);
+	return buf.data;
+}
+} // namespace
+
 bool duckdb_force_execution = false;
 bool duckdb_unsafe_allow_mixed_transactions = false;
 bool duckdb_log_pg_explain = false;
@@ -31,6 +41,9 @@ bool duckdb_allow_community_extensions = false;
 bool duckdb_allow_unsigned_extensions = false;
 bool duckdb_autoinstall_known_extensions = true;
 bool duckdb_autoload_known_extensions = true;
+char *duckdb_temporary_directory = MakeDirName("temp");
+char *duckdb_extension_directory = MakeDirName("extensions");
+char *duckdb_max_temp_directory_size = strdup("");
 
 extern "C" {
 PG_MODULE_MAGIC;
@@ -133,6 +146,19 @@ DuckdbInitGUC(void) {
 	DefineCustomVariable("duckdb.memory_limit",
 	                     "The maximum memory DuckDB can use (e.g., 1GB), alias for duckdb.max_memory",
 	                     &duckdb_maximum_memory, PGC_SUSET);
+
+	DefineCustomVariable("duckdb.temporary_directory",
+	                     "Set the directory to which DuckDB write temp files, alias for duckdb.temporary_directory",
+	                     &duckdb_temporary_directory, PGC_SUSET);
+
+	DefineCustomVariable("duckdb.max_temp_directory_size",
+	                     "The maximum amount of data stored inside DuckDB's 'temp_directory' (when set) (e.g., 1GB), "
+	                     "alias for duckdb.max_temp_directory_size",
+	                     &duckdb_max_temp_directory_size, PGC_SUSET);
+
+	DefineCustomVariable("duckdb.extension_directory",
+	                     "Set the directory to where DuckDB stores extensions in, alias for duckdb.extension_directory",
+	                     &duckdb_extension_directory, PGC_SUSET);
 
 	DefineCustomVariable("duckdb.disabled_filesystems",
 	                     "Disable specific file systems preventing access (e.g., LocalFileSystem)",


### PR DESCRIPTION
Add support for 3 new DuckDB options:
* `duckdb.extension_directory` - Set the directory to store extensions in, by default in `<DataDir>/pg_duckdb/extensions`
* `duckdb.temporary_directory` - Set the directory to which to write temp files, by default in `<DataDir>/pg_duckdb/temp` 
* `duckdb.max_temp_directory_size` - The maximum amount of data stored inside the 'temp_directory' (when set) (e.g., 1GB) 

(Cf. DuckDB's documentation https://duckdb.org/docs/stable/configuration/overview)

Solves https://github.com/duckdb/pg_duckdb/discussions/666
Fixes https://github.com/duckdb/pg_duckdb/issues/684