### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Note, for Azure, we provide a dedicated function:
 SELECT duckdb.create_azure_secret('< connection string >');
 ```
 
-Note: writes to Azure are not yet supported, please see [the current discussion](duckdb/duckdb_azure#44) for more information.
+Note: writes to Azure are not yet supported, please see [the current discussion](https://github.com/duckdb/duckdb-azure/issues/44) for more information.
 
 ### Connect with MotherDuck
 


### PR DESCRIPTION
Current link resolves to a non-existent file on main branch on this repository. This might be a temporary issue with Github.

On my browser, current broken anchor link is `https://github.com/duckdb/pg_duckdb/blob/main/duckdb/duckdb_azure#44`