### PR TITLE
Use Postgres builtin filesystem roles

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -22,9 +22,9 @@ Access: Needs to be in the `postgresql.conf` file and requires a restart
 
 ### `duckdb.disabled_filesystems`
 
-Disable specific file systems preventing access. This setting only applies to non-superusers. Superusers can always access all file systems. Unless you completely trust the user in `duckdb.posgres_role`, it is recommended to disable `LocalFileSystem`. Otherwise they can trivially read and write any file on the machine that the Postgres process can.
+Disable specific file systems preventing access. This setting only to all users including superusers. For non-superusers that are not a member of both the `pg_read_server_files` and `pg_write_server_files` roles, the `LocalFileSystem` is always disabled. If you add `LocalFileSystem` to this setting, superusers won't be able to access the `LocalFileSystem` either through DuckDB.
 
-Default: `"LocalFileSystem"`
+Default: `""`
 
 Access: Superuser-only
 

--- a/include/pgduckdb/pg/permissions.hpp
+++ b/include/pgduckdb/pg/permissions.hpp
@@ -1,0 +1,3 @@
+namespace pgduckdb::pg {
+bool AllowRawFileAccess();
+}

--- a/src/pg/permissions.cpp
+++ b/src/pg/permissions.cpp
@@ -1,0 +1,16 @@
+extern "C" {
+#include "postgres.h"
+#include "miscadmin.h"         // GetUserId
+#include "catalog/pg_authid.h" // ROLE_PG_WRITE_SERVER_FILES, ROLE_PG_READ_SERVER_FILES
+#include "utils/acl.h"         // is_member_of_role
+}
+
+namespace pgduckdb::pg {
+
+bool
+AllowRawFileAccess() {
+	return is_member_of_role(GetUserId(), ROLE_PG_WRITE_SERVER_FILES) &&
+	       is_member_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES);
+}
+
+} // namespace pgduckdb::pg

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -119,7 +119,7 @@ char *duckdb_postgres_role = strdup("");
 
 int duckdb_maximum_threads = -1;
 char *duckdb_maximum_memory = strdup("4GB");
-char *duckdb_disabled_filesystems = strdup("LocalFileSystem");
+char *duckdb_disabled_filesystems = strdup("");
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_community_extensions = false;
 bool duckdb_allow_unsigned_extensions = false;
@@ -206,11 +206,9 @@ InitGUC() {
 	DefineCustomDuckDBVariable("duckdb.motherduck_session_hint", "The session hint to use for MotherDuck connections",
 	                           &duckdb_motherduck_session_hint);
 
-	// This is also a DuckDB variable, but it doesn't need `GucCheckDuckDBNotInitdHook` because we actually handle its
-	// update after DuckDB is initialized (cf. `DuckdbInstallExtension` function)
-	DefineCustomVariable("duckdb.disabled_filesystems",
-	                     "Disable specific file systems preventing access (e.g., LocalFileSystem)",
-	                     &duckdb_disabled_filesystems, PGC_SUSET);
+	DefineCustomDuckDBVariable("duckdb.disabled_filesystems",
+	                           "Disable specific file systems preventing access (e.g., LocalFileSystem)",
+	                           &duckdb_disabled_filesystems, PGC_SUSET);
 }
 
 } // namespace pgduckdb

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -599,6 +599,12 @@ class Postgres(OutputSilencer):
 
     def cleanup_users(self):
         for user in self.users:
+            try:
+                self.sql(
+                    sql.SQL("DROP OWNED BY {} CASCADE").format(sql.Identifier(user))
+                )
+            except psycopg.errors.UndefinedObject:
+                pass
             self.sql(sql.SQL("DROP USER IF EXISTS {}").format(sql.Identifier(user)))
         self.users.clear()
 
@@ -787,6 +793,7 @@ class Postgres(OutputSilencer):
 
     def reset(self):
         os.truncate(self.pgdata / "postgresql.auto.conf", 0)
+        self.sql("TRUNCATE duckdb.extensions")
 
         # If a previous test restarted postgres, it was probably because of some
         # config that could only be changed across restarts. To reset those, we'll

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -1,6 +1,7 @@
 CREATE USER user1 IN ROLE duckdb_group;
 CREATE USER user2 IN ROLE duckdb_group;
 CREATE USER user3;
+CREATE USER user4 IN ROLE duckdb_group, pg_write_server_files, pg_read_server_files;
 CREATE TABLE t (a int);
 GRANT SELECT ON t TO user1;
 GRANT SELECT ON t TO user3;
@@ -29,6 +30,15 @@ SET duckdb.force_execution = true;
 -- read_csv from the local filesystem should be disallowed
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
 ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Permission Error: File system LocalFileSystem has been disabled by configuration
+CALL duckdb.recycle_ddb();
+-- It's allowed for users with pg_read_server_files and pg_write_server_files.
+SET ROLE user4;
+SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
+ count 
+-------
+   150
+(1 row)
+
 -- Should fail because DuckDB execution is not allowed for this user
 SET ROLE user3;
 SELECT * FROM t;

--- a/test/regression/sql/non_superuser.sql
+++ b/test/regression/sql/non_superuser.sql
@@ -1,6 +1,7 @@
 CREATE USER user1 IN ROLE duckdb_group;
 CREATE USER user2 IN ROLE duckdb_group;
 CREATE USER user3;
+CREATE USER user4 IN ROLE duckdb_group, pg_write_server_files, pg_read_server_files;
 CREATE TABLE t (a int);
 GRANT SELECT ON t TO user1;
 GRANT SELECT ON t TO user3;
@@ -23,6 +24,11 @@ SET duckdb.force_execution = true;
 
 -- read_csv from the local filesystem should be disallowed
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
+CALL duckdb.recycle_ddb();
+-- It's allowed for users with pg_read_server_files and pg_write_server_files.
+SET ROLE user4;
+SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
+
 -- Should fail because DuckDB execution is not allowed for this user
 SET ROLE user3;
 SELECT * FROM t;


### PR DESCRIPTION
This changes slightly how we determine if the local file system should be accessible by DuckDB. Instead of defaulting the disabled_filesystems GUC to `LocalFileSystem` we now default it to the empty string. To make such a configuration secure, we now automatically add `LocalFileSystem` to the configured list before configuring it in Postgres if the user isn't a member of the `pg_read_server_files` and `pg_write_server_files` roles.
