### PR TITLE
Fix race condition between duckdb.enable_motherduck() background worker start

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Then you can enable it by simply using the `enable_motherduck` convenience metho
 ```sql
 -- If not provided, the token will be read from the `motherduck_token` environment variable
 -- If not provided, the default MD database name is `my_db`
-SELECT duckdb.enable_motherduck('<optional token>', '<optional MD database name>');
+CALL duckdb.enable_motherduck('<optional token>', '<optional MD database name>');
 ```
 
 Read more [here][md-docs] about MotherDuck integration.

--- a/docker/init.d/0002-enable-md-pg_duckdb.sql
+++ b/docker/init.d/0002-enable-md-pg_duckdb.sql
@@ -5,7 +5,7 @@
 \getenv uc_token MOTHERDUCK_TOKEN
 
 \if :{?lc_token}
-    SELECT duckdb.enable_motherduck(:'lc_token'::TEXT);
+    CALL duckdb.enable_motherduck(:'lc_token'::TEXT);
 \elif :{?uc_token}
-    SELECT duckdb.enable_motherduck(:'uc_token'::TEXT);
+    CALL duckdb.enable_motherduck(:'uc_token'::TEXT);
 \endif

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -9,7 +9,7 @@ Then you can enable it by simply using the `enable_motherduck` convenience metho
 ```sql
 -- If not provided, the token will be read from the `motherduck_token` environment variable
 -- If not provided, the default MD database name is `my_db`
-SELECT duckdb.enable_motherduck('<optional token>', '<optional MD database name>');
+CALL duckdb.enable_motherduck('<optional token>', '<optional MD database name>');
 ```
 
 This convenience method creates a `motherduck` `SERVER` using the `pg_duckdb` Foreign Data Wrapper, which hosts the options for this integration. It also provides an `USER MAPPING` for the current user, which stores the provided MotherDuck token (if any).
@@ -69,7 +69,7 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER motherduck OPTIONS (token '<your tok
 
 Note: with the `duckdb.enable_motherduck` convenience method above, you can simply do:
 ```sql
-SELECT duckdb.enable_motherduck('<token>', '<default database>');
+CALL duckdb.enable_motherduck('<token>', '<default database>');
 ```
 
 ## How DuckDB schemas are mapped to Postgres schemas

--- a/sql/pg_duckdb--0.3.0--0.4.0.sql
+++ b/sql/pg_duckdb--0.3.0--0.4.0.sql
@@ -565,9 +565,7 @@ CREATE FOREIGN DATA WRAPPER duckdb
   HANDLER pgduckdb_fdw_handler
   VALIDATOR pgduckdb_fdw_validator;
 
-CREATE FUNCTION duckdb.enable_motherduck(TEXT DEFAULT '::FROM_ENV::', TEXT DEFAULT '')
-RETURNS bool
-SET search_path = pg_catalog, pg_temp
+CREATE PROCEDURE duckdb.enable_motherduck(TEXT DEFAULT '::FROM_ENV::', TEXT DEFAULT '')
 LANGUAGE C AS 'MODULE_PATHNAME', 'pgduckdb_enable_motherduck';
 
 CREATE TYPE duckdb.map;

--- a/test/pycheck/conftest.py
+++ b/test/pycheck/conftest.py
@@ -92,7 +92,7 @@ def md_cur(pg, default_db_name, ddb, md_test_user):
     # dropped+created
     _ = ddb
 
-    pg.sql(f"SELECT duckdb.enable_motherduck('{md_test_user['token']}')")
+    pg.sql(f"CALL duckdb.enable_motherduck('{md_test_user['token']}')")
 
     pg.search_path = f"ddb${default_db_name}, public"
     with pg.cur() as cur:

--- a/test/regression/expected/foreign_data_wrapper.out
+++ b/test/regression/expected/foreign_data_wrapper.out
@@ -78,16 +78,33 @@ SELECT * FROM duckdb.is_motherduck_enabled();
  f
 (1 row)
 
--- Use helper to enable MD: will fail since there's no token in environment
-SELECT duckdb.enable_motherduck();
-ERROR:  No token was provided and `motherduck_token` environment variable was not set
--- Use helper to enable MD: will succeed
-SELECT duckdb.enable_motherduck('foo');
- enable_motherduck 
--------------------
- t
+-- Not possible to run in a transaction
+BEGIN;
+SELECT 1;
+ ?column? 
+----------
+        1
 (1 row)
 
+CALL duckdb.enable_motherduck();
+ERROR:  (PGDuckDB/pgduckdb_enable_motherduck_cpp) Executor Error: (PGDuckDB/::PreventInTransactionBlock) duckdb.enable_motherduck() cannot run inside a transaction block
+ROLLBACK;
+-- Use helper to enable MD: will fail since there's no token in environment
+CALL duckdb.enable_motherduck();
+ERROR:  No token was provided and `motherduck_token` environment variable was not set
+-- Use helper to enable MD: will succeed
+CALL duckdb.enable_motherduck('foo');
+-- Not possible to run in a transaction, even when it's enabled.
+BEGIN;
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+CALL duckdb.enable_motherduck();
+ERROR:  (PGDuckDB/pgduckdb_enable_motherduck_cpp) Executor Error: (PGDuckDB/::PreventInTransactionBlock) duckdb.enable_motherduck() cannot run inside a transaction block
+ROLLBACK;
 -- Now MD is enabled again
 SELECT * FROM duckdb.is_motherduck_enabled();
  is_motherduck_enabled 

--- a/test/regression/sql/foreign_data_wrapper.sql
+++ b/test/regression/sql/foreign_data_wrapper.sql
@@ -62,11 +62,23 @@ DROP SERVER valid_md_server1 CASCADE;
 -- Now MD is not enabled anymore
 SELECT * FROM duckdb.is_motherduck_enabled();
 
+-- Not possible to run in a transaction
+BEGIN;
+SELECT 1;
+CALL duckdb.enable_motherduck();
+ROLLBACK;
+
 -- Use helper to enable MD: will fail since there's no token in environment
-SELECT duckdb.enable_motherduck();
+CALL duckdb.enable_motherduck();
 
 -- Use helper to enable MD: will succeed
-SELECT duckdb.enable_motherduck('foo');
+CALL duckdb.enable_motherduck('foo');
+
+-- Not possible to run in a transaction, even when it's enabled.
+BEGIN;
+SELECT 1;
+CALL duckdb.enable_motherduck();
+ROLLBACK;
 
 -- Now MD is enabled again
 SELECT * FROM duckdb.is_motherduck_enabled();


### PR DESCRIPTION
When enabling motherduck it was possible for the background worker to
start before the motherduck SERVER & USER MAPPING were committed. Which
would result in the background worker shutting down again like this.
```
2025-04-22 14:24:40.248 CEST [1380182] LOG:  started pg_duckdb background worker for database 311541
2025-04-22 14:24:40.252 CEST [1380182] LOG:  pg_duckdb background worker: MotherDuck is not enabled, will exit.
```

This fixes that by committing the transaction before starting the
background worker.

Fixes #719
