### PR TITLE
Redesign extension installation logic

### DIFF
--- a/include/pgduckdb/pg/permissions.hpp
+++ b/include/pgduckdb/pg/permissions.hpp
@@ -1,0 +1,3 @@
+namespace pgduckdb::pg {
+bool AllowRawFileAccess();
+}

--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -65,6 +65,7 @@ private:
 	void LoadSecrets(duckdb::ClientContext &);
 	void DropSecrets(duckdb::ClientContext &);
 	void LoadExtensions(duckdb::ClientContext &);
+	void InstallExtensions(duckdb::ClientContext &);
 	void LoadFunctions(duckdb::ClientContext &);
 	void RefreshConnectionState(duckdb::ClientContext &);
 

--- a/include/pgduckdb/pgduckdb_options.hpp
+++ b/include/pgduckdb/pgduckdb_options.hpp
@@ -6,15 +6,18 @@
 namespace pgduckdb {
 
 /* constants for duckdb.extensions */
-#define Natts_duckdb_extension       2
-#define Anum_duckdb_extension_name   1
-#define Anum_duckdb_extension_enable 2
+#define Natts_duckdb_extension           3
+#define Anum_duckdb_extension_name       1
+#define Anum_duckdb_extension_enable     2
+#define Anum_duckdb_extension_repository 3
 
 typedef struct DuckdbExension {
 	std::string name;
 	bool enabled;
+	std::string repository;
 } DuckdbExtension;
 
 extern std::vector<DuckdbExtension> ReadDuckdbExtensions();
+extern std::string DuckdbInstallExtensionQuery(const std::string &extension_name, const std::string &repository);
 
 } // namespace pgduckdb

--- a/sql/pg_duckdb--0.3.0--1.0.0.sql
+++ b/sql/pg_duckdb--0.3.0--1.0.0.sql
@@ -64,7 +64,9 @@ LANGUAGE C;
 
 DROP FUNCTION duckdb.install_extension(TEXT);
 CREATE FUNCTION duckdb.install_extension(extension_name TEXT, source TEXT DEFAULT 'core') RETURNS void
+    SECURITY DEFINER
     SET search_path = pg_catalog, pg_temp
+    SET duckdb.force_execution = false
     LANGUAGE C AS 'MODULE_PATHNAME', 'install_extension';
 REVOKE ALL ON FUNCTION duckdb.install_extension(TEXT, TEXT) FROM PUBLIC;
 
@@ -725,4 +727,6 @@ RETURNS TEXT
 SET search_path = pg_catalog, pg_temp
 LANGUAGE C AS 'MODULE_PATHNAME', 'pgduckdb_create_azure_secret';
 
-
+ALTER TABLE duckdb.extensions ADD COLUMN repository TEXT DEFAULT 'core';
+-- TODO: Maybe rename/replace "enabled" column of extensions with autoload or
+-- something similar.

--- a/src/pg/permissions.cpp
+++ b/src/pg/permissions.cpp
@@ -1,0 +1,14 @@
+extern "C" {
+#include "postgres.h"
+#include "miscadmin.h" // GetUserId
+#include "catalog/pg_authid.h" // ROLE_PG_WRITE_SERVER_FILES, ROLE_PG_READ_SERVER_FILES
+#include "utils/acl.h" // is_member_of_role
+}
+
+namespace pgduckdb::pg {
+
+bool AllowRawFileAccess() {
+	return is_member_of_role(GetUserId(), ROLE_PG_WRITE_SERVER_FILES) && is_member_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES);
+}
+
+}

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -9,6 +9,7 @@
 
 #include "pgduckdb/catalog/pgduckdb_storage.hpp"
 #include "pgduckdb/pg/guc.hpp"
+#include "pgduckdb/pg/permissions.hpp"
 #include "pgduckdb/pg/string_utils.hpp"
 #include "pgduckdb/pg/transactions.hpp"
 #include "pgduckdb/pgduckdb_background_worker.hpp"
@@ -31,7 +32,7 @@ extern "C" {
 #include "catalog/namespace.h"
 #include "common/file_perm.h"
 #include "lib/stringinfo.h"
-#include "miscadmin.h" // superuser
+#include "miscadmin.h"        // superuser
 #include "nodes/value.h"      // strVal
 #include "utils/fmgrprotos.h" // pg_sequence_last_value
 #include "utils/lsyscache.h"  // get_relname_relid
@@ -189,6 +190,9 @@ DuckDBManager::Initialize() {
 	}
 
 	LoadFunctions(context);
+	if (duckdb_autoinstall_known_extensions) {
+		InstallExtensions(context);
+	}
 	LoadExtensions(context);
 }
 
