### PR TITLE
Remove bigint epoch_ms function

### DIFF
--- a/sql/pg_duckdb--0.3.0--1.0.0.sql
+++ b/sql/pg_duckdb--0.3.0--1.0.0.sql
@@ -223,16 +223,6 @@ SET search_path = pg_catalog, pg_temp
 AS 'MODULE_PATHNAME', 'duckdb_only_function'
 LANGUAGE C;
 
-CREATE FUNCTION @extschema@.epoch_ms(bigint) RETURNS timestamp
-SET search_path = pg_catalog, pg_temp
-AS 'MODULE_PATHNAME', 'duckdb_only_function'
-LANGUAGE C;
-
-CREATE FUNCTION @extschema@.epoch_ms(duckdb.unresolved_type) RETURNS duckdb.unresolved_type
-SET search_path = pg_catalog, pg_temp
-AS 'MODULE_PATHNAME', 'duckdb_only_function'
-LANGUAGE C;
-
 CREATE FUNCTION @extschema@.epoch_us(interval) RETURNS bigint
 SET search_path = pg_catalog, pg_temp
 AS 'MODULE_PATHNAME', 'duckdb_only_function'

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -110,12 +110,6 @@ select strftime(r['ts'], '%a, %-d %B %Y - %I:%M:%S %p') from duckdb.query($$ SEL
  Wed, 1 January 1992 - 08:38:40 PM
 (1 row)
 
-select epoch_ms(701222400000);
-         epoch_ms         
---------------------------
- Sun Mar 22 00:00:00 1992
-(1 row)
-
 select epoch_ms(TIMESTAMP '2021-08-03 11:59:44.123456');
    epoch_ms    
 ---------------
@@ -140,18 +134,10 @@ select epoch('2022-11-07 08:43:04'::TIMESTAMP);
  1667810584
 (1 row)
 
-select epoch_ms(r['a']) from duckdb.query($$ SELECT 701222400000 a $$) r;
-         epoch_ms         
---------------------------
- Sun Mar 22 00:00:00 1992
-(1 row)
-
-select epoch_ms(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
-   epoch_ms    
----------------
- 1627991984123
-(1 row)
-
+-- TODO: Add this back after we start using DuckDB 1.4, which removes epoch_ms
+-- for bigint:
+--
+-- select epoch_ms(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch_ns(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
       epoch_ns       
 ---------------------

--- a/test/regression/sql/unresolved_type.sql
+++ b/test/regression/sql/unresolved_type.sql
@@ -22,14 +22,15 @@ select strftime(timestamp '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
 select strftime(timestamptz '1992-01-01 20:38:40', '%a, %-d %B %Y - %I:%M:%S %p');
 select strftime(r['ts'], '%a, %-d %B %Y - %I:%M:%S %p') from duckdb.query($$ SELECT timestamp '1992-01-01 20:38:40' ts $$) r;
 
-select epoch_ms(701222400000);
 select epoch_ms(TIMESTAMP '2021-08-03 11:59:44.123456');
 select epoch_ns(TIMESTAMP '2021-08-03 11:59:44.123456');
 select epoch_us(TIMESTAMP '2021-08-03 11:59:44.123456');
 select epoch('2022-11-07 08:43:04'::TIMESTAMP);
 
-select epoch_ms(r['a']) from duckdb.query($$ SELECT 701222400000 a $$) r;
-select epoch_ms(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
+-- TODO: Add this back after we start using DuckDB 1.4, which removes epoch_ms
+-- for bigint:
+--
+-- select epoch_ms(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch_ns(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch_us(r['ts']) from duckdb.query($$ SELECT TIMESTAMP '2021-08-03 11:59:44.123456' ts $$) r;
 select epoch(r['ts']) from duckdb.query($$ SELECT '2022-11-07 08:43:04'::TIMESTAMP ts $$) r;


### PR DESCRIPTION
DuckDB 1.4 removes the bigint variant of epoch_ms for consistency: https://github.com/duckdb/duckdb/pull/17816

This also removes that epoch_ms function for pg_duckdb, to avoid having to do a breaking change in the next release.

This also removes the unresolved_type version of epoch_ms, as that can be used inadvertently to call the bigint one. Once pg_duckdb starts using DuckDB 1.4, we can add this back.
