### PR TITLE
Add make_timestamp and make_timestamptz

### DIFF
--- a/sql/pg_duckdb--0.3.0--1.0.0.sql
+++ b/sql/pg_duckdb--0.3.0--1.0.0.sql
@@ -303,6 +303,26 @@ SET search_path = pg_catalog, pg_temp
 AS 'MODULE_PATHNAME', 'duckdb_only_function'
 LANGUAGE C;
 
+CREATE FUNCTION @extschema@.make_timestamp(microseconds bigint) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.make_timestamp(microseconds duckdb.unresolved_type) RETURNS timestamp
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.make_timestamptz(microseconds bigint) RETURNS timestamptz
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+CREATE FUNCTION @extschema@.make_timestamptz(microseconds duckdb.unresolved_type) RETURNS timestamptz
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
 CREATE FUNCTION @extschema@.date_trunc(text, duckdb.unresolved_type) RETURNS duckdb.unresolved_type
 SET search_path = pg_catalog, pg_temp
 AS 'MODULE_PATHNAME', 'duckdb_only_function'

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -170,6 +170,8 @@ BuildDuckdbOnlyFunctions() {
 	                                "epoch_ms",
 	                                "epoch_us",
 	                                "epoch_ns",
+	                                "make_timestamp",
+	                                "make_timestamptz",
 	                                "time_bucket",
 	                                "union_extract",
 	                                "union_tag"};

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -170,3 +170,50 @@ select epoch(r['ts']) from duckdb.query($$ SELECT '2022-11-07 08:43:04'::TIMESTA
  1667810584
 (1 row)
 
+-- Tests for make_timestamp[tz]. The ones with many arguments also exist in
+-- postgres, so we force duckdb execution by using duckdb.query.
+select make_timestamp(2023, 6, 12, 10, 30, 12.42) FROM duckdb.query($$ SELECT 1
+$$);
+       make_timestamp        
+-----------------------------
+ Mon Jun 12 10:30:12.42 2023
+(1 row)
+
+select make_timestamptz(2023, 6, 12, 10, 30, 12.42) FROM duckdb.query($$ SELECT 1
+$$);
+        make_timestamptz         
+---------------------------------
+ Mon Jun 12 10:30:12.42 2023 PDT
+(1 row)
+
+select make_timestamptz(2023, 6, 12, 10, 30, 12.42, 'CET') FROM duckdb.query($$ SELECT 1
+$$);
+        make_timestamptz         
+---------------------------------
+ Mon Jun 12 01:30:12.42 2023 PDT
+(1 row)
+
+select make_timestamp(1686570000000000);
+      make_timestamp      
+--------------------------
+ Mon Jun 12 11:40:00 2023
+(1 row)
+
+select make_timestamp(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;
+      make_timestamp      
+--------------------------
+ Mon Jun 12 11:40:00 2023
+(1 row)
+
+select make_timestamptz(1686570000000000);
+       make_timestamptz       
+------------------------------
+ Mon Jun 12 04:40:00 2023 PDT
+(1 row)
+
+select make_timestamptz(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;
+       make_timestamptz       
+------------------------------
+ Mon Jun 12 04:40:00 2023 PDT
+(1 row)
+

--- a/test/regression/sql/unresolved_type.sql
+++ b/test/regression/sql/unresolved_type.sql
@@ -33,3 +33,17 @@ select epoch_ms(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59
 select epoch_ns(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch_us(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch(r['ts']) from duckdb.query($$ SELECT '2022-11-07 08:43:04'::TIMESTAMP ts $$) r;
+
+-- Tests for make_timestamp[tz]. The ones with many arguments also exist in
+-- postgres, so we force duckdb execution by using duckdb.query.
+select make_timestamp(2023, 6, 12, 10, 30, 12.42) FROM duckdb.query($$ SELECT 1
+$$);
+select make_timestamptz(2023, 6, 12, 10, 30, 12.42) FROM duckdb.query($$ SELECT 1
+$$);
+select make_timestamptz(2023, 6, 12, 10, 30, 12.42, 'CET') FROM duckdb.query($$ SELECT 1
+$$);
+
+select make_timestamp(1686570000000000);
+select make_timestamp(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;
+select make_timestamptz(1686570000000000);
+select make_timestamptz(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;


### PR DESCRIPTION
On the DuckDB main branch `epoch_ms` is removed, and instead `make_timestamp[tz]` is recommended: https://github.com/duckdb/duckdb/pull/17816

So, this starts supporting make_timestamp[tz] in pg_duckdb. We might even want to remove `epoch_ms` support, since it has not been released yet, and DuckDB intends to remove it in a future release.
