### PR TITLE
Improve `create_simple_secret` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,14 @@ Querying data stored in Parquet, CSV, JSON, Iceberg and Delta format can be done
 
 	```sql
 	SELECT duckdb.create_simple_secret(
-		'S3',                -- Type (S3, GCS, R2)
-		'access_key_id',     -- Key Id
-		'secret_access_key', -- Secret
-		'session_token',     -- Session Token (optional)
-		'us-east-1'          -- region (optional)
+		type          := 'S3',          -- Type: one of (S3, GCS, R2)
+		key_id        := 'access_key_id',
+		secret        := 'xxx',
+		session_token := 'yyy',         -- (optional)
+		region        := 'us-east-1',   -- (optional)
+		url_style     := 'xxx',         -- (optional)
+		provider      := 'xxx',         -- (optional)
+		endpoint      := 'xxx'          -- (optional)
 	)
 	```
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -8,11 +8,14 @@ For example with utility functions:
 
 ```sql
 SELECT duckdb.create_simple_secret(
-    'S3',                -- Type (S3, GCS, R2)
-    'access_key_id',     -- Key Id
-    'secret_access_key', -- Secret
-    'session_token',     -- Session Token (optional, default: not set)
-    'us-east-1'          -- region (optional, default: 'us-east-1')
+    type          := 'S3',          -- Type: one of (S3, GCS, R2)
+    key_id        := 'access_key_id',
+    secret        := 'xxx',
+    session_token := 'yyy',         -- (optional)
+    region        := 'us-east-1',   -- (optional)
+    url_style     := 'xxx',         -- (optional)
+    provider      := 'xxx',         -- (optional)
+    endpoint      := 'xxx'          -- (optional)
 )
 ```
 

--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -592,11 +592,14 @@ DROP FUNCTION duckdb.duckdb_update_secrets_table_seq();
 
 -- Secrets helpers
 CREATE FUNCTION duckdb.create_simple_secret(
-    TEXT,              -- Type (S3, GCS, R2)
-    TEXT,              -- Key Id
-    TEXT,              -- Secret
-    TEXT DEFAULT '',   -- Session Token
-    TEXT DEFAULT ''    -- Region
+    type          TEXT, -- One of (S3, GCS, R2)
+    key_id        TEXT,
+    secret        TEXT,
+    session_token TEXT DEFAULT '',
+    region        TEXT DEFAULT '',
+    url_style     TEXT DEFAULT '',
+    provider      TEXT DEFAULT '',
+    endpoint      TEXT DEFAULT ''
 )
 RETURNS TEXT
 SET search_path = pg_catalog, pg_temp

--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -150,13 +150,13 @@ SELECT * FROM duckdb.query($$ SELECT name, type FROM duckdb_secrets(); $$);
 -- User helpers --
 -- 1. Simple secrets
 -- S3
-SELECT duckdb.create_simple_secret('S3', 'my first key', 'my secret', 'my-region-42', 'my session token');
+SELECT duckdb.create_simple_secret('S3', 'my first key', 'my secret', 'my session token', 'my-region-42');
  create_simple_secret 
 ----------------------
  simple_s3_secret
 (1 row)
 
-SELECT duckdb.create_simple_secret('S3', 'my other key', 'my secret', 'my-region-42'); -- No session token
+SELECT duckdb.create_simple_secret('S3', 'my other key', 'my secret', 'my session token'); -- Default region
  create_simple_secret 
 ----------------------
  simple_s3_secret_1
@@ -166,6 +166,21 @@ SELECT duckdb.create_simple_secret('S3', 'my third key', 'my secret'); -- No ses
  create_simple_secret 
 ----------------------
  simple_s3_secret_2
+(1 row)
+
+-- With named arguments
+SELECT duckdb.create_simple_secret(
+    'S3',
+    key_id := 'my named key',
+    secret := 'my secret',
+    session_token := 'foo',
+    url_style := 'path',
+    provider := 'credential_chain',
+    endpoint := 'my-endpoint.com'
+);
+ create_simple_secret 
+----------------------
+ simple_s3_secret_3
 (1 row)
 
 -- R2
