### PR TITLE
Remove unnecessary workaround for iceberg_scan/query function

### DIFF
--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -24,7 +24,6 @@ bool pgduckdb_var_is_duckdb_row(Var *var);
 bool pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc);
 Var *pgduckdb_duckdb_row_subscript_var(Expr *expr);
 bool pgduckdb_reconstruct_star_step(StarReconstructionContext *ctx, ListCell *tle_cell);
-bool pgduckdb_function_needs_subquery(Oid function_oid);
 int pgduckdb_show_type(Const *constval, int original_showtype);
 bool pgduckdb_subscript_has_custom_alias(Plan *plan, List *rtable, Var *subscript_var, char *colname);
 SubscriptingRef *pgduckdb_strip_first_subscript(SubscriptingRef *sbsref, StringInfo buf);

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -294,39 +294,6 @@ pgduckdb_reconstruct_star_step(StarReconstructionContext *ctx, ListCell *tle_cel
 }
 
 /*
- * iceberg_scan needs to be wrapped in an additianol subquery to resolve a
- * bug where aliasses on iceberg_scan are ignored:
- * https://github.com/duckdb/duckdb-iceberg/issues/44
- *
- * By wrapping the iceberg_scan call the alias is given to the subquery,
- * instead of th call. This subquery is easily optimized away by DuckDB,
- * because it doesn't do anything.
- *
- * This problem is also true for the "query" function, which we use when
- * creating materialized views and CTAS.
- * https://github.com/duckdb/duckdb/issues/15570#issuecomment-2598419474
- *
- * TODO: Probably check this in a bit more efficient way and move it to
- * pgduckdb_ruleutils.cpp
- */
-bool
-pgduckdb_function_needs_subquery(Oid function_oid) {
-	if (!pgduckdb::IsDuckdbOnlyFunction(function_oid)) {
-		return false;
-	}
-
-	auto func_name = get_func_name(function_oid);
-	if (strcmp(func_name, "iceberg_scan") == 0) {
-		return true;
-	}
-
-	if (strcmp(func_name, "query") == 0) {
-		return true;
-	}
-	return false;
-}
-
-/*
  * A wrapper around pgduckdb_is_fake_type that returns -1 if the type of the
  * Const is fake, because that's the type of value that get_const_expr requires
  * in its showtype variable to never show the type.

--- a/src/vendor/pg_ruleutils_14.c
+++ b/src/vendor/pg_ruleutils_14.c
@@ -9931,11 +9931,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		nargs++;
 	}
 
-	bool function_needs_subquery = pgduckdb_function_needs_subquery(funcoid);
-	if (function_needs_subquery) {
-		appendStringInfoString(buf, "(FROM ");
-	}
-
 	appendStringInfo(buf, "%s(",
 					 generate_function_name(funcoid, nargs,
 											argnames, argtypes,
@@ -9952,10 +9947,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		get_rule_expr((Node *) lfirst(l), context, true);
 	}
 	appendStringInfoChar(buf, ')');
-
-	if (function_needs_subquery) {
-		appendStringInfoChar(buf, ')');
-	}
 }
 
 /*

--- a/src/vendor/pg_ruleutils_15.c
+++ b/src/vendor/pg_ruleutils_15.c
@@ -10133,11 +10133,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		nargs++;
 	}
 
-	bool function_needs_subquery = pgduckdb_function_needs_subquery(funcoid);
-	if (function_needs_subquery) {
-		appendStringInfoString(buf, "(FROM ");
-	}
-
 	appendStringInfo(buf, "%s(",
 					 generate_function_name(funcoid, nargs,
 											argnames, argtypes,
@@ -10154,10 +10149,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		get_rule_expr((Node *) lfirst(l), context, true);
 	}
 	appendStringInfoChar(buf, ')');
-
-	if (function_needs_subquery) {
-		appendStringInfoChar(buf, ')');
-	}
 }
 
 /*

--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -10124,11 +10124,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		nargs++;
 	}
 
-	bool function_needs_subquery = pgduckdb_function_needs_subquery(funcoid);
-	if (function_needs_subquery) {
-		appendStringInfoString(buf, "(FROM ");
-	}
-
 	appendStringInfo(buf, "%s(",
 					 generate_function_name(funcoid, nargs,
 											argnames, argtypes,
@@ -10145,10 +10140,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		get_rule_expr((Node *) lfirst(l), context, true);
 	}
 	appendStringInfoChar(buf, ')');
-
-	if (function_needs_subquery) {
-		appendStringInfoChar(buf, ')');
-	}
 }
 
 /*

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -10527,11 +10527,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		nargs++;
 	}
 
-	bool function_needs_subquery = pgduckdb_function_needs_subquery(funcoid);
-	if (function_needs_subquery) {
-		appendStringInfoString(buf, "(FROM ");
-	}
-
 	appendStringInfo(buf, "%s(",
 					 generate_function_name(funcoid, nargs,
 											argnames, argtypes,
@@ -10548,10 +10543,6 @@ get_func_expr(FuncExpr *expr, deparse_context *context,
 		get_rule_expr((Node *) lfirst(l), context, true);
 	}
 	appendStringInfoChar(buf, ')');
-
-	if (function_needs_subquery) {
-		appendStringInfoChar(buf, ')');
-	}
 }
 
 /*

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -42,13 +42,13 @@ select r['a'] SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
 ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
 Did you mean "list_sem"?
 
-LINE 1: SELECT (r.a ~ similar_to_escape('%b%'::text)) AS "?column?" FROM (FROM...
+LINE 1: SELECT (r.a ~ similar_to_escape('%b%'::text)) AS "?column?" FROM system...
                       ^
 select r['a'] NOT SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
 ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
 Did you mean "list_sem"?
 
-LINE 1: SELECT (r.a !~ similar_to_escape('%b%'::text)) AS "?column?" FROM (FROM...
+LINE 1: SELECT (r.a !~ similar_to_escape('%b%'::text)) AS "?column?" FROM system...
                        ^
 select length(r['a']) from duckdb.query($$ SELECT 'abc' a $$) r;
  length 


### PR DESCRIPTION
The issue that this code was working around has been fixed for a while
now in DuckDB: https://github.com/duckdb/duckdb-iceberg/issues/44

So this removes the now unnecessary workaround.