@@ -246,7 +250,44 @@ DuckDBManager::LoadExtensions(duckdb::ClientContext &context) {
 }
 
 void
+DuckDBManager::InstallExtensions(duckdb::ClientContext &context) {
+	auto duckdb_extensions = ReadDuckdbExtensions();
+
+	for (auto &extension : duckdb_extensions) {
+		DuckDBQueryOrThrow(context, DuckdbInstallExtensionQuery(extension.name, extension.repository));
+	}
+}
+
+static std::string
+DisabledFileSystems() {
+	if (pgduckdb::pg::AllowRawFileAccess()) {
+		return duckdb_disabled_filesystems;
+	}
+
+	if (IsEmptyString(duckdb_disabled_filesystems)) {
+		return "LocalFileSystem";
+	}
+
+	return "LocalFileSystem," + std::string(duckdb_disabled_filesystems);
+}
+
+void
 DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
+	std::string disabled_filesystems = DisabledFileSystems();
+	if (disabled_filesystems != "") {
+		/*
+		 * DuckDB does not allow us to disable this setting on the
+		 * database after the DuckDB connection is created for a non
+		 * superuser, any further connections will inherit this
+		 * restriction. This means that once a non-superuser used a
+		 * DuckDB connection in a Postgres backend, any other
+		 * connection will inherit these same filesystem restrictions.
+		 * This shouldn't be a problem in practice.
+		 */
+		pgduckdb::DuckDBQueryOrThrow(context, "SET disabled_filesystems=" +
+		                                          duckdb::KeywordHelper::WriteQuoted(disabled_filesystems));
+	}
+
 	const auto extensions_table_last_seq = GetSeqLastValue("extensions_table_seq");
 	if (IsExtensionsSeqLessThan(extensions_table_last_seq)) {
 		LoadExtensions(context);
@@ -257,20 +298,6 @@ DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
 		DropSecrets(context);
 		LoadSecrets(context);
 		secrets_valid = true;
-	}
-
-	if (duckdb_disabled_filesystems != NULL && !superuser()) {
-		/*
-		 * DuckDB does not allow us to disable this setting on the
-		 * database after the DuckDB connection is created for a non
-		 * superuser, any further connections will inherit this
-		 * restriction. This means that once a non-superuser used a
-		 * DuckDB connection in aside a Postgres backend, any other
-		 * connection will inherit these same filesystem restrictions.
-		 * This shouldn't be a problem in practice.
-		 */
-		pgduckdb::DuckDBQueryOrThrow(context,
-		                             "SET disabled_filesystems='" + std::string(duckdb_disabled_filesystems) + "'");
 	}
 }
 
