### PR TITLE
Hopefully fix static build issue in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ PG_DUCKDB_LINK_FLAGS = -Wl,-rpath,$(PG_LIB)/ -Lthird_party/duckdb/build/$(DUCKDB
 DUCKDB_BUILD_DIR = third_party/duckdb/build/$(DUCKDB_BUILD_TYPE)
 
 ifeq ($(DUCKDB_BUILD), ReleaseStatic)
-	PG_DUCKDB_LINK_FLAGS += third_party/duckdb/build/release/libduckdb_bundle.a
-	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/$(DUCKDB_LIB)
+	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/libduckdb_bundle.a
+	PG_DUCKDB_LINK_FLAGS += $(FULL_DUCKDB_LIB)
 else
+	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/src/libduckdb$(DLSUFFIX)
 	PG_DUCKDB_LINK_FLAGS += -lduckdb
-	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/src/$(DUCKDB_LIB)/libduckdb$(DLSUFFIX)
 endif
 
 ERROR_ON_WARNING ?=


### PR DESCRIPTION
In CI we sometimes get this error:

```
/usr/bin/ld: cannot find third_party/duckdb/build/release/libduckdb_bundle.a: No such file or directory
```

The intent of this change is to avoid that by adding a correct
dependency on the `.a` file in case of a static build.
