### PR TITLE
Disallow DuckDB execution inside functions

### DIFF
--- a/include/pgduckdb/pgduckdb_hooks.hpp
+++ b/include/pgduckdb/pgduckdb_hooks.hpp
@@ -3,6 +3,7 @@
 #include "pgduckdb/pg/declarations.hpp"
 
 namespace pgduckdb {
+extern int64_t executor_nest_level;
 bool IsAllowedStatement(Query *query, bool throw_error = false);
 bool IsCatalogTable(Relation rel);
 bool NeedsDuckdbExecution(Query *query);

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -3,6 +3,7 @@
 #include "pgduckdb/pgduckdb_duckdb.hpp"
 #include "pgduckdb/pgduckdb_guc.h"
 #include "pgduckdb/pgduckdb_xact.hpp"
+#include "pgduckdb/pgduckdb_hooks.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
 #include "pgduckdb/pgduckdb_background_worker.hpp"
 
@@ -214,10 +215,11 @@ IsDuckdbTempTable(Oid relid) {
 static void
 DuckdbXactCallback_Cpp(XactEvent event) {
 	/*
-	 * We're in a committing phase, always reset the top_level_statement flag,
-	 * even if this was not a DuckDB transaction.
+	 * We're in a committing phase. Some global variables we modify even when
+	 * we're not using DuckDB execution. So we always reset those.
 	 */
 	top_level_statement = true;
+	executor_nest_level = 0;
 
 	/* If DuckDB is not initialized there's no need to do anything */
 	if (!DuckDBManager::IsInitialized()) {

--- a/test/regression/expected/issue_730.out
+++ b/test/regression/expected/issue_730.out
@@ -23,17 +23,15 @@ Did you mean "sniff_csv"?
 
 LINE 1: SELECT f2 FROM f2() f2(f2)
                        ^
- f2 
-----
- 
-(1 row)
-
+ERROR:  DuckDB execution is not supported inside functions
+CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1"
+PL/pgSQL function f2() line 4 at SQL statement
 SELECT * FROM f2();
 WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Table Function with name f2 does not exist!
 Did you mean "sniff_csv"?
 
 LINE 1: SELECT f2 FROM f2() f2(f2)
                        ^
-ERROR:  relation "t_ddb4" already exists
-CONTEXT:  SQL statement "ALTER TABLE t_ddb2 RENAME TO t_ddb4"
-PL/pgSQL function f2() line 11 at SQL statement
+ERROR:  DuckDB execution is not supported inside functions
+CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1"
+PL/pgSQL function f2() line 4 at SQL statement

--- a/test/regression/expected/issue_749.out
+++ b/test/regression/expected/issue_749.out
@@ -1,0 +1,15 @@
+create temp table users (data jsonb);
+insert into users values ('{"a": 123}');
+create or replace function get_users() returns setof users as
+$$ SELECT * FROM users; $$
+language sql stable;
+SET duckdb.force_execution = true;
+-- This command used to crash due to DuckDB returning data in the json
+-- format instoad of in jsonb format.
+SELECT * FROM ROWS FROM(get_users()) WITH ORDINALITY;
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: WITH ORDINALITY not implemented
+    data    | ordinality 
+------------+------------
+ {"a": 123} |          1
+(1 row)
+

--- a/test/regression/expected/issue_749.out
+++ b/test/regression/expected/issue_749.out
@@ -5,7 +5,7 @@ $$ SELECT * FROM users; $$
 language sql stable;
 SET duckdb.force_execution = true;
 -- This command used to crash due to DuckDB returning data in the json
--- format instoad of in jsonb format.
+-- format instead of in jsonb format.
 SELECT * FROM ROWS FROM(get_users()) WITH ORDINALITY;
 WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: WITH ORDINALITY not implemented
     data    | ordinality 

--- a/test/regression/expected/transactions.out
+++ b/test/regression/expected/transactions.out
@@ -117,8 +117,9 @@ $$;
 -- After executing the function the table should not contain the value 8,
 -- because that change was rolled back
 SELECT * FROM f(true);
-ERROR:  fail
-CONTEXT:  PL/pgSQL function f(boolean) line 5 at RAISE
+ERROR:  DuckDB execution is not supported inside functions
+CONTEXT:  SQL statement "INSERT INTO t_ddb VALUES (8)"
+PL/pgSQL function f(boolean) line 3 at SQL statement
 SELECT * FROM t_ddb ORDER BY a;
  a 
 ---
@@ -135,11 +136,9 @@ SELECT * FROM t_ddb ORDER BY a;
 
 -- But if the function succeeds we should see the new value
 SELECT * FROM f(false);
- f 
----
- 
-(1 row)
-
+ERROR:  DuckDB execution is not supported inside functions
+CONTEXT:  SQL statement "INSERT INTO t_ddb VALUES (8)"
+PL/pgSQL function f(boolean) line 3 at SQL statement
 SELECT * FROM t_ddb ORDER BY a;
  a 
 ---
@@ -152,8 +151,7 @@ SELECT * FROM t_ddb ORDER BY a;
  5
  5
  6
- 8
-(10 rows)
+(9 rows)
 
 -- DuckDB DDL in transactions is allowed
 BEGIN;
@@ -193,12 +191,11 @@ BEGIN
 END;
 $$;
 SELECT * FROM f2();
- f2 
-----
- 
-(1 row)
-
+ERROR:  DuckDB execution is not supported inside functions
+CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1"
+PL/pgSQL function f2() line 4 at SQL statement
 DROP TABLE t_ddb4;
+ERROR:  table "t_ddb4" does not exist
 -- ...unless there's also PG only changes happing in the same transaction (no matter the order of statements).
 BEGIN;
     CREATE TABLE t_x(a int);

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -32,6 +32,7 @@ test: function
 test: issue_410
 test: issue_730
 test: issue_748
+test: issue_749
 test: timestamp_with_interval
 test: approx_count_distinct
 test: time_bucket

--- a/test/regression/sql/issue_749.sql
+++ b/test/regression/sql/issue_749.sql
@@ -1,0 +1,11 @@
+create temp table users (data jsonb);
+insert into users values ('{"a": 123}');
+
+create or replace function get_users() returns setof users as
+$$ SELECT * FROM users; $$
+language sql stable;
+
+SET duckdb.force_execution = true;
+-- This command used to crash due to DuckDB returning data in the json
+-- format instoad of in jsonb format.
+SELECT * FROM ROWS FROM(get_users()) WITH ORDINALITY;

--- a/test/regression/sql/issue_749.sql
+++ b/test/regression/sql/issue_749.sql
@@ -7,5 +7,5 @@ language sql stable;
 
 SET duckdb.force_execution = true;
 -- This command used to crash due to DuckDB returning data in the json
--- format instoad of in jsonb format.
+-- format instead of in jsonb format.
 SELECT * FROM ROWS FROM(get_users()) WITH ORDINALITY;


### PR DESCRIPTION
pg_duckdb changes result types of queries at the planning stage. This is needed for pg_duckdb to function correctly. However, Postgres code is sometimes not written with this in mind. One such case is sql functions, as reported in #749. There it causes a crash, because Postgres expects a different type to be returned by the function than what is actually returned.

As far as I can tell there is no easy way of fixing this, apart from changing Postgres to learn how to deal with this. I'll open issue/patch to Postgres for this at some point in the near future.

For now, we simply start disallowing all DuckDB execution inside functions. That is quite a shame because using DuckDB execution in functions works fine in many other cases. Sadly, I cannot think of a way to only disallow the crashing cases. Since a very important part of pg_duckdb 1.0 is stability, it seems better to err on the side of caution and disable this feature for now and stabilize it in a future release.

Fixes #749
