### PR TITLE
Cancel outdated runs in PRs

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -5,6 +5,11 @@ on:
     tags: ["v*"]
   pull_request:
 
+# Cancel in-progress jobs if a new commit is pushed to the same branch (except for main)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
 jobs:
   format:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Today each commits to a branch we will lead to a new workflow execution.
This is quite inefficient since we don't need the outcome for old commits.

This PR cancel concurrent runs on the same `{ branch, workflow }` except on `main` branch.