### PR TITLE
Support parallel DuckDB threads for Postgres table scan

### DIFF
--- a/include/pgduckdb/pg/relations.hpp
+++ b/include/pgduckdb/pg/relations.hpp
@@ -21,6 +21,9 @@ Form_pg_attribute GetAttr(const TupleDesc tupleDesc, int i);
 bool TupleIsNull(TupleTableSlot *slot);
 
 void SlotGetAllAttrs(TupleTableSlot *slot);
+void SlotGetAllAttrsUnsafe(TupleTableSlot *slot);
+
+TupleTableSlot *ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, bool shouldFree);
 
 double EstimateRelSize(Relation rel);
 

--- a/include/pgduckdb/pg/relations.hpp
+++ b/include/pgduckdb/pg/relations.hpp
@@ -21,7 +21,6 @@ Form_pg_attribute GetAttr(const TupleDesc tupleDesc, int i);
 bool TupleIsNull(TupleTableSlot *slot);
 
 void SlotGetAllAttrs(TupleTableSlot *slot);
-void SlotGetAllAttrsUnsafe(TupleTableSlot *slot);
 
 TupleTableSlot *ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, bool shouldFree);
 

--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -15,6 +15,7 @@ extern bool duckdb_allow_community_extensions;
 extern bool duckdb_allow_unsigned_extensions;
 extern bool duckdb_autoinstall_known_extensions;
 extern bool duckdb_autoload_known_extensions;
+extern int duckdb_threads_for_postgres_scan;
 extern int duckdb_max_workers_per_postgres_scan;
 extern char *duckdb_postgres_role;
 extern char *duckdb_motherduck_session_hint;

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -37,5 +37,7 @@ duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type
 void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, uint64_t offset);
 bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, uint64_t col);
 void InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot *slot);
+void InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot **slots,
+                           int num_slots);
 
 } // namespace pgduckdb

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -18,7 +18,7 @@ struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {
 	~PostgresScanGlobalState();
 	idx_t
 	MaxThreads() const override {
-		return 1;
+		return max_threads;
 	}
 	void ConstructTableScanQuery(const duckdb::TableFunctionInitInput &input);
 
@@ -38,15 +38,18 @@ public:
 	std::ostringstream scan_query;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;
+	int max_threads;
 };
 
 // Local State
