### PR TITLE
Try out the dot-subscripting Postgres 19 patch

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -52,7 +52,7 @@ jobs:
           type: ReleaseStatic
         - version: REL_17_STABLE
           type: Debug
-        - version: REL_18_BETA1
+        - version: master
           type: Release
 
         # Not enabled for now (waiting for April 2025 code freeze)

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -40,19 +40,25 @@ jobs:
       matrix:
         include:
         - version: REL_14_STABLE
+          repo: postgres/postgres
           type: Release
         - version: REL_15_STABLE
+          repo: postgres/postgres
           type: Release
         - version: REL_16_STABLE
+          repo: postgres/postgres
           type: Release
         # For PG17 we build DuckDB as a static library. There's nothing special
         # about the static library, nor PG17. This is only done so that we have
         # CI coverage for our logic to build a static library version.
         - version: REL_17_STABLE
+          repo: postgres/postgres
           type: ReleaseStatic
         - version: REL_17_STABLE
+          repo: postgres/postgres
           type: Debug
-        - version: master
+        - version: cf/5214
+          repo: postgresql-cfbot/postgresql
           type: Release
 
         # Not enabled for now (waiting for April 2025 code freeze)
@@ -89,7 +95,7 @@ jobs:
       - name: Checkout PostgreSQL code
         run: |
           rm -rf postgres
-          git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/postgres/postgres.git
+          git clone --branch ${{ matrix.version }} --single-branch --depth 1 https://github.com/${{ matrix.repo }}.git postgres
 
       - name: Compute Version SHAs
         id: versions

--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -22,7 +22,7 @@ bool pgduckdb_is_unresolved_type(Oid type_oid);
 bool pgduckdb_is_fake_type(Oid type_oid);
 bool pgduckdb_var_is_duckdb_row(Var *var);
 bool pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc);
-Var *pgduckdb_duckdb_row_subscript_var(Expr *expr);
+Var *pgduckdb_duckdb_subscript_var(Expr *expr);
 bool pgduckdb_reconstruct_star_step(StarReconstructionContext *ctx, ListCell *tle_cell);
 bool pgduckdb_replace_subquery_with_view(Query *query, StringInfo buf);
 int pgduckdb_show_type(Const *constval, int original_showtype);

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -331,31 +331,18 @@ DuckdbExecutorStartHook_Cpp(QueryDesc *queryDesc) {
 	pgduckdb::ClaimCurrentCommandId();
 }
 
-#if PG_VERSION_NUM >= 180000
-static bool
-#else
 static void
-#endif
 DuckdbExecutorStartHook(QueryDesc *queryDesc, int eflags) {
 	pgduckdb::executor_nest_level++;
 	if (!pgduckdb::IsExtensionRegistered()) {
 		pgduckdb::MarkStatementNotTopLevel();
-		return prev_executor_start_hook(queryDesc, eflags);
+		prev_executor_start_hook(queryDesc, eflags);
+		return;
 	}
 
-#if PG_VERSION_NUM >= 180000
-	if (!prev_executor_start_hook(queryDesc, eflags)) {
-		return false;
-	}
-#else
 	prev_executor_start_hook(queryDesc, eflags);
-#endif
 
 	InvokeCPPFunc(DuckdbExecutorStartHook_Cpp, queryDesc);
-
-#if PG_VERSION_NUM >= 180000
-	return true;
-#endif
 }
 
 /*

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -350,6 +350,14 @@ pgduckdb_subscript_has_custom_alias(Plan *plan, List *rtable, Var *subscript_var
 	int varno;
 	int varattno;
 
+	if (strcmp(colname, "?column?") == 0) {
+		/*
+		 * If the column name is "?column?", then it means that Postgres
+		 * couldn't figure out a decent alias.
+		 */
+		return false;
+	}
+
 	/*
 	 * If we have a syntactic referent for the Var, and we're working from a
 	 * parse tree, prefer to use the syntactic referent.  Otherwise, fall back
@@ -388,6 +396,15 @@ pgduckdb_strip_first_subscript(SubscriptingRef *sbsref, StringInfo buf) {
 	}
 
 	Assert(sbsref->refupperindexpr);
+
+	if (linitial(sbsref->refupperindexpr) == NULL) {
+		return sbsref;
+	}
+
+	if (IsA(linitial(sbsref->refupperindexpr), String)) {
+		return sbsref;
+	}
+
 	Oid typoutput;
 	bool typIsVarlena;
 	Const *constval = castNode(Const, linitial(sbsref->refupperindexpr));

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -126,7 +126,7 @@ pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc) {
  * the Var of the duckdb row if it is.
  */
 Var *
