### PR TITLE
Add sqlsmith fuzzy test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
             libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev libtinfo6 cmake \
-            libstdc++-12-dev ninja-build
+            libstdc++-12-dev ninja-build sqlsmith
           echo "${PWD}/postgres/inst/bin:$PATH'" > $GITHUB_PATH
 
       - name: ccache

--- a/test/pycheck/sqlsmith_fuzzy_test.py
+++ b/test/pycheck/sqlsmith_fuzzy_test.py
@@ -7,10 +7,15 @@ def test_fuzzy_pg_crashing(pg: Postgres, cur: Cursor):
     cur.sql("CREATE DATABASE sqlsmith_test")
     with pg.cur(dbname="sqlsmith_test") as sqlsmith_cur:
         sqlsmith_cur.sql("CREATE EXTENSION pg_duckdb")
-        # create a test table with arbitary data to allow sqlsmith to do more operations
+        # create test tables with dummy data to allow sqlsmith to do more operations
         sqlsmith_cur.sql("CREATE TABLE test_table (id INT, name TEXT)")
+        sqlsmith_cur.sql("CREATE TABLE test_table2 (id INT, name VARCHAR)")
+
         sqlsmith_cur.sql(
-            "INSERT INTO test_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')"
+            "INSERT INTO test_table (SELECT num, 'name_' || num FROM generate_series(1, 100) as num)"
+        )
+        sqlsmith_cur.sql(
+            "INSERT INTO test_table2 (SELECT num, 'name_' || num FROM generate_series(10, 100) as num)"
         )
 
     # any crash caused by sqlsmith will be detected from logs on the teardown of pg fixture

--- a/test/pycheck/sqlsmith_fuzzy_test.py
+++ b/test/pycheck/sqlsmith_fuzzy_test.py
@@ -1,0 +1,26 @@
+from .utils import Postgres, Cursor, run
+import pytest
+
+
+@pytest.mark.timeout(300)
+def test_fuzzy_pg_crashing(pg: Postgres, cur: Cursor):
+    cur.sql("CREATE DATABASE sqlsmith_test")
+    with pg.cur(dbname="sqlsmith_test") as sqlsmith_cur:
+        sqlsmith_cur.sql("CREATE EXTENSION pg_duckdb")
+        # create a test table with arbitary data to allow sqlsmith to do more operations
+        sqlsmith_cur.sql("CREATE TABLE test_table (id INT, name TEXT)")
+        sqlsmith_cur.sql(
+            "INSERT INTO test_table (id, name) VALUES (1, 'Alice'), (2, 'Bob')"
+        )
+
+    # any crash caused by sqlsmith will be detected from logs on the teardown of pg fixture
+    run(
+        [
+            "/usr/bin/sqlsmith",
+            f"--target=host={pg.host} port={pg.port} user={pg.default_user} dbname=sqlsmith_test",
+            "--max-queries=1500",
+        ],
+        check=True,
+    )
+
+    cur.sql("DROP DATABASE sqlsmith_test")


### PR DESCRIPTION
This adds a test that runs sqlsmith on a sqlsmith_test database that has pg_duckdb extension enabled and any caused crashes will get detected by the logs in the teardown of pg fixture

```
...
assert (
    "was terminated by signal 6" not in logs
), "Postgres crashed! Check the logs above."
assert (
    "was terminated by signal 11" not in logs
), "Postgres crashed! Check the logs above."
```
closes: #222 