### PR TITLE
Only show hints about duckdb.row access for queries including duckdb functions

### DIFF
--- a/test/regression/expected/read_functions.out
+++ b/test/regression/expected/read_functions.out
@@ -310,6 +310,22 @@ ERROR:  a column definition list is only allowed for functions returning "record
 LINE 1: ... FROM read_parquet('../../data/iris.parquet') AS ("sepal.len...
                                                              ^
 HINT:  If you use DuckDB functions like read_parquet, you need to use the r['colname'] syntax introduced in pg_duckdb 0.3.0. It seems like you might be using the outdated "AS (colname coltype, ...)" syntax
+-- But we don't show that hint for queries that don't use these functions.
+SELECT count("sepal.length") FROM generate_series(1, 100) AS ("sepal.length" FLOAT);
+ERROR:  a column definition list is only allowed for functions returning "record"
+LINE 1: ...("sepal.length") FROM generate_series(1, 100) AS ("sepal.len...
+                                                             ^
+-- Show a hint for users trying to use columns as normal instead of using r['column_name']
+SELECT count("sepal.length") FROM read_parquet('../../data/iris.parquet');
+ERROR:  column "sepal.length" does not exist
+LINE 1: SELECT count("sepal.length") FROM read_parquet('../../data/i...
+                     ^
+HINT:  If you use DuckDB functions like read_parquet, you need to use the r['colname'] syntax to use columns. If you're already doing that, maybe you forgot to to give the function the r alias.
+-- But again only show it when we use functions that return duckdb.rows
+SELECT count("sepal.length") FROM generate_series(1, 100) a(x);
+ERROR:  column "sepal.length" does not exist
+LINE 1: SELECT count("sepal.length") FROM generate_series(1, 100) a(...
+                     ^
 -- read_csv
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
  count 

--- a/test/regression/sql/read_functions.sql
+++ b/test/regression/sql/read_functions.sql
@@ -190,6 +190,15 @@ select * from experiences;
 -- We show a hint for the new syntax when someone uses the old syntax.
 SELECT count("sepal.length") FROM read_parquet('../../data/iris.parquet') AS ("sepal.length" FLOAT);
 
+-- But we don't show that hint for queries that don't use these functions.
+SELECT count("sepal.length") FROM generate_series(1, 100) AS ("sepal.length" FLOAT);
+
+-- Show a hint for users trying to use columns as normal instead of using r['column_name']
+SELECT count("sepal.length") FROM read_parquet('../../data/iris.parquet');
+
+-- But again only show it when we use functions that return duckdb.rows
+SELECT count("sepal.length") FROM generate_series(1, 100) a(x);
+
 -- read_csv
 
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;


### PR DESCRIPTION
We were adding hints to queries to which they did not apply. This is
unhelpful and confusing for users. So this makes some changes to our
logic for adding these hints to only do so when the query string
includes the pg_duckdb functions that return a duckdb.row.
