### PR TITLE
Add basic collation support

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -21,4 +21,5 @@ extern char *duckdb_motherduck_session_hint;
 extern char *duckdb_temporary_directory;
 extern char *duckdb_extension_directory;
 extern char *duckdb_max_temp_directory_size;
+extern char *duckdb_default_collation;
 } // namespace pgduckdb

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -177,6 +177,8 @@ DuckDBManager::Initialize() {
 	auto &db_manager = duckdb::DatabaseManager::Get(context);
 	default_dbname = db_manager.GetDefaultDatabase(context);
 	pgduckdb::DuckDBQueryOrThrow(context, "SET TimeZone =" + duckdb::KeywordHelper::WriteQuoted(pg_time_zone));
+	pgduckdb::DuckDBQueryOrThrow(context, "SET default_collation =" +
+	                                          duckdb::KeywordHelper::WriteQuoted(duckdb_default_collation));
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE 'pgduckdb' (TYPE pgduckdb)");
 	pgduckdb::DuckDBQueryOrThrow(context, "ATTACH DATABASE ':memory:' AS pg_temp;");
 

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -128,6 +128,7 @@ bool duckdb_autoload_known_extensions = true;
 char *duckdb_temporary_directory = MakeDirName("temp");
 char *duckdb_extension_directory = MakeDirName("extensions");
 char *duckdb_max_temp_directory_size = strdup("");
+char *duckdb_default_collation = strdup("C");
 
 void
 InitGUC() {
@@ -202,6 +203,10 @@ InitGUC() {
 	DefineCustomDuckDBVariable("duckdb.worker_threads",
 	                           "Maximum number of DuckDB threads per Postgres backend, alias for duckdb.threads",
 	                           &duckdb_maximum_threads, -1, 1024, PGC_SUSET);
+
+	DefineCustomDuckDBVariable("duckdb.default_collation",
+	                           "The default collation to use for DuckDB queries, e.g., 'en_us'",
+	                           &duckdb_default_collation, PGC_SUSET);
 
 	DefineCustomDuckDBVariable("duckdb.motherduck_session_hint", "The session hint to use for MotherDuck connections",
 	                           &duckdb_motherduck_session_hint);


### PR DESCRIPTION
Differences in collations between Postgres and DuckDB can lead to unexpected behavior, especially when it comes to string comparisons and sorting. Automatically choosing the right DuckDB collation is hard, because collation names don't necessarily match. This change allows people to at least configure the collation that's used by DuckDB.
