### PR TITLE
Also set `DUCKDB_BUILD` when running `pycheck`

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -138,7 +138,7 @@ jobs:
       - name: Run make pycheck
         id: pycheck
         working-directory: duckdb
-        run: make pycheck
+        run: make pycheck DUCKDB_BUILD=${{ matrix.type }}
 
       - name: Print regression.diffs if regression tests failed
         if: failure() && steps.installcheck.outcome == 'failure'


### PR DESCRIPTION
To avoid rebuilding everything

Cf. [this run](https://github.com/duckdb/pg_duckdb/actions/runs/14660959410/job/41145142443) where it takes ~4min to build the extension and another 8 to run `pycheck` because we're rebuilding everything.