### PR TITLE
Use DROP IF EXISTS for when dropping DuckDB tables

### DIFF
--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -994,8 +994,9 @@ DECLARE_PG_FUNCTION(duckdb_drop_trigger) {
 
 			char *postgres_schema_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 1);
 			char *table_name = SPI_getvalue(tuple, SPI_tuptable->tupdesc, 2);
-			char *drop_query = psprintf("DROP TABLE %s.%s", pgduckdb_db_and_schema_string(postgres_schema_name, true),
-			                            quote_identifier(table_name));
+			char *drop_query =
+			    psprintf("DROP TABLE IF EXISTS %s.%s", pgduckdb_db_and_schema_string(postgres_schema_name, true),
+			             quote_identifier(table_name));
 			pgduckdb::DuckDBQueryOrThrow(*connection, drop_query);
 
 			deleted_duckdb_tables++;


### PR DESCRIPTION
It's possible for DuckDB and Postgres to get out of sync. Obviously we
don't generally want this, but in some cases it's impossible to avoid.
In those cases users should at least be able to clean up out-of-sync
tables themselves. This change allows users to drop the Postgres side of
tables, even if the DuckDB table does not exist.
