### PR TITLE
Add support for changing secrets public options

### DIFF
--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -168,7 +168,7 @@ SELECT duckdb.create_simple_secret('S3', 'my third key', 'my secret'); -- No ses
  simple_s3_secret_2
 (1 row)
 
--- With named arguments
+-- With named arguments (simple_s3_secret_3)
 SELECT duckdb.create_simple_secret(
     'S3',
     key_id := 'my named key',
@@ -183,6 +183,8 @@ SELECT duckdb.create_simple_secret(
  simple_s3_secret_3
 (1 row)
 
+-- Alter SERVER (public options only)
+ALTER SERVER simple_s3_secret_3 OPTIONS (SET endpoint 'my_other_endoint', SET url_style 'true');
 -- R2
 SELECT duckdb.create_simple_secret('R2', 'my r2 key1', 'my secret', 'my session token', 'my-region-42');
  create_simple_secret 
@@ -231,18 +233,18 @@ FROM pg_foreign_server fs
 INNER JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 LEFT JOIN pg_user_mapping um ON um.umserver = fs.oid
 WHERE fdw.fdwname = 'duckdb' AND fs.srvtype != 'motherduck';
-       srvname       | srvtype |                             srvoptions                              |                                  umoptions                                  
----------------------+---------+---------------------------------------------------------------------+-----------------------------------------------------------------------------
- simple_s3_secret    | S3      | {region=my-region-42}                                               | {"key_id=my first key","secret=my secret","session_token=my session token"}
- simple_s3_secret_1  | S3      |                                                                     | {"key_id=my other key","secret=my secret","session_token=my session token"}
- simple_s3_secret_2  | S3      |                                                                     | {"key_id=my third key","secret=my secret"}
- simple_s3_secret_3  | S3      | {url_style=path,provider=credential_chain,endpoint=my-endpoint.com} | {"key_id=my named key","secret=my secret",session_token=foo}
- simple_r2_secret    | R2      | {region=my-region-42}                                               | {"key_id=my r2 key1","secret=my secret","session_token=my session token"}
- simple_r2_secret_1  | R2      |                                                                     | {"key_id=my r2 key2","secret=my secret"}
- simple_gcs_secret   | GCS     | {region=my-region-42}                                               | {"key_id=my first key","secret=my secret","session_token=my session token"}
- simple_gcs_secret_1 | GCS     |                                                                     | {"key_id=my other key","secret=my secret","session_token=my session token"}
- simple_gcs_secret_2 | GCS     |                                                                     | {"key_id=my third key","secret=my secret"}
- azure_secret        | azure   |                                                                     | {"connection_string=hello world"}
+       srvname       | srvtype |                              srvoptions                              |                                  umoptions                                  
+---------------------+---------+----------------------------------------------------------------------+-----------------------------------------------------------------------------
+ simple_s3_secret    | S3      | {region=my-region-42}                                                | {"key_id=my first key","secret=my secret","session_token=my session token"}
+ simple_s3_secret_1  | S3      |                                                                      | {"key_id=my other key","secret=my secret","session_token=my session token"}
+ simple_s3_secret_2  | S3      |                                                                      | {"key_id=my third key","secret=my secret"}
+ simple_s3_secret_3  | S3      | {url_style=true,provider=credential_chain,endpoint=my_other_endoint} | {"key_id=my named key","secret=my secret",session_token=foo}
+ simple_r2_secret    | R2      | {region=my-region-42}                                                | {"key_id=my r2 key1","secret=my secret","session_token=my session token"}
+ simple_r2_secret_1  | R2      |                                                                      | {"key_id=my r2 key2","secret=my secret"}
+ simple_gcs_secret   | GCS     | {region=my-region-42}                                                | {"key_id=my first key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_1 | GCS     |                                                                      | {"key_id=my other key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_2 | GCS     |                                                                      | {"key_id=my third key","secret=my secret"}
+ azure_secret        | azure   |                                                                      | {"connection_string=hello world"}
 (10 rows)
 
 SELECT * FROM duckdb.query($$

--- a/test/regression/sql/duckdb_secrets.sql
+++ b/test/regression/sql/duckdb_secrets.sql
@@ -122,7 +122,7 @@ SELECT duckdb.create_simple_secret('S3', 'my first key', 'my secret', 'my sessio
 SELECT duckdb.create_simple_secret('S3', 'my other key', 'my secret', 'my session token'); -- Default region
 SELECT duckdb.create_simple_secret('S3', 'my third key', 'my secret'); -- No session token, default region
 
--- With named arguments
+-- With named arguments (simple_s3_secret_3)
 SELECT duckdb.create_simple_secret(
     'S3',
     key_id := 'my named key',
@@ -132,6 +132,9 @@ SELECT duckdb.create_simple_secret(
     provider := 'credential_chain',
     endpoint := 'my-endpoint.com'
 );
+
+-- Alter SERVER (public options only)
+ALTER SERVER simple_s3_secret_3 OPTIONS (SET endpoint 'my_other_endoint', SET url_style 'true');
 
 -- R2
 SELECT duckdb.create_simple_secret('R2', 'my r2 key1', 'my secret', 'my session token', 'my-region-42');


### PR DESCRIPTION
Follow-up of https://github.com/duckdb/pg_duckdb/pull/697: add support for `ALTER SERVER` syntax 