### PR TITLE
Remove MOTHERDUCK_TOKEN before running tests

### DIFF
--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -4,6 +4,9 @@ ROOT_DIR = ../..
 
 include $(ROOT_DIR)/Makefile.global
 
+# Make sure foreign_data_wrapper tests fail as expected
+unexport MOTHERDUCK_TOKEN
+
 check-regression-duckdb:
 	TEST_DIR=$(CURDIR) $(pg_regress_installcheck) \
 	--encoding=UTF8 \


### PR DESCRIPTION
The `foreign_data_wrapper` test assumes MOTHERDUCK_TOKEN is not set. I
usually have this env variable set in my environment, so this removes it
automatically before running the tests so the tests continue to pass.
Without this change tests fail like this:

```diff
 -- Use helper to enable MD: will fail since there's no token in environment
 SELECT duckdb.enable_motherduck();
-ERROR:  No token was provided and `motherduck_token` environment variable was not set
+ enable_motherduck
+-------------------
+ t
+(1 row)
+
 -- Use helper to enable MD: will succeed
 SELECT duckdb.enable_motherduck('foo');
  enable_motherduck
 -------------------
- t
+ f
 (1 row)

 -- Now MD is enabled again
```