@@ -182,13 +197,13 @@ SELECT duckdb.create_simple_secret('R2', 'my r2 key2', 'my secret');
 (1 row)
 
 -- GCS
-SELECT duckdb.create_simple_secret('GCS', 'my first key', 'my secret', 'my-region-42', 'my session token');
+SELECT duckdb.create_simple_secret('GCS', 'my first key', 'my secret', 'my session token', 'my-region-42');
  create_simple_secret 
 ----------------------
  simple_gcs_secret
 (1 row)
 
-SELECT duckdb.create_simple_secret('GCS', 'my other key', 'my secret', 'my-region-42'); -- No session token
+SELECT duckdb.create_simple_secret('GCS', 'my other key', 'my secret', 'my session token'); -- Default region
  create_simple_secret 
 ----------------------
  simple_gcs_secret_1
@@ -216,18 +231,19 @@ FROM pg_foreign_server fs
 INNER JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 LEFT JOIN pg_user_mapping um ON um.umserver = fs.oid
 WHERE fdw.fdwname = 'duckdb' AND fs.srvtype != 'motherduck';
-       srvname       | srvtype |      srvoptions       |                                  umoptions                                  
----------------------+---------+-----------------------+-----------------------------------------------------------------------------
- simple_s3_secret    | S3      | {region=my-region-42} | {"key_id=my first key","secret=my secret","session_token=my session token"}
- simple_s3_secret_1  | S3      | {region=my-region-42} | {"key_id=my other key","secret=my secret"}
- simple_s3_secret_2  | S3      |                       | {"key_id=my third key","secret=my secret"}
- simple_r2_secret    | R2      |                       | {"key_id=my r2 key1","secret=my secret"}
- simple_r2_secret_1  | R2      |                       | {"key_id=my r2 key2","secret=my secret"}
- simple_gcs_secret   | GCS     | {region=my-region-42} | {"key_id=my first key","secret=my secret","session_token=my session token"}
- simple_gcs_secret_1 | GCS     | {region=my-region-42} | {"key_id=my other key","secret=my secret"}
- simple_gcs_secret_2 | GCS     |                       | {"key_id=my third key","secret=my secret"}
- azure_secret        | azure   |                       | {"connection_string=hello world"}
-(9 rows)
+       srvname       | srvtype |                             srvoptions                              |                                  umoptions                                  
+---------------------+---------+---------------------------------------------------------------------+-----------------------------------------------------------------------------
+ simple_s3_secret    | S3      | {region=my-region-42}                                               | {"key_id=my first key","secret=my secret","session_token=my session token"}
+ simple_s3_secret_1  | S3      |                                                                     | {"key_id=my other key","secret=my secret","session_token=my session token"}
+ simple_s3_secret_2  | S3      |                                                                     | {"key_id=my third key","secret=my secret"}
+ simple_s3_secret_3  | S3      | {url_style=path,provider=credential_chain,endpoint=my-endpoint.com} | {"key_id=my named key","secret=my secret",session_token=foo}
+ simple_r2_secret    | R2      | {region=my-region-42}                                               | {"key_id=my r2 key1","secret=my secret","session_token=my session token"}
+ simple_r2_secret_1  | R2      |                                                                     | {"key_id=my r2 key2","secret=my secret"}
+ simple_gcs_secret   | GCS     | {region=my-region-42}                                               | {"key_id=my first key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_1 | GCS     |                                                                     | {"key_id=my other key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_2 | GCS     |                                                                     | {"key_id=my third key","secret=my secret"}
+ azure_secret        | azure   |                                                                     | {"connection_string=hello world"}
+(10 rows)
 
 SELECT * FROM duckdb.query($$
     SELECT
@@ -256,12 +272,13 @@ $$);
 -------------------------------------+-------+--------------+--------------+---------------+----------+-------------------
  pgduckdb_secret_azure_secret        | azure |              |              |               |          | redacted
  pgduckdb_secret_simple_gcs_secret   | gcs   | my first key | my-region-42 | redacted      | redacted | 
- pgduckdb_secret_simple_gcs_secret_1 | gcs   | my other key | my-region-42 |               | redacted | 
+ pgduckdb_secret_simple_gcs_secret_1 | gcs   | my other key |              | redacted      | redacted | 
  pgduckdb_secret_simple_gcs_secret_2 | gcs   | my third key |              |               | redacted | 
- pgduckdb_secret_simple_r2_secret    | r2    | my r2 key1   |              |               | redacted | 
+ pgduckdb_secret_simple_r2_secret    | r2    | my r2 key1   | my-region-42 | redacted      | redacted | 
  pgduckdb_secret_simple_r2_secret_1  | r2    | my r2 key2   |              |               | redacted | 
  pgduckdb_secret_simple_s3_secret    | s3    | my first key | my-region-42 | redacted      | redacted | 
- pgduckdb_secret_simple_s3_secret_1  | s3    | my other key | my-region-42 |               | redacted | 
+ pgduckdb_secret_simple_s3_secret_1  | s3    | my other key |              | redacted      | redacted | 
  pgduckdb_secret_simple_s3_secret_2  | s3    | my third key |              |               | redacted | 
-(9 rows)
+ pgduckdb_secret_simple_s3_secret_3  | s3    | my named key | us-east-1    | redacted      | redacted | 
+(10 rows)
 

--- a/test/regression/sql/duckdb_secrets.sql
+++ b/test/regression/sql/duckdb_secrets.sql
@@ -118,17 +118,28 @@ SELECT * FROM duckdb.query($$ SELECT name, type FROM duckdb_secrets(); $$);
 -- 1. Simple secrets
 
 -- S3
-SELECT duckdb.create_simple_secret('S3', 'my first key', 'my secret', 'my-region-42', 'my session token');
-SELECT duckdb.create_simple_secret('S3', 'my other key', 'my secret', 'my-region-42'); -- No session token
+SELECT duckdb.create_simple_secret('S3', 'my first key', 'my secret', 'my session token', 'my-region-42');
+SELECT duckdb.create_simple_secret('S3', 'my other key', 'my secret', 'my session token'); -- Default region
 SELECT duckdb.create_simple_secret('S3', 'my third key', 'my secret'); -- No session token, default region
+
+-- With named arguments
+SELECT duckdb.create_simple_secret(
+    'S3',
+    key_id := 'my named key',
+    secret := 'my secret',
+    session_token := 'foo',
+    url_style := 'path',
+    provider := 'credential_chain',
+    endpoint := 'my-endpoint.com'
+);
 
 -- R2
 SELECT duckdb.create_simple_secret('R2', 'my r2 key1', 'my secret', 'my session token', 'my-region-42');
 SELECT duckdb.create_simple_secret('R2', 'my r2 key2', 'my secret');
 
 -- GCS
-SELECT duckdb.create_simple_secret('GCS', 'my first key', 'my secret', 'my-region-42', 'my session token');
-SELECT duckdb.create_simple_secret('GCS', 'my other key', 'my secret', 'my-region-42'); -- No session token
+SELECT duckdb.create_simple_secret('GCS', 'my first key', 'my secret', 'my session token', 'my-region-42');
+SELECT duckdb.create_simple_secret('GCS', 'my other key', 'my secret', 'my session token'); -- Default region
 SELECT duckdb.create_simple_secret('GCS', 'my third key', 'my secret'); -- No session token, default region
 
 -- Invalid


### PR DESCRIPTION
As reported in https://github.com/duckdb/pg_duckdb/issues/716, some parameters were not easily available with the `create_simple_secret` helper function.

This PR makes the following important changes:
* moves the `region` parameter *after* the `session_token`
* names the arguments of `create_simple_secret`
* adds `url_style`, `provider` and `endpoint` named parameters

Fixes https://github.com/duckdb/pg_duckdb/issues/716