### PR TITLE
Fix `loop-until`

### DIFF
--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -8,7 +8,7 @@ library for that purpose.
 
 import datetime
 
-from .utils import Cursor, Postgres, Duckdb, PG_MAJOR_VERSION
+from .utils import wait_until, Cursor, Postgres, Duckdb, PG_MAJOR_VERSION
 from .motherduck_token_helper import (
     can_run_md_multi_user_tests,
     can_run_md_tests,
@@ -182,7 +182,7 @@ def test_md_alter_table(md_cur: Cursor):
         md_cur.sql("ALTER TABLE t SET SCHEMA public")
 
     md_cur.sql("ALTER TABLE t ADD COLUMN b int DEFAULT 100")
-    md_cur.wait_until(
+    wait_until(
         lambda: md_cur.sql("SELECT * FROM t") == (1, 100), "Failed to add column"
     )
     assert md_cur.sql("SELECT * FROM t") == (1, 100)

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -137,16 +137,39 @@ def create_duckdb(db_name, token):
     return con
 
 
-def loop_until(timeout=5, error_message="Did not complete in time"):
+def wait_until(func, on_fail=None, timeout=5, interval=0.1):
     """
-    Loop until the timeout is reached. If the timeout is reached, raise an
-    exception with the given error message.
+    Repeatedly calls `func()` until it returns a truthy value or timeout is reached.
+
+    Args:
+        func: A callable that returns True when the condition is met.
+        timeout: Maximum time in seconds to wait.
+        interval: Time to wait between retries (in seconds).
+        on_fail: Optional callable to run or message to raise if the condition isn't met in time.
+
+    Returns:
+        The result of `func()` if successful.
+
+    Raises:
+        TimeoutError: If the condition isn't met before timeout.
     """
-    end = time.time() + timeout
-    while time.time() < end:
-        yield
-        time.sleep(0.1)
-    raise TimeoutError(error_message)
+    start = time.time()
+    while True:
+        result = func()
+        if result:
+            return result
+        if time.time() - start > timeout:
+            if callable(on_fail):
+                on_fail()
+
+            message = (
+                on_fail
+                if isinstance(on_fail, str)
+                else f"Condition not met within {timeout} seconds"
+            )
+            message = f"Timeout after {timeout}s: {message}"
+            raise TimeoutError(message)
+        time.sleep(interval)
 
 
 PG_MAJOR_VERSION = get_pg_major_version()
@@ -323,31 +346,21 @@ class Cursor(OutputSilencer):
         """Run a DuckDB query using duckdb.query()"""
         return self.sql(f"SELECT * FROM duckdb.query($ddb$ {query} $ddb$)", **kwargs)
 
-    def wait_until(self, func, error_message, timeout=5):
-        while loop_until(
-            error_message=error_message,
-            timeout=timeout,
-        ):
-            if func():
-                return
-
     def wait_until_table_exists(self, table_name, timeout=5, **kwargs):
-        while loop_until(
-            error_message=f"Table {table_name} did not appear in time",
-            timeout=timeout,
-        ):
+        def has_table():
             with self.suppress(psycopg.errors.UndefinedTable):
                 self.sql("SELECT %s::regclass", (table_name,), **kwargs)
-                return
+                return True
+
+        wait_until(has_table, f"Table {table_name} did not appear in time", **kwargs)
 
     def wait_until_schema_exists(self, schema_name, timeout=5, **kwargs):
-        while loop_until(
-            timeout=timeout,
-            error_message=f"Schema {schema_name} did not appear in time",
-        ):
+        def has_schema():
             with self.suppress(psycopg.errors.InvalidSchemaName):
                 self.sql("SELECT %s::regnamespace", (schema_name,), **kwargs)
-                return
+                return True
+
+        wait_until(has_schema, f"Schema {schema_name} did not appear in time", timeout)
 
 
 class AsyncCursor:


### PR DESCRIPTION
In a recent refactoring we changed the `loop_until` implementation using a generator with `while`. This, in effect defeat the purpose of the function since it will loop indefinitely, the generator being always truthy.

This PR replace `loop_until` with a `wait_until` function everywhere which checks if the given function becomes truthy eventually.