### PR TITLE
Make sure tests can run anywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,9 @@ check-regression-duckdb:
 clean-regression:
 	$(MAKE) -C test/regression clean-regression
 
+# Specify AWS_REGION to make sure test output the same thing regardless of where they are run
 installcheck: all install
-	$(MAKE) check-regression-duckdb
+	AWS_REGION=us-east-1 $(MAKE) check-regression-duckdb
 
 pycheck: all install
 	LD_LIBRARY_PATH=$(PG_LIBDIR):${LD_LIBRARY_PATH} pytest -n $(PYTEST_CONCURRENCY)

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -101,11 +101,7 @@ SELECT * FROM duckdb.install_extension('iceberg');
 (1 row)
 
 -- We should handle SQL injections carefully though to only allow INSTALL
-SELECT * FROM duckdb.install_extension($$ '; select * from hacky '' $$);
-ERROR:  (PGDuckDB/install_extension_cpp) HTTP Error: Failed to download extension " '; select * from hacky '' " at URL "http://extensions.duckdb.org/v1.2.2/linux_amd64/ '; select * from hacky '' .duckdb_extension.gz" (HTTP 403)
-
-Candidate extensions: "delta", "excel", "sqlite_scanner", "inet", "sqlite"
-For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=v1.2.2&platform=linux_amd64&extension= '; select * from hacky '' 
+-- `duckdb.install_extension` is tested in Python
 INSERT INTO duckdb.extensions (name) VALUES ($$ '; select * from hacky $$);
 SELECT * FROM duckdb.query($$ SELECT 1 $$);
 ERROR:  (PGDuckDB/CreatePlan) Parser Error: unterminated quoted string at or near "'; select * from hacky "

--- a/test/regression/sql/non_superuser.sql
+++ b/test/regression/sql/non_superuser.sql
@@ -81,7 +81,7 @@ SET ROLE user1;
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.install_extension('iceberg');
 -- We should handle SQL injections carefully though to only allow INSTALL
-SELECT * FROM duckdb.install_extension($$ '; select * from hacky '' $$);
+-- `duckdb.install_extension` is tested in Python
 INSERT INTO duckdb.extensions (name) VALUES ($$ '; select * from hacky $$);
 SELECT * FROM duckdb.query($$ SELECT 1 $$);
 TRUNCATE duckdb.extensions;


### PR DESCRIPTION
Today if tests are run on a different platform (eg. MacOS vs Linux or Arm vs Intel CPU), or in a different AWS Region, they would fail because messages checks are a bit to strict.

This PR make sure we can run them anywhere.