### PR TITLE
Disallow ALTER TABLE ... SET SCHEMA for duckdb tables

### DIFF
--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -175,6 +175,12 @@ def test_md_alter_table(md_cur: Cursor):
     with pytest.raises(psycopg.errors.FeatureNotSupported):
         md_cur.sql("ALTER TABLE t FORCE ROW LEVEL SECURITY")
 
+    with pytest.raises(
+        psycopg.errors.FeatureNotSupported,
+        match="Changing the schema of a duckdb table is currently not supported",
+    ):
+        md_cur.sql("ALTER TABLE t SET SCHEMA public")
+
     md_cur.sql("ALTER TABLE t ADD COLUMN b int DEFAULT 100")
     md_cur.wait_until(
         lambda: md_cur.sql("SELECT * FROM t") == (1, 100), "Failed to add column"


### PR DESCRIPTION
This would be good to have but for now it doesn't work. This makes the
error clear. Before this change it would throw the error:

```
Cannot ALTER a DuckDB table this way, please use ALTER TABLE
```

Fixes #766
