### PR TITLE
fix: do not allow relative path in DuckDB COPY statements

### DIFF
--- a/src/pgduckdb_ddl.cpp
+++ b/src/pgduckdb_ddl.cpp
@@ -520,6 +520,11 @@ DuckdbUtilityHook_Cpp(PlannedStmt *pstmt, const char *query_string, bool read_on
                       QueryCompletion *qc) {
 	Node *parsetree = pstmt->utilityStmt;
 	if (IsA(parsetree, CopyStmt)) {
+		CopyStmt *stmt = castNode(CopyStmt, parsetree);
+		char *filename = stmt->filename;
+		if (!is_absolute_path(filename))
+			ereport(ERROR, (errcode(ERRCODE_INVALID_NAME), errmsg("relative path not allowed for COPY to file")));
+
 		auto copy_query = PostgresFunctionGuard(MakeDuckdbCopyQuery, pstmt, query_string, query_env);
 		if (copy_query) {
 			auto res = pgduckdb::DuckDBQueryOrThrow(copy_query);


### PR DESCRIPTION
Vanilla PostgreSQL does not allow COPY statements with relative path as it may lead to overriding database files and result in database corruption. 

DuckDB (as well as pg_duckdb for now) allows COPY with relative path. Can't tell if it is suitable to restrict it in DuckDB, but we can handle these cases in pg_duckdb for consistency. 

Suggested PR does this