### PR TITLE
Fix pgspot errors for 1.0.0 release

### DIFF
--- a/sql/pg_duckdb--0.3.0--1.0.0.sql
+++ b/sql/pg_duckdb--0.3.0--1.0.0.sql
@@ -1,6 +1,32 @@
+-- Move internal functions that are outside of the duckdb schema to the duckdb schema
+ALTER FUNCTION duckdb_unresolved_type_operator(duckdb.unresolved_type, "any") SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator_bool(duckdb.unresolved_type, "any") SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator("any", duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator_bool("any", duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator(duckdb.unresolved_type, duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator_bool(duckdb.unresolved_type, duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_operator(duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type) SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type, other "any") SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type, other "any", another "any") SET SCHEMA duckdb;
+ALTER FUNCTION duckdb_unresolved_type_final(state duckdb.unresolved_type) SET SCHEMA duckdb;
+
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator(duckdb.unresolved_type, "any") RENAME TO unresolved_type_operator;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator_bool(duckdb.unresolved_type, "any") RENAME TO unresolved_type_operator_bool;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator("any", duckdb.unresolved_type) RENAME TO unresolved_type_operator;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator_bool("any", duckdb.unresolved_type) RENAME TO unresolved_type_operator_bool;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator(duckdb.unresolved_type, duckdb.unresolved_type) RENAME TO unresolved_type_operator;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator_bool(duckdb.unresolved_type, duckdb.unresolved_type) RENAME TO unresolved_type_operator_bool;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_operator(duckdb.unresolved_type) RENAME TO unresolved_type_operator;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type) RENAME TO unresolved_type_state_trans;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type, other "any") RENAME TO unresolved_type_state_trans;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_state_trans(state duckdb.unresolved_type, value duckdb.unresolved_type, other "any", another "any") RENAME TO unresolved_type_state_trans;
+ALTER FUNCTION duckdb.duckdb_unresolved_type_final(state duckdb.unresolved_type) RENAME TO unresolved_type_final;
+
 -- Ensure UTF8 encoding
 DO $$
 BEGIN
+    SET LOCAL search_path = pg_catalog, pg_temp;
     IF current_setting('server_encoding') != 'UTF8' THEN
         RAISE EXCEPTION 'pg_duckdb can only be installed in a Postgres database with UTF8 encoding, this one is encoded using %.', current_setting('server_encoding');
     END IF;
@@ -87,9 +113,9 @@ CREATE FUNCTION duckdb.load_extension(extension_name TEXT) RETURNS void
 
 -- The min aggregate was somehow missing from the list of aggregates in 0.3.0
 CREATE AGGREGATE @extschema@.min(duckdb.unresolved_type) (
-    SFUNC = duckdb_unresolved_type_state_trans,
+    SFUNC = duckdb.unresolved_type_state_trans,
     STYPE = duckdb.unresolved_type,
-    FINALFUNC = duckdb_unresolved_type_final
+    FINALFUNC = duckdb.unresolved_type_final
 );
 
 CREATE FUNCTION @extschema@.strftime(date, text) RETURNS text
@@ -536,109 +562,109 @@ CREATE CAST (duckdb.unresolved_type AS bytea[])
 CREATE OPERATOR pg_catalog.~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~ (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~ (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~ (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~* (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~* (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.~~* (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~ (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~ (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~* (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~* (
     LEFTARG = duckdb.unresolved_type,
     RIGHTARG = "any",
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE OPERATOR pg_catalog.!~~* (
     LEFTARG = "any",
     RIGHTARG = duckdb.unresolved_type,
-    FUNCTION = duckdb_unresolved_type_operator
+    FUNCTION = duckdb.unresolved_type_operator
 );
 
 CREATE TYPE duckdb.union;


### PR DESCRIPTION
We weren't fully qualifying all functions and operators in our UTF8 encoding check. This sets a safe search_path before doing the check, so that we don't accidentally use a function or operator from a different schema during extension installation/upgrade.

Failing tests (after changing the search_path) notified me of the fact that we also don't store some of our internal functions in the duckdb schema. That was unintended. This fixes that too.