### PR TITLE
Improve MD test user creation

### DIFF
--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -6,17 +6,18 @@ different client that pg_duckdb. By using python we can use the DuckDB python
 library for that purpose.
 """
 
-from .utils import Cursor, MOTHERDUCK, PG_MAJOR_VERSION
+from .utils import Cursor, PG_MAJOR_VERSION
+from .motherduck_token_helper import can_run_md_tests
 
 import pytest
 import psycopg.errors
 
 
-if not MOTHERDUCK:
+if not can_run_md_tests():
     pytestmark = pytest.mark.skip(reason="Skipping all motherduck tests")
 
 
-def test_md_duckdb_version(md_cur: Cursor, ddb):
+def test_md_duckdb_version(ddb, md_cur: Cursor):
     version_query = "SELECT library_version FROM pragma_version();"
     python_duckdb_version = ddb.sql(version_query)
     pg_duckdb_duckdb_version = md_cur.sql(

--- a/test/pycheck/motherduck_token_helper.py
+++ b/test/pycheck/motherduck_token_helper.py
@@ -7,11 +7,12 @@ import os
 os.environ.pop("motherduck_token", None)
 
 MD_TEST_USER_CREATOR_TOKEN = os.environ.get("md_test_user_creator_token")
+MOTHERDUCK_TEST_TOKEN = os.environ.get("MOTHERDUCK_TEST_TOKEN")
 CACHED_TEST_USER = None
 
 
 def can_run_md_tests():
-    return MD_TEST_USER_CREATOR_TOKEN is not None
+    return MD_TEST_USER_CREATOR_TOKEN is not None or MOTHERDUCK_TEST_TOKEN is not None
 
 
 def create_test_user():
@@ -21,6 +22,12 @@ def create_test_user():
 
     For now, this function only supports one user, that will be re-used for all tests.
     """
+
+    if MOTHERDUCK_TEST_TOKEN is not None:
+        print(
+            "Found `MOTHERDUCK_TEST_TOKEN` environment variable, using it as the test user token."
+        )
+        return {"token": MOTHERDUCK_TEST_TOKEN}
 
     global CACHED_TEST_USER
     if CACHED_TEST_USER is not None:

--- a/test/pycheck/motherduck_token_helper.py
+++ b/test/pycheck/motherduck_token_helper.py
@@ -1,0 +1,46 @@
+from urllib.request import urlopen, Request
+import json
+import os
+
+# Remove any normal user token from the environment so that we don't
+# accidentally use it.
+os.environ.pop("motherduck_token", None)
+
+MD_TEST_USER_CREATOR_TOKEN = os.environ.get("md_test_user_creator_token")
+CACHED_TEST_USER = None
+
+
+def can_run_md_tests():
+    return MD_TEST_USER_CREATOR_TOKEN is not None
+
+
+def create_test_user():
+    """
+    Given a `motherduck_token` environment variable, this function creates a test user and returns its details.
+    The user to which the `motherduck_token` belongs needs to have the rights to create test users.
+
+    For now, this function only supports one user, that will be re-used for all tests.
+    """
+
+    global CACHED_TEST_USER
+    if CACHED_TEST_USER is not None:
+        return CACHED_TEST_USER
+
+    token = MD_TEST_USER_CREATOR_TOKEN
+    if not token:
+        raise ValueError("Environment variable 'motherduck_token' not set.")
+
+    data = json.dumps({"token": token}).encode("utf-8")
+
+    host = os.environ.get("motherduck_host", "api.motherduck.com")
+    req = Request(url=f"https://{host}/tuc/createTestUser", data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+
+    with urlopen(req) as f:
+        res = f.read().decode("utf-8")
+        res_json = json.loads(res)
+        print(
+            f"Created user with email='{res_json['testEmail']}' and id='{res_json['id']}'"
+        )
+        CACHED_TEST_USER = res_json
+        return res_json

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -60,16 +60,7 @@ elif platform.system() == "OpenBSD":
 
 BSD = MACOS or FREEBSD or OPENBSD
 
-MOTHERDUCK_TEST_TOKEN = os.environ.get("MOTHERDUCK_TEST_TOKEN", "")
-MOTHERDUCK = bool(MOTHERDUCK_TEST_TOKEN)
-
 os.environ["motherduck_disable_web_login"] = "1"
-if MOTHERDUCK:
-    os.environ["MOTHERDUCK_TOKEN"] = MOTHERDUCK_TEST_TOKEN
-else:
-    # Remove any normal user token from the environment so that we don't
-    # accidentally use it.
-    os.environ.pop("MOTHERDUCK_TOKEN", None)
 
 
 def eprint(*args, **kwargs):


### PR DESCRIPTION
In order to correctly test https://github.com/duckdb/pg_duckdb/pull/545 we will need to have multiple test users.

This PR paves the way to generate as many MotherDuck test user as we want.

I am considering removing the support for `MOTHERDUCK_TEST_TOKEN`, but I have kept it for now.

The main change is now we can run the test suite with a token that can generate test users and it will generates one and use it through the test suite.