### PR TITLE
Disallow DuckDB tables as partitions

### DIFF
--- a/test/pycheck/temporary_table_test.py
+++ b/test/pycheck/temporary_table_test.py
@@ -27,3 +27,18 @@ def test_temporary_table_alter_table(cur: Cursor):
         # duckdb after the table is created
         with pytest.raises(psycopg.errors.FeatureNotSupported):
             cur.sql("ALTER TABLE t SET ACCESS METHOD duckdb")
+
+
+def test_temporary_table_partition(cur: Cursor):
+    if PG_MAJOR_VERSION >= 17:
+        with pytest.raises(
+            psycopg.errors.FeatureNotSupported,
+            match="Using duckdb as a table access method on a partitioned table is not supported",
+        ):
+            cur.sql("CREATE TEMP TABLE t(a int) PARTITION BY RANGE (a) USING duckdb")
+    else:
+        with pytest.raises(
+            psycopg.errors.FeatureNotSupported,
+            match="specifying a table access method is not supported on a partitioned table",
+        ):
+            cur.sql("CREATE TEMP TABLE t(a int) PARTITION BY RANGE (a) USING duckdb")

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -525,4 +525,14 @@ SELECT * FROM ta;
  3 | 3 |     | 
 (6 rows)
 
-DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td;
+CREATE TEMP TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) PARTITION BY RANGE (logdate);
+-- This command should fail because we don't support duckdb partitions yet
+CREATE TEMP TABLE measurement_y2006m02 PARTITION OF measurement
+    FOR VALUES FROM ('2006-02-01') TO ('2006-03-01') USING duckdb;
+ERROR:  DuckDB tables cannot be used as a partition
+DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td, measurement;

--- a/test/regression/sql/temporary_tables.sql
+++ b/test/regression/sql/temporary_tables.sql
@@ -279,4 +279,15 @@ select * from duckdb.query( $$ describe pg_temp.ta $$ );
 
 SELECT * FROM ta;
 
-DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td;
+CREATE TEMP TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) PARTITION BY RANGE (logdate);
+
+-- This command should fail because we don't support duckdb partitions yet
+CREATE TEMP TABLE measurement_y2006m02 PARTITION OF measurement
+    FOR VALUES FROM ('2006-02-01') TO ('2006-03-01') USING duckdb;
+
+DROP TABLE webpages, t, t_heap, t_heap2, t_heap3, ta, tb, tc, td, measurement;


### PR DESCRIPTION
This would definitely be a useful feature, but currently it's not supported.

Fixes #767
