### PR TITLE
Simplify how CREATE SECRET command is built

### DIFF
--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -287,3 +287,16 @@ $$);
  pgduckdb_secret_simple_s3_secret_3  | s3    | my named key | us-east-1    | redacted      | redacted | 
 (10 rows)
 
+set client_min_messages=WARNING; -- suppress NOTICE that include username
+DROP SERVER
+    simple_s3_secret,
+    simple_s3_secret_1,
+    simple_s3_secret_2,
+    simple_s3_secret_3,
+    simple_r2_secret,
+    simple_r2_secret_1,
+    simple_gcs_secret,
+    simple_gcs_secret_1,
+    simple_gcs_secret_2,
+    azure_secret
+CASCADE;

--- a/test/regression/sql/duckdb_secrets.sql
+++ b/test/regression/sql/duckdb_secrets.sql
@@ -187,3 +187,17 @@ SELECT * FROM duckdb.query($$
         FROM duckdb_secrets()
     );
 $$);
+
+set client_min_messages=WARNING; -- suppress NOTICE that include username
+DROP SERVER
+    simple_s3_secret,
+    simple_s3_secret_1,
+    simple_s3_secret_2,
+    simple_s3_secret_3,
+    simple_r2_secret,
+    simple_r2_secret_1,
+    simple_gcs_secret,
+    simple_gcs_secret_1,
+    simple_gcs_secret_2,
+    azure_secret
+CASCADE;


### PR DESCRIPTION
By adding TYPE as the first argument to CREATE SECRET, we don't need to
track if we still need to add commas. The final command also reads much
more natural, because the TYPE is at the start.

This also drop all SERVERs at the end of the duckdb_secrets.sql test,
keeping them around was significantly slowing down the tests that were
later in the schedule. The `duckdb_secrets.sql` test also takes very
long itself to run on my machine (170 seconds!). That's something we
should probably fix too, but this is at least a good start.
