### PR TITLE
Also unexport motherduck_token

### DIFF
--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -6,6 +6,7 @@ include $(ROOT_DIR)/Makefile.global
 
 # Make sure foreign_data_wrapper tests fail as expected
 unexport MOTHERDUCK_TOKEN
+unexport motherduck_token
 
 check-regression-duckdb:
 	TEST_DIR=$(CURDIR) $(pg_regress_installcheck) \


### PR DESCRIPTION
`motherduck_token` is also a valid variable name (along with the upper case version), so remove both for consistency