### PR TITLE
Disallow ALTER TABLE ... RENAME in a mixed transaction

### DIFF
--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -378,12 +378,11 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 			if (strncmp("ddb$", stmt->newname, 4) == 0) {
 				elog(ERROR, "Changing a schema to a ddb$ schema is currently not supported");
 			}
-		}
-		if (stmt->renameType == OBJECT_TABLE || stmt->renameType == OBJECT_COLUMN) {
+		} else if (stmt->renameType == OBJECT_TABLE || stmt->renameType == OBJECT_COLUMN) {
 			Oid relation_oid = RangeVarGetRelid(stmt->relation, AccessShareLock, false);
-			Relation relation = RelationIdGetRelation(relation_oid);
+			Relation rel = RelationIdGetRelation(relation_oid);
 
-			if (pgduckdb::IsDuckdbTable(relation)) {
+			if (pgduckdb::IsDuckdbTable(rel)) {
 				if (pgduckdb::top_level_duckdb_ddl_type != pgduckdb::DDLType::NONE) {
 					ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 					                errmsg("Only one DuckDB %s can be renamed in a single statement",
@@ -392,7 +391,7 @@ DuckdbHandleDDL(PlannedStmt *pstmt, const char *query_string, ParamListInfo para
 				pgduckdb::top_level_duckdb_ddl_type = pgduckdb::DDLType::ALTER_TABLE;
 				pgduckdb::ClaimCurrentCommandId();
 			}
-			RelationClose(relation);
+			RelationClose(rel);
 		}
 
 		return;

--- a/src/pgduckdb_xact.cpp
+++ b/src/pgduckdb_xact.cpp
@@ -219,6 +219,7 @@ DuckdbXactCallback_Cpp(XactEvent event) {
 	 * we're not using DuckDB execution. So we always reset those.
 	 */
 	top_level_statement = true;
+	top_level_duckdb_ddl_type = DDLType::NONE;
 	executor_nest_level = 0;
 
 	/* If DuckDB is not initialized there's no need to do anything */
@@ -234,8 +235,6 @@ DuckdbXactCallback_Cpp(XactEvent event) {
 	case XACT_EVENT_PARALLEL_PRE_COMMIT:
 		CheckForDisallowedMixedWrites();
 
-		top_level_duckdb_ddl_type = DDLType::NONE;
-		top_level_statement = true;
 		next_expected_command_id = FirstCommandId;
 		pg::force_allow_writes = false;
 		if (modified_temporary_duckdb_tables) {
@@ -251,8 +250,6 @@ DuckdbXactCallback_Cpp(XactEvent event) {
 
 	case XACT_EVENT_ABORT:
 	case XACT_EVENT_PARALLEL_ABORT:
-		top_level_duckdb_ddl_type = DDLType::NONE;
-		top_level_statement = true;
 		next_expected_command_id = FirstCommandId;
 		pg::force_allow_writes = false;
 		if (modified_temporary_duckdb_tables) {

--- a/test/regression/expected/transactions.out
+++ b/test/regression/expected/transactions.out
@@ -272,6 +272,26 @@ BEGIN;
     CREATE TABLE t_x(a int);
 END;
 ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+BEGIN;
+    CREATE TABLE t_x(a int);
+    ALTER TABLE t_ddb RENAME COLUMN a TO z;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+BEGIN;
+    ALTER TABLE t_ddb RENAME COLUMN a TO z;
+    CREATE TABLE t_x(a int);
+END;
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+BEGIN;
+    CREATE TABLE t_x(a int);
+    ALTER TABLE t_ddb RENAME TO t_ddb_new;
+ERROR:  (PGDuckDB/DuckdbUtilityHook_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
+END;
+BEGIN;
+    ALTER TABLE t_ddb RENAME TO t_ddb_new;
+    CREATE TABLE t_x(a int);
+END;
+ERROR:  (PGDuckDB/DuckdbXactCallback_Cpp) Not implemented Error: Writing to DuckDB and Postgres tables in the same transaction block is not supported
 -- Dropping both duckdb tables and postgres tables in the same command is
 -- disallowed in a transaction.
 BEGIN;

--- a/test/regression/sql/transactions.sql
+++ b/test/regression/sql/transactions.sql
@@ -222,6 +222,26 @@ BEGIN;
     CREATE TABLE t_x(a int);
 END;
 
+BEGIN;
+    CREATE TABLE t_x(a int);
+    ALTER TABLE t_ddb RENAME COLUMN a TO z;
+END;
+
+BEGIN;
+    ALTER TABLE t_ddb RENAME COLUMN a TO z;
+    CREATE TABLE t_x(a int);
+END;
+
+BEGIN;
+    CREATE TABLE t_x(a int);
+    ALTER TABLE t_ddb RENAME TO t_ddb_new;
+END;
+
+BEGIN;
+    ALTER TABLE t_ddb RENAME TO t_ddb_new;
+    CREATE TABLE t_x(a int);
+END;
+
 -- Dropping both duckdb tables and postgres tables in the same command is
 -- disallowed in a transaction.
 BEGIN;


### PR DESCRIPTION
To protect users against themselves we disallow DDL on DuckDB tables and
changes to Postgres tables in the same transaction. We were accidentally
not doing this for `ALTER TABLE ... RENAME` statements though. This
fixes that and refactors code to catch issues like that better in the
future.
