### PR TITLE
Fix CTAS with NUMERIC type

### DIFF
--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -80,6 +80,7 @@ CreatePlan(Query *query, bool throw_error) {
 		}
 
 		typtup = (Form_pg_type)GETSTRUCT(tp);
+		typtup->typtypmod = pgduckdb::GetPostgresDuckDBTypemod(prepared_result_types[i]);
 
 		/* We fill in the varno later, once we know the index of the custom RTE
 		 * that we create. We'll know this at the end of DuckdbPlanNode. This

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -166,6 +166,41 @@ ERROR:  Storage options are not supported in DuckDB
 -- Should fail because user should specify the precision of the NUMERIC.
 CREATE TEMP TABLE large_numeric_tbl (a NUMERIC) USING duckdb;
 ERROR:  (PGDuckDB/duckdb_create_table_trigger_cpp) Not implemented Error: Unsupported Postgres type: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.duckdb.convert_unsupported_numeric_to_double = true'
+-- But it's fine if the user specifies the precision
+CREATE TEMP TABLE large_numeric_tbl_specified (a NUMERIC(38,20)) USING duckdb;
+-- CTAS is fine though, it will use duckdb its default
+-- TODO: Maybe make this fail too for consistency?
+CREATE TEMP TABLE duckdb_numeric_from_pg_bare USING duckdb AS select 1::numeric x;
+SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 'duckdb_numeric_from_pg_bare'::regclass AND attname = 'x';
+  format_type  
+---------------
+ numeric(18,3)
+(1 row)
+
+-- Except if they are fully specified
+CREATE TEMP TABLE duckdb_numeric_from_pg USING duckdb AS select 1::numeric(10,8) x;
+SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 'duckdb_numeric_from_pg'::regclass AND attname = 'x';
+  format_type  
+---------------
+ numeric(10,8)
+(1 row)
+
+-- Same when the query is forced by duckdb
+CREATE TEMP TABLE duckdb_numeric_bare USING duckdb AS select * from duckdb.query($$ select 1::numeric x $$);
+SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 'duckdb_numeric_bare'::regclass AND attname = 'x';
+  format_type  
+---------------
+ numeric(18,3)
+(1 row)
+
+-- But CTAS with numerics coming from a duckdb query are fine (i.e. we pass on the precision that duckdb uses)
+CREATE TEMP TABLE duckdb_numeric USING duckdb AS select * from duckdb.query($$ select 1::numeric(10, 5) x $$);
+SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 'duckdb_numeric'::regclass AND attname = 'x';
+  format_type  
+---------------
+ numeric(10,5)
+(1 row)
+
 CREATE TEMP TABLE cities_duckdb (
   name       text,
   population real,
@@ -268,7 +303,12 @@ SELECT atttypid::regtype FROM pg_attribute WHERE attrelid = 't_json'::regclass A
 SELECT duckdb.raw_query($$ SELECT database_name, schema_name, sql FROM duckdb_tables() $$);
 NOTICE:  result: database_name	schema_name	sql	
 VARCHAR	VARCHAR	VARCHAR	
-[ Rows: 3]
+[ Rows: 8]
+pg_temp	main	CREATE TABLE duckdb_numeric(x DECIMAL(10,5));
+pg_temp	main	CREATE TABLE duckdb_numeric_bare(x DECIMAL(18,3));
+pg_temp	main	CREATE TABLE duckdb_numeric_from_pg(x DECIMAL(10,8));
+pg_temp	main	CREATE TABLE duckdb_numeric_from_pg_bare(x DECIMAL(18,3));
+pg_temp	main	CREATE TABLE large_numeric_tbl_specified(a DECIMAL(38,20));
 pg_temp	main	CREATE TABLE t(b INTEGER);
 pg_temp	main	CREATE TABLE t_json("data" JSON);
 pg_temp	main	CREATE TABLE webpages(column00 BIGINT, column01 VARCHAR, column02 DATE);


### PR DESCRIPTION
In #795 errors were added when using NUMERIC without a precision. It
turns out that these were impossible to avoid for a CTAS command,
because we didn't use the precision provided by DuckDB when creating the
Postgres table. This fixes that and adds some tests to encode the
current behaviour.

Related to #795
