### PR TITLE
Fix type mismatch issues with CTAS and materialized views

### DIFF
--- a/include/pgduckdb/pgduckdb_ddl.hpp
+++ b/include/pgduckdb/pgduckdb_ddl.hpp
@@ -3,7 +3,7 @@
 #include "pgduckdb/pg/declarations.hpp"
 
 namespace pgduckdb {
-enum class DDLType { NONE, CREATE_TABLE, ALTER_TABLE };
+enum class DDLType { NONE, CREATE_TABLE, ALTER_TABLE, REFRESH_MATERIALIZED_VIEW };
 /* Tracks the type of DDL statement that is currently being executed */
 extern DDLType top_level_duckdb_ddl_type;
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_hooks.hpp
+++ b/include/pgduckdb/pgduckdb_hooks.hpp
@@ -5,4 +5,6 @@
 namespace pgduckdb {
 bool IsAllowedStatement(Query *query, bool throw_error = false);
 bool IsCatalogTable(Relation rel);
+bool NeedsDuckdbExecution(Query *query);
+bool ShouldTryToUseDuckdbExecution(Query *query);
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -22,7 +22,6 @@ bool pgduckdb_is_unresolved_type(Oid type_oid);
 bool pgduckdb_is_fake_type(Oid type_oid);
 bool pgduckdb_var_is_duckdb_row(Var *var);
 bool pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc);
-bool pgduckdb_target_list_contains_unresolved_type_or_row(List *target_list);
 Var *pgduckdb_duckdb_row_subscript_var(Expr *expr);
 bool pgduckdb_reconstruct_star_step(StarReconstructionContext *ctx, ListCell *tle_cell);
 bool pgduckdb_function_needs_subquery(Oid function_oid);

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -3,6 +3,7 @@
 #include "pgduckdb/pgduckdb_xact.hpp"
 #include "pgduckdb/pgduckdb_guc.h"
 #include "pgduckdb/pgduckdb_ddl.hpp"
+#include "pgduckdb/pgduckdb_hooks.hpp"
 
 extern "C" {
 #include "postgres.h"
@@ -47,6 +48,7 @@ extern "C" {
 
 namespace pgduckdb {
 DDLType top_level_duckdb_ddl_type = DDLType::NONE;
+bool refreshing_materialized_view = false;
 } // namespace pgduckdb
 
 /*
@@ -246,20 +248,41 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 
 		Query *original_query = castNode(Query, stmt->query);
 
-		// For cases where Postgres does not usually plan the query, we need
-		// to do hacky things if the targetlist contains duckdb.unresolved_type
-		// or duckdb.row columns. In those cases we want to run the query
-		// through duckdb to get the actual result types for these queries,
-		// which won't happen automatically if the query is not planned by
-		// Postgres. So we will manually do it here.
+		// For cases where Postgres does not usually plan the query, sometimes
+		// still need to. Specifically for these cases:
+		// 1. If we're creating a DuckDB table, we need to plan the query
+		//    because the types that Postgres inferred might be different than
+		//    the ones that DuckDB execution inferred, e.g. when reading a
+		//    JSONB column from a Postgres table it will result in a JSONB
+		//    column according to Postgres, but DuckDB execution will actually
+		//    return a JSON column.
+		// 2. Similarly, if the query will use DuckDB execution (either because
+		//    it's required or because duckdb.force_execution is set to true),
+		//    we need to plan the query so that we can get the correct types
+		//    for the target list. This is because DuckDB execution will not be
+		//    able to infer the types from the target list, and will instead
+		//    use the types that Postgres inferred.
 		//
-		// If we're doing that anyway we might as well slightly change the
-		// query so that it always returns the types that are expected by
-		// Postgres. This is especially useful for materialized views, since
-		// the query for is likely to be run many times.
-		if (!pgduckdb_target_list_contains_unresolved_type_or_row(original_query->targetList)) {
-			// ... but if the target list doesn't contain duckdb.row or
-			// duckdb.unresolved_type, there's no need to do any of that.
+		// One final important thing to consider is that for materialized views
+		// it's really bad if a future REFRESH MATERIALIZED VIEW command
+		// returns different column types than the types that were returned by
+		// the query during creation. That can easily result in data
+		// corruption. To make sure this doesn't happen we do a few things:
+		// - Wrap the resulting duckdb query in a duckdb.query() call, this
+		//   means that even if the query did not require motherduck, it will
+		//   still use duckdb execution in any future refresh calls.
+		// - For the reverse problem, we make sure that REFRESH MATARIALIZED
+		//   VIEW ignores duckdb.force_execution (see the code comments in
+		//   ShouldTryToUseDuckdbExecution for details)
+		// - Explicity select all the arguments from the target list, from the
+		//   duckdb.query() call and cast them to the expected type. This way,
+		//   a "SELECT * FROM read_csv(...)" will always return the same
+		//   columns and column types, even if the CSV is changed.
+		bool needs_planning = is_duckdb_table || pgduckdb::NeedsDuckdbExecution(original_query) ||
+		                      pgduckdb::ShouldTryToUseDuckdbExecution(original_query);
+
+		if (!needs_planning) {
+			// If we don't need planning let's not do anything though.
 			return;
 		}
 
@@ -282,7 +305,18 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 
 		Query *rewritten_query_copy = (Query *)copyObjectImpl(query);
 
+		/*
+		 * We temporarily set the force_execution GUC to true, so that we can
+		 * plan the query in DuckDB. This is needed for a CTAS into a DuckDB
+		 * table, where the query itself does not require DuckDB execution.
+		 * If we don't set force_execution to true, the query will be planned
+		 * using Postgres, but then later executed using DuckDB when we
+		 * actually write into the DuckDB table.
+		 */
+		auto save_nestlevel = NewGUCNestLevel();
+		SetConfigOption("duckdb.force_execution", "true", PGC_USERSET, PGC_S_SESSION);
 		PlannedStmt *plan = pg_plan_query(query, query_string, CURSOR_OPT_PARALLEL_OK, params);
+		AtEOXact_GUC(false, save_nestlevel);
 
 		/* This is where our custom code starts again */
 		List *target_list = plan->planTree->targetlist;
@@ -298,7 +332,12 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 			 */
 			stmt->into->viewQuery = (Node *)copyObjectImpl(stmt->query);
 		}
-
+	} else if (IsA(parsetree, RefreshMatViewStmt)) {
+		/* We need to set the top level DDL type to REFRESH_MATERIALIZED_VIEW
+		 * here, because want ignore the value of duckdb.force_execution for
+		 * the duration of this REFRESH. See the code comment in
+		 * ShouldTryToUseDuckdbExecution for details. */
+		pgduckdb::top_level_duckdb_ddl_type = pgduckdb::DDLType::REFRESH_MATERIALIZED_VIEW;
 	} else if (IsA(parsetree, CreateSchemaStmt) && !pgduckdb::doing_motherduck_sync) {
 		auto stmt = castNode(CreateSchemaStmt, parsetree);
 		if (stmt->schemaname) {

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -250,7 +250,7 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 		Query *original_query = castNode(Query, stmt->query);
 
 		// For cases where Postgres does not usually plan the query, sometimes
-		// still need to. Specifically for these cases:
+		// we still need to. Specifically for these cases:
 		// 1. If we're creating a DuckDB table, we need to plan the query
 		//    because the types that Postgres inferred might be different than
 		//    the ones that DuckDB execution inferred, e.g. when reading a

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -116,21 +116,6 @@ pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc) {
 	return pgduckdb_is_duckdb_row(func_expr->funcresulttype);
 }
 
-bool
-pgduckdb_target_list_contains_unresolved_type_or_row(List *target_list) {
-	foreach_node(TargetEntry, tle, target_list) {
-		Oid type = exprType((Node *)tle->expr);
-		if (pgduckdb_is_unresolved_type(type)) {
-			return true;
-		}
-
-		if (pgduckdb_is_duckdb_row(type)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 /*
  * Returns NULL if the expression is not a subscript on a duckdb row. Returns
  * the Var of the duckdb row if it is.

--- a/test/pycheck/prepared_test.py
+++ b/test/pycheck/prepared_test.py
@@ -156,7 +156,7 @@ def test_prepared_ctas(cur: Cursor):
     # crash.
     with pytest.raises(
         psycopg.errors.InternalError,
-        match="Expected 1 parameters, but none were supplied",
+        match="Could not find parameter with identifier 1",
     ):
         cur.sql(
             "CREATE TEMP TABLE t2 USING duckdb AS SELECT * FROM heapt where id = %s",

--- a/test/regression/expected/create_table_as.out
+++ b/test/regression/expected/create_table_as.out
@@ -13,4 +13,19 @@ select count(*) from webpages;
     60
 (1 row)
 
+CREATE TEMP TABLE t_jsonb(data jsonb);
+INSERT INTO t_jsonb VALUES ('{"a": 1, "b": 2}');
+CREATE TEMP TABLE t_json AS SELECT * FROM t_jsonb WITH NO DATA;
+SELECT * FROM t_json;
+ data 
+------
+(0 rows)
+
+-- DuckDB table should have
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 't_json'::regclass AND attname = 'data';
+ atttypid 
+----------
+ json
+(1 row)
+
 DROP TABLE webpages;

--- a/test/regression/expected/materialized_view.out
+++ b/test/regression/expected/materialized_view.out
@@ -41,6 +41,78 @@ SELECT COUNT(*) FROM tv WHERE a < 3;
 
 DROP MATERIALIZED VIEW tv;
 DROP TABLE t;
+-- materialized view where duckdb execution changes result types of query
+CREATE TABLE t_jsonb(data jsonb);
+INSERT INTO t_jsonb VALUES ('{"a": 1, "b": 2}');
+CREATE MATERIALIZED VIEW mv_json AS SELECT * FROM t_jsonb;
+SELECT * from mv_json;
+       data       
+------------------
+ {"a": 1, "b": 2}
+(1 row)
+
+-- Should return json, because that's the return type of the query duckdb query
+-- (since it does not have the jsonb type).
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 'mv_json'::regclass AND attname = 'data';
+ atttypid 
+----------
+ json
+(1 row)
+
+INSERT INTO t_jsonb VALUES ('{"a": 3, "b": 4}');
+REFRESH MATERIALIZED VIEW mv_json;
+SELECT * from mv_json;
+       data       
+------------------
+ {"a": 1, "b": 2}
+ {"a": 3, "b": 4}
+(2 rows)
+
+SET duckdb.force_execution = false;
+INSERT INTO t_jsonb VALUES ('{"a": 5, "b": 6}');
+REFRESH MATERIALIZED VIEW mv_json;
+SET duckdb.force_execution = true;
+DROP MATERIALIZED VIEW mv_json;
+-- Materialized view created without duckdb execution, and then refresh with
+-- duckdb execution enabled.
+SET duckdb.force_execution = false;
+CREATE MATERIALIZED VIEW mv_jsonb AS SELECT * FROM t_jsonb;
+SELECT * from mv_jsonb;
+       data       
+------------------
+ {"a": 1, "b": 2}
+ {"a": 3, "b": 4}
+ {"a": 5, "b": 6}
+(3 rows)
+
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 'mv_jsonb'::regclass AND attname = 'data';
+ atttypid 
+----------
+ jsonb
+(1 row)
+
+REFRESH MATERIALIZED VIEW mv_jsonb;
+SELECT * from mv_jsonb;
+       data       
+------------------
+ {"a": 1, "b": 2}
+ {"a": 3, "b": 4}
+ {"a": 5, "b": 6}
+(3 rows)
+
+SET duckdb.force_execution = true;
+REFRESH MATERIALIZED VIEW mv_jsonb;
+SET duckdb.force_execution = false;
+SELECT * from mv_jsonb;
+       data       
+------------------
+ {"a": 1, "b": 2}
+ {"a": 3, "b": 4}
+ {"a": 5, "b": 6}
+(3 rows)
+
+SET duckdb.force_execution = true;
+DROP MATERIALIZED VIEW mv_jsonb;
 -- materialized view from duckdb execution
 CREATE TABLE t_csv(a INT, b INT);
 INSERT INTO t_csv VALUES (1,1),(2,2),(3,3);

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -245,11 +245,29 @@ SELECT * FROM t_heap3;
  1
 (1 row)
 
+CREATE TEMP TABLE t_jsonb_heap(data jsonb) USING heap;
+INSERT INTO t_jsonb_heap VALUES ('{"a": 1, "b": 2}');
+-- CTAS from postgres table with type that has a different name in DuckDB
+CREATE TEMP TABLE t_json AS SELECT * FROM t_jsonb_heap;
+SELECT * FROM t_json;
+       data       
+------------------
+ {"a": 1, "b": 2}
+(1 row)
+
+-- DuckDB table should have
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 't_json'::regclass AND attname = 'data';
+ atttypid 
+----------
+ json
+(1 row)
+
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 NOTICE:  result: database_name	schema_name	sql	
 VARCHAR	VARCHAR	VARCHAR	
-[ Rows: 2]
+[ Rows: 3]
 pg_temp	main	CREATE TABLE t(b INTEGER);
+pg_temp	main	CREATE TABLE t_json("data" JSON);
 pg_temp	main	CREATE TABLE webpages(column00 BIGINT, column01 VARCHAR, column02 DATE);
 
 

--- a/test/regression/sql/create_table_as.sql
+++ b/test/regression/sql/create_table_as.sql
@@ -4,4 +4,11 @@ CREATE TABLE webpages AS SELECT r['column00'], r['column01'], r['column02'] FROM
 select * from webpages order by column00 limit 2;
 select count(*) from webpages;
 
+CREATE TEMP TABLE t_jsonb(data jsonb);
+INSERT INTO t_jsonb VALUES ('{"a": 1, "b": 2}');
+CREATE TEMP TABLE t_json AS SELECT * FROM t_jsonb WITH NO DATA;
+SELECT * FROM t_json;
+-- DuckDB table should have
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 't_json'::regclass AND attname = 'data';
+
 DROP TABLE webpages;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -173,6 +173,15 @@ SELECT * FROM t_heap2;
 CREATE TEMP TABLE t_heap3(c) USING heap AS SELECT * FROM t_heap;
 SELECT * FROM t_heap3;
 
+CREATE TEMP TABLE t_jsonb_heap(data jsonb) USING heap;
+INSERT INTO t_jsonb_heap VALUES ('{"a": 1, "b": 2}');
+
+-- CTAS from postgres table with type that has a different name in DuckDB
+CREATE TEMP TABLE t_json AS SELECT * FROM t_jsonb_heap;
+SELECT * FROM t_json;
+-- DuckDB table should have
+SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 't_json'::regclass AND attname = 'data';
+
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 
 -- multi-VALUES


### PR DESCRIPTION
DuckDB and Postgres can return different types for the same queries.
This can confuse Postgres in various ways when these queries are
involved in CTAS or materialized views. This fixes a bunch of issues
related to that and adds appropriate regression tests.

This includes a fix for the materialized view issue that was found in #583