@@ -328,8 +355,8 @@ DuckDBManager::GetConnection(bool force_transaction) {
  * Returns the cached connection to the global DuckDB instance, but does not do
  * any checks required to correctly initialize the DuckDB transaction nor
  * refreshes the secrets/extensions/etc. Only use this in rare cases where you
- * know for sure that the connection is already initialized for the correctly
- * for the current query, and you just want a pointer to it.
+ * know for sure that the connection is already initialized correctly for the
+ * current query, and you just want a pointer to it.
  */
 duckdb::Connection *
 DuckDBManager::GetConnectionUnsafe() {

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -119,7 +119,7 @@ char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;
 char *duckdb_maximum_memory = strdup("4GB");
-char *duckdb_disabled_filesystems = strdup("LocalFileSystem");
+char *duckdb_disabled_filesystems = strdup("");
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_community_extensions = false;
 bool duckdb_allow_unsigned_extensions = false;
@@ -206,11 +206,9 @@ InitGUC() {
 	DefineCustomDuckDBVariable("duckdb.motherduck_session_hint", "The session hint to use for MotherDuck connections",
 	                           &duckdb_motherduck_session_hint);
 
-	// This is also a DuckDB variable, but it doesn't need `GucCheckDuckDBNotInitdHook` because we actually handle its
-	// update after DuckDB is initialized (cf. `DuckdbInstallExtension` function)
-	DefineCustomVariable("duckdb.disabled_filesystems",
-	                     "Disable specific file systems preventing access (e.g., LocalFileSystem)",
-	                     &duckdb_disabled_filesystems, PGC_SUSET);
+	DefineCustomDuckDBVariable("duckdb.disabled_filesystems",
+	                           "Disable specific file systems preventing access (e.g., LocalFileSystem)",
+	                           &duckdb_disabled_filesystems, PGC_SUSET);
 }
 
 } // namespace pgduckdb

--- a/test/pycheck/extension_test.py
+++ b/test/pycheck/extension_test.py
@@ -1,0 +1,72 @@
+import shutil
+
+from .utils import wait_until, Cursor, Postgres, Duckdb, PG_MAJOR_VERSION
+
+import pytest
+import psycopg.errors
+import psycopg.sql
+
+
+def test_autoinstall_known_extensions(pg: Postgres, cur: Cursor):
+    cur.sql("SET duckdb.autoinstall_known_extensions = 'off'")
+    cur.sql("SET duckdb.allow_community_extensions = 'on'")
+    # Cleanup any existing extensions before the test
+    extension_dir = pg.pgdata / "pg_duckdb" / "extensions"
+    if extension_dir.exists():
+        shutil.rmtree(extension_dir)
+    cur.sql("TRUNCATE duckdb.extensions")
+    assert (
+        cur.sql(
+            "SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'prql' $$)"
+        )
+        == []
+    )
+
+    cur.sql("SELECT duckdb.install_extension('prql', 'community')")
+    assert cur.sql(
+        "SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'prql' $$)"
+    ) == (True, True)
+
+    # Now we delete it from disk, which should be reflected in the duckdb_extensions() table function
+    if extension_dir.exists():
+        shutil.rmtree(extension_dir)
+    assert cur.sql(
+        "SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'prql' $$)"
+    ) == (False, True)
+
+    # We close the duckdb database for this session.
+    cur.sql("CALL duckdb.recycle_ddb()")
+    # The next query should then try to load the extension, which will fail because it's not there and autoinstall_known_extensions is off.
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match=r'prql.duckdb_extension" not found.',
+    ):
+        cur.sql("SELECT * FROM duckdb.query($$ SELECT 1 $$)")
+
+    # Let's try that again with autoinstall_known_extensions on. That should make it work.
+    cur.sql("CALL duckdb.recycle_ddb()")
+    cur.sql("SET duckdb.autoinstall_known_extensions = 'on'")
+    assert cur.sql(
+        "SELECT * FROM duckdb.query($$ FROM duckdb_extensions() SELECT installed, loaded WHERE extension_name = 'prql' $$)"
+    ) == (True, True)
+
+    # MotherDuck should also not be installed automatically if
+    # autoinstall_known_extensions is off
+    cur.sql("CALL duckdb.recycle_ddb()")
+    cur.sql("SET duckdb.autoinstall_known_extensions = 'off'")
+    # Disabling duckdb.autoinstall_known_extensions should prevent
+    # automatically installing the MotherDuck extension.
+    pg.create_server(
+        "motherduck",
+        psycopg.sql.SQL("TYPE 'motherduck' FOREIGN DATA WRAPPER duckdb"),
+    )
+
+    cur.sql(
+        "CREATE USER MAPPING FOR CURRENT_USER SERVER motherduck OPTIONS (token 'fake-token')"
+    )
+
+    with pytest.raises(
+        psycopg.errors.InternalError,
+        match=r'motherduck.duckdb_extension" not found.',
+    ):
+        cur.sql("SELECT * FROM duckdb.query($$ SELECT 1 $$)")

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -21,4 +21,4 @@ ERROR:  XX000: (PGDuckDB/pgduckdb_raw_query_cpp) Parser Error: syntax error at o
 
 LINE 1: aaaaa
         ^
-LOCATION:  pgduckdb_raw_query_cpp, pgduckdb_options.cpp:192
+LOCATION:  pgduckdb_raw_query_cpp, pgduckdb_options.cpp:180


### PR DESCRIPTION
This PR starts auto-installing missing extensions if both of the following are true:
1. `duckdb.autoinstall_known_extensions` is set to `true`
2. The extension is listed in the `duckdb.extensions` table.