-pgduckdb_duckdb_row_subscript_var(Expr *expr) {
+pgduckdb_duckdb_subscript_var(Expr *expr) {
 	if (!expr) {
 		return NULL;
 	}
@@ -143,9 +143,6 @@ pgduckdb_duckdb_row_subscript_var(Expr *expr) {
 
 	Var *refexpr = (Var *)subscript->refexpr;
 
-	if (!pgduckdb_var_is_duckdb_row(refexpr)) {
-		return NULL;
-	}
 	return refexpr;
 }
 

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -65,13 +65,8 @@ PostgresTableReader::InitUnsafe(const char *table_scan_query, bool count_tuples_
 
 	PlannedStmt *planned_stmt = standard_planner(query, table_scan_query, 0, nullptr);
 
-#if PG_VERSION_NUM >= 180000
-	table_scan_query_desc = CreateQueryDesc(planned_stmt, nullptr, table_scan_query, GetActiveSnapshot(),
-	                                        InvalidSnapshot, None_Receiver, nullptr, nullptr, 0);
-#else
 	table_scan_query_desc = CreateQueryDesc(planned_stmt, table_scan_query, GetActiveSnapshot(), InvalidSnapshot,
 	                                        None_Receiver, nullptr, nullptr, 0);
-#endif
 
 	ExecutorStart(table_scan_query_desc, 0);
 

--- a/src/vendor/pg_ruleutils_14.c
+++ b/src/vendor/pg_ruleutils_14.c
@@ -6075,7 +6075,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_15.c
+++ b/src/vendor/pg_ruleutils_15.c
@@ -6156,7 +6156,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -6115,7 +6115,7 @@ get_target_list(List *targetList, deparse_context *context,
 			* to the column name are still valid.
 			*/
 		if (!duckdb_skip_as && outermost_targetlist) {
-				Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+				Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 				if (subscript_var) {
 						/*
 							* This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -6129,7 +6129,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_18.c
+++ b/src/vendor/pg_ruleutils_18.c
@@ -6333,7 +6333,7 @@ get_target_list(List *targetList, deparse_context *context)
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_18.c
+++ b/src/vendor/pg_ruleutils_18.c
@@ -13082,17 +13082,33 @@ printSubscripts(SubscriptingRef *sbsref, deparse_context *context)
 	lowlist_item = list_head(sbsref->reflowerindexpr);	/* could be NULL */
 	foreach(uplist_item, sbsref->refupperindexpr)
 	{
-		appendStringInfoChar(buf, '[');
-		if (lowlist_item)
+		Node	   *up = (Node *) lfirst(uplist_item);
+
+		if (!up)
 		{
-			/* If subexpression is NULL, get_rule_expr prints nothing */
-			get_rule_expr((Node *) lfirst(lowlist_item), context, false);
-			appendStringInfoChar(buf, ':');
-			lowlist_item = lnext(sbsref->reflowerindexpr, lowlist_item);
+			appendStringInfoString(buf, ".*");
 		}
-		/* If subexpression is NULL, get_rule_expr prints nothing */
-		get_rule_expr((Node *) lfirst(uplist_item), context, false);
-		appendStringInfoChar(buf, ']');
+		else if (IsA(up, String))
+		{
+			appendStringInfoChar(buf, '.');
+			appendStringInfoString(buf, quote_identifier(strVal(up)));
+		}
+		else
+		{
+			appendStringInfoChar(buf, '[');
+			if (lowlist_item)
+			{
+				/* If subexpression is NULL, get_rule_expr prints nothing */
+				get_rule_expr((Node *) lfirst(lowlist_item), context, false);
+				appendStringInfoChar(buf, ':');
+			}
+			/* If subexpression is NULL, get_rule_expr prints nothing */
+			get_rule_expr((Node *) lfirst(uplist_item), context, false);
+			appendStringInfoChar(buf, ']');
+		}
+
+		if (lowlist_item)
+			lowlist_item = lnext(sbsref->reflowerindexpr, lowlist_item);
 	}
 }
 

--- a/test/regression/expected/json_functions_duckdb.out
+++ b/test/regression/expected/json_functions_duckdb.out
@@ -343,6 +343,15 @@ SELECT public.json_transform(j, '{"family": "VARCHAR", "coolness": "DOUBLE"}') F
  {'family': canidae, 'coolness': NULL}
 (2 rows)
 
+SELECT (transformed).* FROM (
+    SELECT public.json_transform(j, '{"family": "VARCHAR", "coolness": "DOUBLE"}') as transformed FROM example2
+) q;
+  family  | coolness 
+----------+----------
+ anatidae |    42.42
+ canidae  |         
+(2 rows)
+
 SELECT public.json_transform(j, '{"family": "TINYINT", "coolness": "DECIMAL(4, 2)"}') FROM example2;
            json_transform            
 -------------------------------------

--- a/test/regression/expected/read_functions.out
+++ b/test/regression/expected/read_functions.out
@@ -41,9 +41,9 @@ SELECT jsoncol[1], arraycol[2] FROM (
     SELECT r['jsoncol'] jsoncol, r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
- jsoncol | arraycol 
----------+----------
- "d"     |       22
+ jsoncol[1] | arraycol[2] 
+------------+-------------
+ "d"        |          22
 (1 row)
 
 -- And the same for slice subscripts
@@ -57,8 +57,8 @@ SELECT arraycol[1:2] FROM (
     SELECT r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
- arraycol 
-----------
+ arraycol[1:2] 
+---------------
  {11,22}
 (1 row)
 

--- a/test/regression/expected/read_functions.out
+++ b/test/regression/expected/read_functions.out
@@ -63,20 +63,15 @@ SELECT arraycol[1:2] FROM (
 (1 row)
 
 SELECT r['arraycol'][:] FROM read_parquet('../../data/indexable.parquet') r;
- r.arraycol[:] 
----------------
- {11,22,33}
-(1 row)
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Parser Error: syntax error at or near "*"
 
+LINE 1: SELECT r.arraycol.* FROM system.main.read_parquet('../../data/indexable.parquet...
+                          ^
 SELECT arraycol[:] FROM (
     SELECT r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
-  arraycol  
-------------
- {11,22,33}
-(1 row)
-
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Binder Error: Cannot extract field from expression "arraycol.*" because it is not a struct
 -- Subqueries correctly expand *, in case of multiple columns.
 SELECT * FROM (
     SELECT 'something' as prefix, *, 'something else' as postfix
@@ -506,7 +501,7 @@ SELECT COUNT(r['a']) FROM read_json('../../data/table.json') r WHERE r['c'] > 50
     51
 (1 row)
 
-SELECT r['a'], r['b'], r['c'] FROM read_json('../../data/table.json') r WHERE r['c'] > 50.4 AND r['c'] < 51.2;
+SELECT (r).a, (r).b, (r).c FROM read_json('../../data/table.json') r WHERE (r).c > 50.4 AND (r).c < 51.2;
  a  |    b    |  c   
 ----+---------+------
  50 | json_50 | 50.5

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -203,3 +203,9 @@ select make_timestamptz(r['microseconds']) from duckdb.query($$ SELECT 168657000
  Mon Jun 12 04:40:00 2023 PDT
 (1 row)
 
+SELECT (s).* FROM (select (r).s FROM duckdb.query($$ SELECT {'key1': 'value1', 'key2': 42} AS s $$) r);
+  key1  | key2 
+--------+------
+ value1 |   42
+(1 row)
+

--- a/test/regression/sql/json_functions_duckdb.sql
+++ b/test/regression/sql/json_functions_duckdb.sql
@@ -212,6 +212,9 @@ SELECT public.json_group_structure(j) FROM example2;
 --     ('{"family": "canidae", "species": ["labrador", "bulldog"], "hair": true}');
 -- -- <JSON_TRANSFORM>
 SELECT public.json_transform(j, '{"family": "VARCHAR", "coolness": "DOUBLE"}') FROM example2;
+SELECT (transformed).* FROM (
+    SELECT public.json_transform(j, '{"family": "VARCHAR", "coolness": "DOUBLE"}') as transformed FROM example2
+) q;
 
 SELECT public.json_transform(j, '{"family": "TINYINT", "coolness": "DECIMAL(4, 2)"}') FROM example2;
 

--- a/test/regression/sql/read_functions.sql
+++ b/test/regression/sql/read_functions.sql
@@ -284,4 +284,4 @@ SELECT * FROM iceberg_metadata('../../data/lineitem_iceberg',  allow_moved_paths
 
 SELECT COUNT(r['a']) FROM read_json('../../data/table.json') r;
 SELECT COUNT(r['a']) FROM read_json('../../data/table.json') r WHERE r['c'] > 50.4;
-SELECT r['a'], r['b'], r['c'] FROM read_json('../../data/table.json') r WHERE r['c'] > 50.4 AND r['c'] < 51.2;
+SELECT (r).a, (r).b, (r).c FROM read_json('../../data/table.json') r WHERE (r).c > 50.4 AND (r).c < 51.2;

--- a/test/regression/sql/unresolved_type.sql
+++ b/test/regression/sql/unresolved_type.sql
@@ -48,3 +48,5 @@ select make_timestamp(1686570000000000);
 select make_timestamp(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;
 select make_timestamptz(1686570000000000);
 select make_timestamptz(r['microseconds']) from duckdb.query($$ SELECT 1686570000000000 AS microseconds $$) r;
+
+SELECT (s).* FROM (select (r).s FROM duckdb.query($$ SELECT {'key1': 'value1', 'key2': 42} AS s $$) r);


### PR DESCRIPTION
There is a patch on the Postgres mailinglist that allows subscripting with a dot syntax instead of square brackets: https://commitfest.postgresql.org/patch/5214/

This is a draft PR to try out if that patch works well for pg_duckdb.