-
+#define LOCAL_STATE_SLOT_BATCH_SIZE 32
 struct PostgresScanLocalState : public duckdb::LocalTableFunctionState {
 	PostgresScanLocalState(PostgresScanGlobalState *global_state);
 	~PostgresScanLocalState() override;
 
 	PostgresScanGlobalState *global_state;
+	TupleTableSlot *slots[LOCAL_STATE_SLOT_BATCH_SIZE];
+	std::vector<uint8_t> minimal_tuple_buffer[LOCAL_STATE_SLOT_BATCH_SIZE];
 
 	size_t output_vector_size;
 	bool exhausted_scan;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -48,7 +48,7 @@ struct PostgresScanLocalState : public duckdb::LocalTableFunctionState {
 	~PostgresScanLocalState() override;
 
 	PostgresScanGlobalState *global_state;
-	TupleTableSlot *slots[LOCAL_STATE_SLOT_BATCH_SIZE];
+	TupleTableSlot *slot;
 	std::vector<uint8_t> minimal_tuple_buffer[LOCAL_STATE_SLOT_BATCH_SIZE];
 
 	size_t output_vector_size;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -21,7 +21,7 @@ struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {
 		return max_threads;
 	}
 	void ConstructTableScanQuery(const duckdb::TableFunctionInitInput &input);
-	void RegisterLocalState();
+	bool RegisterLocalState();
 	void UnregisterLocalState();
 
 private:
@@ -37,7 +37,7 @@ public:
 	bool count_tuples_only;
 	duckdb::vector<AttrNumber> output_columns;
 	std::atomic<std::uint32_t> total_row_count;
-	std::atomic<std::uint32_t> registered_local_states;
+	std::atomic<std::int32_t> registered_local_states;
 	std::ostringstream scan_query;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -21,6 +21,7 @@ struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {
 		return max_threads;
 	}
 	void ConstructTableScanQuery(const duckdb::TableFunctionInitInput &input);
+	void UnregisterLocalState();
 
 private:
 	int ExtractQueryFilters(duckdb::TableFilter *filter, const char *column_name, duckdb::string &filters,
@@ -35,6 +36,7 @@ public:
 	bool count_tuples_only;
 	duckdb::vector<AttrNumber> output_columns;
 	std::atomic<std::uint32_t> total_row_count;
+	std::atomic<std::uint32_t> finished_threads;
 	std::ostringstream scan_query;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;
@@ -48,7 +50,7 @@ struct PostgresScanLocalState : public duckdb::LocalTableFunctionState {
 	~PostgresScanLocalState() override;
 
 	PostgresScanGlobalState *global_state;
-	TupleTableSlot *slot;
+	TupleTableSlot *slots[LOCAL_STATE_SLOT_BATCH_SIZE];
 	std::vector<uint8_t> minimal_tuple_buffer[LOCAL_STATE_SLOT_BATCH_SIZE];
 
 	size_t output_vector_size;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -21,6 +21,7 @@ struct PostgresScanGlobalState : public duckdb::GlobalTableFunctionState {
 		return max_threads;
 	}
 	void ConstructTableScanQuery(const duckdb::TableFunctionInitInput &input);
+	void RegisterLocalState();
 	void UnregisterLocalState();
 
 private:
@@ -36,7 +37,7 @@ public:
 	bool count_tuples_only;
 	duckdb::vector<AttrNumber> output_columns;
 	std::atomic<std::uint32_t> total_row_count;
-	std::atomic<std::uint32_t> finished_threads;
+	std::atomic<std::uint32_t> registered_local_states;
 	std::ostringstream scan_query;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;

--- a/include/pgduckdb/scan/postgres_scan.hpp
+++ b/include/pgduckdb/scan/postgres_scan.hpp
@@ -38,7 +38,7 @@ public:
 	std::ostringstream scan_query;
 	duckdb::shared_ptr<PostgresTableReader> table_reader_global_state;
 	MemoryContext duckdb_scan_memory_ctx;
-	int max_threads;
+	idx_t max_threads;
 };
 
 // Local State

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -18,9 +18,8 @@ public:
 	bool GetNextMinimalTuple(std::vector<uint8_t> &minimal_tuple_buffer);
 	void PostgresTableReaderCleanup();
 	TupleTableSlot *InitTupleSlot();
-	bool
-	IsParallelScan() const {
-		return nworkers_launched > 0;
+	int NumWorkersLaunched() const {
+		return nworkers_launched;
 	}
 
 private:

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -16,7 +16,6 @@ public:
 	void Init(const char *table_scan_query, bool count_tuples_only);
 	void Cleanup();
 	bool GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer);
-	void PostgresTableReaderCleanup();
 	TupleTableSlot *InitTupleSlot();
 	int
 	NumWorkersLaunched() const {

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -18,7 +18,8 @@ public:
 	bool GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer);
 	void PostgresTableReaderCleanup();
 	TupleTableSlot *InitTupleSlot();
-	int NumWorkersLaunched() const {
+	int
+	NumWorkersLaunched() const {
 		return nworkers_launched;
 	}
 

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -2,6 +2,8 @@
 
 #include "pgduckdb/pg/declarations.hpp"
 
+#include <vector>
+
 #include "pgduckdb/utility/cpp_only_file.hpp" // Must be last include.
 
 namespace pgduckdb {
@@ -13,6 +15,13 @@ public:
 	TupleTableSlot *GetNextTuple();
 	void Init(const char *table_scan_query, bool count_tuples_only);
 	void Cleanup();
+	bool GetNextMinimalTuple(std::vector<uint8_t> &minimal_tuple_buffer);
+	void PostgresTableReaderCleanup();
+	TupleTableSlot *InitTupleSlot();
+	bool
+	IsParallelScan() const {
+		return nworkers_launched > 0;
+	}
 
 private:
 	PostgresTableReader(const PostgresTableReader &) = delete;

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -15,7 +15,7 @@ public:
 	TupleTableSlot *GetNextTuple();
 	void Init(const char *table_scan_query, bool count_tuples_only);
 	void Cleanup();
-	bool GetNextMinimalTuple(std::vector<uint8_t> &minimal_tuple_buffer);
+	bool GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer);
 	void PostgresTableReaderCleanup();
 	TupleTableSlot *InitTupleSlot();
 	int NumWorkersLaunched() const {

--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -66,17 +66,18 @@ TupleIsNull(TupleTableSlot *slot) {
 
 void
 SlotGetAllAttrs(TupleTableSlot *slot) {
-	PostgresFunctionGuard(slot_getallattrs, slot);
-}
-
-void
-SlotGetAllAttrsUnsafe(TupleTableSlot *slot) {
+	// It is safe to call slot_getallattrs directly without the PostgresFunctionGuard because the function doesn't
+	// perform any memory allocations. Assertions or errors are guaranteed not to occur for minimal slots.
 	slot_getallattrs(slot);
 }
 
 TupleTableSlot *
 ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, bool shouldFree) {
-	return ExecStoreMinimalTuple(minmal_tuple, slot, shouldFree);
+	// It's safe to call ExecStoreMinimalTuple without the PostgresFunctionGuard as long as the slot is not "owned" by
+	// the tuple, i.e., TTS_SHOULDFREE(slot) is false. This is because it does not allocate in memory contexts and the
+	// only error it can throw is when the slot is not a minimal slot. That error is an obvious programming error so we
+	// can ignore it here.
+	return ::ExecStoreMinimalTuple(minmal_tuple, slot, shouldFree);
 }
 
 Relation

--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -69,6 +69,16 @@ SlotGetAllAttrs(TupleTableSlot *slot) {
 	PostgresFunctionGuard(slot_getallattrs, slot);
 }
 
+void
+SlotGetAllAttrsUnsafe(TupleTableSlot *slot) {
+	slot_getallattrs(slot);
+}
+
+TupleTableSlot *
+ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, bool shouldFree) {
+	return ExecStoreMinimalTuple(minmal_tuple, slot, shouldFree);
+}
+
 Relation
 OpenRelation(Oid relationId) {
 	if (PostgresFunctionGuard(check_enable_rls, relationId, InvalidOid, false) == RLS_ENABLED) {

--- a/src/pgduckdb_detoast.cpp
+++ b/src/pgduckdb_detoast.cpp
@@ -134,6 +134,7 @@ ToastFetchDatum(struct varlena *attr) {
 	return result;
 }
 
+// This function is thread-safe and does not utilize the PostgreSQL memory context.
 Datum
 DetoastPostgresDatum(struct varlena *attr, bool *should_free) {
 	struct varlena *toasted_value = nullptr;

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -149,7 +149,7 @@ InitGUC() {
 
 	DefineCustomVariable("duckdb.threads_for_postgres_scan",
 	                     "Maximum number of DuckDB threads used for a single Postgres scan",
-	                     &duckdb_threads_for_postgres_scan, 1, MAX_PARALLEL_WORKER_LIMIT, PGC_SUSET);
+	                     &duckdb_threads_for_postgres_scan, 1, MAX_PARALLEL_WORKER_LIMIT);
 	DefineCustomVariable("duckdb.max_workers_per_postgres_scan",
 	                     "Maximum number of PostgreSQL workers used for a single Postgres scan",
 	                     &duckdb_max_workers_per_postgres_scan, 0, MAX_PARALLEL_WORKER_LIMIT);

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -113,6 +113,7 @@ bool duckdb_force_execution = false;
 bool duckdb_unsafe_allow_mixed_transactions = false;
 bool duckdb_convert_unsupported_numeric_to_double = false;
 bool duckdb_log_pg_explain = false;
+int duckdb_threads_for_postgres_scan = 2;
 int duckdb_max_workers_per_postgres_scan = 2;
 char *duckdb_motherduck_session_hint = strdup("");
 char *duckdb_postgres_role = strdup("");
@@ -146,9 +147,12 @@ InitGUC() {
 	DefineCustomVariable("duckdb.log_pg_explain", "Logs the EXPLAIN plan of a Postgres scan at the NOTICE log level",
 	                     &duckdb_log_pg_explain);
 
+	DefineCustomVariable("duckdb.threads_for_postgres_scan",
+	                     "Maximum number of DuckDB threads used for a single Postgres scan",
+	                     &duckdb_threads_for_postgres_scan, 1, MAX_PARALLEL_WORKER_LIMIT, PGC_SUSET);
 	DefineCustomVariable("duckdb.max_workers_per_postgres_scan",
 	                     "Maximum number of PostgreSQL workers used for a single Postgres scan",
-	                     &pgduckdb::duckdb_max_workers_per_postgres_scan, 0, MAX_PARALLEL_WORKER_LIMIT);
+	                     &duckdb_max_workers_per_postgres_scan, 0, MAX_PARALLEL_WORKER_LIMIT);
 
 	DefineCustomVariable("duckdb.postgres_role",
 	                     "Which postgres role should be allowed to use DuckDB execution, use the secrets and create "

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -11,6 +11,7 @@
 #include "pgduckdb/pgduckdb_utils.hpp"
 #include "pgduckdb/pgduckdb_metadata_cache.hpp"
 #include "pgduckdb/scan/postgres_scan.hpp"
+#include "pgduckdb/pg/memory.hpp"
 #include "pgduckdb/pg/types.hpp"
 
 extern "C" {
@@ -355,8 +356,8 @@ ConvertTimestampTzDatum(const duckdb::Value &value) {
 	if (!ValidTimestampOrTimestampTz(rawValue))
 		throw duckdb::OutOfRangeException(
 		    "The TimestampTz value should be between min and max value (%s <-> %s)",
-		    duckdb::Timestamp::ToString(static_cast<duckdb::timestamp_t>(PGDUCKDB_MIN_TIMESTAMP_VALUE)),
-		    duckdb::Timestamp::ToString(static_cast<duckdb::timestamp_t>(PGDUCKDB_MAX_TIMESTAMP_VALUE)));
+		    duckdb::Timestamp::ToString(static_cast<duckdb::timestamp_tz_t>(PGDUCKDB_MIN_TIMESTAMP_VALUE)),
+		    duckdb::Timestamp::ToString(static_cast<duckdb::timestamp_tz_t>(PGDUCKDB_MAX_TIMESTAMP_VALUE)));
 
 	return TimestampTzGetDatum(rawValue - pgduckdb::PGDUCKDB_DUCK_TIMESTAMP_OFFSET);
 }
@@ -1565,7 +1566,6 @@ AppendString(duckdb::Vector &result, Datum value, idx_t offset, bool is_bpchar) 
 
 static void
 AppendJsonb(duckdb::Vector &result, Datum value, idx_t offset) {
-	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	auto jsonb = DatumGetJsonbP(value);
 	StringInfo str = PostgresFunctionGuard(makeStringInfo);
 	auto json_str = PostgresFunctionGuard(JsonbToCString, str, &jsonb->root, VARSIZE(jsonb));
@@ -1871,7 +1871,6 @@ ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, i
 		break;
 	}
 	case duckdb::LogicalTypeId::LIST: {
-		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 		// Convert Datum to ArrayType
 		auto array = DatumGetArrayTypeP(value);
 
@@ -1984,6 +1983,82 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_loc
 
 	scan_local_state.output_vector_size++;
 	scan_global_state->total_row_count++;
+}
+
+/*
+ * Returns true if the given type can be converted from a Postgres datum to a DuckDB value
+ * without requiring any Postgres-specific functions or memory allocations (such as palloc).
+ */
+static bool
+IsThreadSafeTypeForPostgresToDuckDB(Oid attr_type, duckdb::LogicalTypeId duckdb_type) {
+	if (duckdb_type == duckdb::LogicalTypeId::VARCHAR) {
+		return attr_type != JSONBOID;
+	}
+	if (duckdb_type == duckdb::LogicalTypeId::LIST || duckdb_type == duckdb::LogicalTypeId::BIT) {
+		return false;
+	}
+
+	return true;
+}
+
+/*
+ * Insert batch of tuples into chunk. This function is thread-safe and is meant for multi-threaded scans.
+ *
+ * Global lock & PG memory context are handled for unsafe types, e.g., JSONB/LIST/VARBIT.
+ */
+void
+InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot **slots,
+                      int num_slots) {
+	if (num_slots == 0) {
+		return;
+	}
+
+	auto scan_global_state = scan_local_state.global_state;
+	int natts = slots[0]->tts_tupleDescriptor->natts;
+	D_ASSERT(!scan_global_state->count_tuples_only);
+
+	for (int duckdb_output_index = 0; duckdb_output_index < natts; duckdb_output_index++) {
+		auto &result = output.data[duckdb_output_index];
+		auto attr = slots[0]->tts_tupleDescriptor->attrs[duckdb_output_index];
+		bool is_safe_type = IsThreadSafeTypeForPostgresToDuckDB(attr.atttypid, result.GetType().id());
+
+		std::unique_ptr<std::lock_guard<std::recursive_mutex>> lock_guard;
+		MemoryContext old_ctx = NULL;
+		if (!is_safe_type) {
+			lock_guard = std::make_unique<std::lock_guard<std::recursive_mutex>>(GlobalProcessLock::GetLock());
+			old_ctx = pg::MemoryContextSwitchTo(scan_global_state->duckdb_scan_memory_ctx);
+		}
+
+		for (int row = 0; row < num_slots; row++) {
+			if (slots[row]->tts_isnull[duckdb_output_index]) {
+				auto &array_mask = duckdb::FlatVector::Validity(result);
+				array_mask.SetInvalid(scan_local_state.output_vector_size + row);
+			} else {
+				if (attr.attlen == -1) {
+					bool should_free = false;
+					Datum detoasted_value = DetoastPostgresDatum(
+					    reinterpret_cast<varlena *>(slots[row]->tts_values[duckdb_output_index]), &should_free);
+					ConvertPostgresToDuckValue(attr.atttypid, detoasted_value, result,
+					                           scan_local_state.output_vector_size + row);
+					if (should_free) {
+						duckdb_free(reinterpret_cast<void *>(detoasted_value));
+					}
+				} else {
+					ConvertPostgresToDuckValue(attr.atttypid, slots[row]->tts_values[duckdb_output_index], result,
+					                           scan_local_state.output_vector_size + row);
+				}
+			}
+		}
+
+		if (!is_safe_type) {
+			pg::MemoryContextSwitchTo(old_ctx);
+			pg::MemoryContextReset(scan_global_state->duckdb_scan_memory_ctx);
+			// Lock will be automatically unlocked when lock_guard goes out of scope
+		}
+	}
+
+	scan_local_state.output_vector_size += num_slots;
+	scan_global_state->total_row_count += num_slots;
 }
 
 NumericVar

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1565,6 +1565,7 @@ AppendString(duckdb::Vector &result, Datum value, idx_t offset, bool is_bpchar) 
 
 static void
 AppendJsonb(duckdb::Vector &result, Datum value, idx_t offset) {
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	auto jsonb = DatumGetJsonbP(value);
 	StringInfo str = PostgresFunctionGuard(makeStringInfo);
 	auto json_str = PostgresFunctionGuard(JsonbToCString, str, &jsonb->root, VARSIZE(jsonb));
@@ -1870,6 +1871,7 @@ ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, i
 		break;
 	}
 	case duckdb::LogicalTypeId::LIST: {
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 		// Convert Datum to ArrayType
 		auto array = DatumGetArrayTypeP(value);
 

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -1565,7 +1565,6 @@ AppendString(duckdb::Vector &result, Datum value, idx_t offset, bool is_bpchar) 
 
 static void
 AppendJsonb(duckdb::Vector &result, Datum value, idx_t offset) {
-	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	auto jsonb = DatumGetJsonbP(value);
 	StringInfo str = PostgresFunctionGuard(makeStringInfo);
 	auto json_str = PostgresFunctionGuard(JsonbToCString, str, &jsonb->root, VARSIZE(jsonb));
@@ -1871,7 +1870,6 @@ ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, i
 		break;
 	}
 	case duckdb::LogicalTypeId::LIST: {
-		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 		// Convert Datum to ArrayType
 		auto array = DatumGetArrayTypeP(value);
 

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -587,9 +587,9 @@ PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb:
 			std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 			for (size_t i = 0; i < batch_size; i++) {
 				bool ret = is_parallel_scan
-							? local_state.global_state->table_reader_global_state->GetNextMinimalWorkerTuple(
-									local_state.minimal_tuple_buffer[i])
-							: ScanSingleTuple(output, local_state);
+				               ? local_state.global_state->table_reader_global_state->GetNextMinimalWorkerTuple(
+				                     local_state.minimal_tuple_buffer[i])
+				               : ScanSingleTuple(output, local_state);
 				if (!ret) {
 					local_state.global_state->table_reader_global_state->PostgresTableReaderCleanup();
 					local_state.exhausted_scan = true;

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -447,7 +447,6 @@ PostgresScanGlobalState::PostgresScanGlobalState(Snapshot _snapshot, Relation _r
 
 bool
 PostgresScanGlobalState::RegisterLocalState() {
-	pd_log(DEBUG2, "(DuckDB/PostgresSeqScanGlobalState) Registering local state");
 	if (registered_local_states < 0) {
 		return false;
 	}
@@ -457,7 +456,7 @@ PostgresScanGlobalState::RegisterLocalState() {
 
 void
 PostgresScanGlobalState::UnregisterLocalState() {
-	pd_log(DEBUG2, "(DuckDB/PostgresSeqScanGlobalState) Unregistering local state");
+	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	registered_local_states--;
 	// Cleanup up the table reader global state when all registered local states are gone.
 	// And set the flag to negative to indicate no more local states are allowed to be registered.

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -153,7 +153,6 @@ PostgresTableReader::~PostgresTableReader() {
 	Cleanup();
 }
 
-// The caller should hold GlobalProcessLock to ensure thread-safety
 void
 PostgresTableReader::Cleanup() {
 	D_ASSERT(!cleaned_up);

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -146,6 +146,9 @@ PostgresTableReader::InitTupleSlot() {
 }
 
 PostgresTableReader::~PostgresTableReader() {
+	if (cleaned_up) {
+		return;
+	}
 	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	Cleanup();
 }
@@ -153,10 +156,7 @@ PostgresTableReader::~PostgresTableReader() {
 // The caller should hold GlobalProcessLock to ensure thread-safety
 void
 PostgresTableReader::Cleanup() {
-	if (cleaned_up) {
-		return;
-	}
-
+	D_ASSERT(!cleaned_up);
 	cleaned_up = true;
 	PostgresScopedStackReset scoped_stack_reset;
 	PostgresMemberGuard(PostgresTableReader::CleanupUnsafe);

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -291,12 +291,16 @@ PostgresTableReader::GetNextTupleUnsafe() {
 }
 
 /*
- * Get the next minimal tuple from the table scan into the provided buffer.
- * Returns true if a tuple was read, false if the scan is finished.
- * GlobalProcessLock should be held before calling this.
+ * Reads the next minimal tuple from a Postgres parallel worker and copies it into the provided buffer.
+ * This function should only be called when the table scan is running with parallel workers.
+ *
+ * @param minimal_tuple_buffer Buffer to store the copied minimal tuple.
+ * @return true if a tuple was read and copied; false if the scan is complete and no more tuples are available.
+ *
+ * Note: The caller must hold the GlobalProcessLock before invoking this function.
  */
 bool
-PostgresTableReader::GetNextMinimalTuple(std::vector<uint8_t> &minimal_tuple_buffer) {
+PostgresTableReader::GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer) {
 	MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
 	if (HeapTupleIsValid(worker_minmal_tuple)) {
 		// deep copy worker_minmal_tuple to destination buffer

--- a/test/regression/expected/parallel_postgres_scan.out
+++ b/test/regression/expected/parallel_postgres_scan.out
@@ -20,4 +20,16 @@ SELECT * FROM tbl ORDER BY id DESC LIMIT 3;
  499998 | {"a": 499998} | {499998}
 (3 rows)
 
-DROP TABLE tbl;
+CREATE TABLE tbl1 (id int, c jsonb, d text[]);
+INSERT INTO tbl1 SELECT i, jsonb_build_object('a', i), array_agg(i) FROM generate_series(1, 100000) i GROUP BY i;
+SELECT tbl.id, tbl.c, tbl.d, tbl1.c, tbl1.d FROM tbl JOIN tbl1 ON tbl.id = tbl1.id ORDER BY 1,2,3,4 LIMIT 5;
+ id |    c     |  d  |    c     |  d  
+----+----------+-----+----------+-----
+  1 | {"a": 1} | {1} | {"a": 1} | {1}
+  2 | {"a": 2} | {2} | {"a": 2} | {2}
+  3 | {"a": 3} | {3} | {"a": 3} | {3}
+  4 | {"a": 4} | {4} | {"a": 4} | {4}
+  5 | {"a": 5} | {5} | {"a": 5} | {5}
+(5 rows)
+
+DROP TABLE tbl, tbl1;

--- a/test/regression/expected/parallel_postgres_scan.out
+++ b/test/regression/expected/parallel_postgres_scan.out
@@ -1,0 +1,23 @@
+CREATE TABLE tbl (id int, c float8, d text);
+INSERT INTO tbl SELECT i, i * 2.0, 'helloworld' FROM generate_series(1, 1000000) i;
+SELECT * FROM tbl ORDER BY 1,2,3 LIMIT 3;
+ id | c |     d      
+----+---+------------
+  1 | 2 | helloworld
+  2 | 4 | helloworld
+  3 | 6 | helloworld
+(3 rows)
+
+DROP TABLE tbl;
+-- JSON/LIST type
+CREATE TABLE tbl (id int, c jsonb, d text[]);
+INSERT INTO tbl SELECT i, jsonb_build_object('a', i), array_agg(i) FROM generate_series(1, 500000) i GROUP BY i;
+SELECT * FROM tbl ORDER BY id DESC LIMIT 3;
+   id   |       c       |    d     
+--------+---------------+----------
+ 500000 | {"a": 500000} | {500000}
+ 499999 | {"a": 499999} | {499999}
+ 499998 | {"a": 499998} | {499998}
+(3 rows)
+
+DROP TABLE tbl;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -53,3 +53,4 @@ test: type_support
 test: union_functions
 test: unresolved_type
 test: views
+test: parallel_postgres_scan

--- a/test/regression/sql/parallel_postgres_scan.sql
+++ b/test/regression/sql/parallel_postgres_scan.sql
@@ -1,0 +1,10 @@
+CREATE TABLE tbl (id int, c float8, d text);
+INSERT INTO tbl SELECT i, i * 2.0, 'helloworld' FROM generate_series(1, 1000000) i;
+SELECT * FROM tbl ORDER BY 1,2,3 LIMIT 3;
+DROP TABLE tbl;
+
+-- JSON/LIST type
+CREATE TABLE tbl (id int, c jsonb, d text[]);
+INSERT INTO tbl SELECT i, jsonb_build_object('a', i), array_agg(i) FROM generate_series(1, 500000) i GROUP BY i;
+SELECT * FROM tbl ORDER BY id DESC LIMIT 3;
+DROP TABLE tbl;

--- a/test/regression/sql/parallel_postgres_scan.sql
+++ b/test/regression/sql/parallel_postgres_scan.sql
@@ -7,4 +7,10 @@ DROP TABLE tbl;
 CREATE TABLE tbl (id int, c jsonb, d text[]);
 INSERT INTO tbl SELECT i, jsonb_build_object('a', i), array_agg(i) FROM generate_series(1, 500000) i GROUP BY i;
 SELECT * FROM tbl ORDER BY id DESC LIMIT 3;
-DROP TABLE tbl;
+
+CREATE TABLE tbl1 (id int, c jsonb, d text[]);
+INSERT INTO tbl1 SELECT i, jsonb_build_object('a', i), array_agg(i) FROM generate_series(1, 100000) i GROUP BY i;
+SELECT tbl.id, tbl.c, tbl.d, tbl1.c, tbl1.d FROM tbl JOIN tbl1 ON tbl.id = tbl1.id ORDER BY 1,2,3,4 LIMIT 5;
+
+DROP TABLE tbl, tbl1;
+


### PR DESCRIPTION

Currently, we use a single DuckDB thread for Postgres table scan, even though multiple Postgres workers will be initialized. This leads to a performance bottleneck when scanning large amounts of data.

This PR parallelizes the conversion from Postgres tuple to DuckDB data chunk. Below are benchmark results on a 5GB TPCH lineitem table.

- Benchmark query: `select * from lineitem order by 1 limit 1`
- Other GUC setups: `duckdb.max_workers_per_postgres_scan` = 2

| Threads  (`duckdb.threads_for_postgres_scan`) | Costs (seconds) |
|---|---|
| 1 | 15.8 |
| 2 | 8.7 |
| 4 | 5.8 |