### PR TITLE
Drop MD tables when MD support is disabled

### DIFF
--- a/include/pgduckdb/pg/declarations.hpp
+++ b/include/pgduckdb/pg/declarations.hpp
@@ -81,6 +81,8 @@ typedef MinimalTupleData *MinimalTuple;
 
 struct TupleQueueReader;
 
+struct ObjectAddress;
+
 struct PlanState;
 
 struct Plan;

--- a/include/pgduckdb/pg/relations.hpp
+++ b/include/pgduckdb/pg/relations.hpp
@@ -35,4 +35,6 @@ const char *QuoteIdentifier(const char *ident);
 
 const char *GetRelationName(Relation rel);
 
+Oid GetOid(Form_pg_class rel);
+
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -10,8 +10,6 @@ void TriggerActivity(void);
 void UnclaimBgwSessionHint(int code = 0, Datum arg = 0);
 const char *PossiblyReuseBgwSessionHint(void);
 
-void RecordDependencyOnMDServer(ObjectAddress *);
-
 extern bool is_background_worker;
 extern bool doing_motherduck_sync;
 extern char *current_duckdb_database_name;

--- a/include/pgduckdb/pgduckdb_background_worker.hpp
+++ b/include/pgduckdb/pgduckdb_background_worker.hpp
@@ -10,6 +10,8 @@ void TriggerActivity(void);
 void UnclaimBgwSessionHint(int code = 0, Datum arg = 0);
 const char *PossiblyReuseBgwSessionHint(void);
 
+void RecordDependencyOnMDServer(ObjectAddress *);
+
 extern bool is_background_worker;
 extern bool doing_motherduck_sync;
 extern char *current_duckdb_database_name;

--- a/include/pgduckdb/pgduckdb_fdw.hpp
+++ b/include/pgduckdb/pgduckdb_fdw.hpp
@@ -57,5 +57,7 @@ const char *FindMotherDuckToken();
 
 const char *FindMotherDuckBackgroundCatalogRefreshInactivityTimeout();
 
+void RecordDependencyOnMDServer(ObjectAddress *);
+
 } // namespace pgduckdb
 }

--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -172,4 +172,9 @@ GetRelationName(Relation rel) {
 	return RelationGetRelationName(rel);
 }
 
+Oid
+GetOid(Form_pg_class rel) {
+	return rel->oid;
+}
+
 } // namespace pgduckdb

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -42,6 +42,7 @@ extern "C" {
 #include "catalog/namespace.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_foreign_server.h"
 #include "utils/acl.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
@@ -925,7 +926,7 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 	if (!is_default_db) {
 		/*
 		 * For ddb$ schemas we need to record a dependency between the schema
-		 * and the extension, so that DROP EXTENSION also drops these schemas.
+		 * and the FDW, so that DROP SERVER motherduck also drops these schemas.
 		 */
 		schema_oid = get_namespace_oid(postgres_schema_name, true);
 		if (schema_oid == InvalidOid) {
@@ -939,12 +940,12 @@ CreateSchemaIfNotExists(const char *postgres_schema_name, bool is_default_db) {
 		    .objectId = schema_oid,
 		    .objectSubId = 0,
 		};
-		ObjectAddress extension_address = {
-		    .classId = ExtensionRelationId,
-		    .objectId = pgduckdb::ExtensionOid(),
+		ObjectAddress server_address = {
+		    .classId = ForeignServerRelationId,
+		    .objectId = GetMotherduckForeignServerOid(), // pgduckdb::ExtensionOid(),
 		    .objectSubId = 0,
 		};
-		recordDependencyOn(&schema_address, &extension_address, DEPENDENCY_NORMAL);
+		recordDependencyOn(&schema_address, &server_address, DEPENDENCY_NORMAL);
 	}
 
 	/* Success, so we commit the subtransaction */

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "pgduckdb/pgduckdb_fdw.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
 #include "pgduckdb/pg/relations.hpp"
@@ -231,16 +232,6 @@ BgwMainLoop() {
 	}
 
 	elog(LOG, "pg_duckdb background worker for database '%s' (%u) has now terminated.", db_name, MyDatabaseId);
-}
-
-void
-RecordDependencyOnMDServer(ObjectAddress *object_address) {
-	ObjectAddress server_address = {
-	    .classId = ForeignServerRelationId,
-	    .objectId = GetMotherduckForeignServerOid(),
-	    .objectSubId = 0,
-	};
-	recordDependencyOn(object_address, &server_address, DEPENDENCY_NORMAL);
 }
 
 } // namespace pgduckdb

--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -732,6 +732,12 @@ DECLARE_PG_FUNCTION(duckdb_create_table_trigger) {
 			elog(ERROR, "SPI_exec failed: error code %s", SPI_result_code_string(ret));
 		}
 
+		ObjectAddress table_address = {
+		    .classId = RelationRelationId,
+		    .objectId = relid,
+		    .objectSubId = 0,
+		};
+		pgduckdb::RecordDependencyOnMDServer(&table_address);
 		ATExecChangeOwner(relid, pgduckdb::MotherDuckPostgresUser(), false, AccessExclusiveLock);
 	}
 

--- a/src/pgduckdb_fdw.cpp
+++ b/src/pgduckdb_fdw.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_user_mapping.h"
 #include "commands/defrem.h"
+#include "catalog/dependency.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "fmgr.h"
@@ -258,6 +259,16 @@ ValidateMotherduckServerFdw(List *options_list, Oid context) {
 }
 
 } // namespace pg
+
+void
+RecordDependencyOnMDServer(ObjectAddress *object_address) {
+	ObjectAddress server_address = {
+	    .classId = ForeignServerRelationId,
+	    .objectId = GetMotherduckForeignServerOid(),
+	    .objectSubId = 0,
+	};
+	recordDependencyOn(object_address, &server_address, DEPENDENCY_NORMAL);
+}
 
 const char *CurrentServerType = nullptr;
 Oid CurrentServerOid = InvalidOid;

--- a/test/pycheck/conftest.py
+++ b/test/pycheck/conftest.py
@@ -145,7 +145,7 @@ def md_cur(pg, default_db_name, ddb, md_test_user):
 
     pg.search_path = f"ddb${default_db_name}, public"
     with pg.cur() as cur:
-        cur.wait_until_schema_exists(f"ddb${default_db_name}")
+        cur.wait_until_schema_exists(f"ddb${default_db_name}", timeout=60)
         yield cur
 
 


### PR DESCRIPTION
Currently PG catalog entries mirroring MD tables are dropped only when the extension is.

This PR changes this behavior to have them depend on the `motherduck` SERVER so that when it is removed, the entries are removed as well.