### PR TITLE
CI: Auto-expand the regression.diffs output

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -147,7 +147,9 @@ jobs:
 
       - name: Print regression.diffs if regression tests failed
         if: failure() && steps.installcheck.outcome == 'failure'
-        run: cat duckdb/test/regression/regression.diffs
+        # Always "fail" this task by adding "&& false", so that rits output
+        # gets expanded in the github UI.
+        run: cat duckdb/test/regression/regression.diffs && false
 
       - name: Print postmaster.log if regression tests failed
         if: failure() && steps.installcheck.outcome == 'failure'


### PR DESCRIPTION
You basically always want to look at the diffs when a test failed. This
makes sure it gets auto-expanded.
