### PR TITLE
Dynamically set the time zone of duckdb

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -2,6 +2,7 @@
 
 namespace pgduckdb {
 void InitGUC();
+void InitGUCHooks();
 
 extern bool duckdb_force_execution;
 extern bool duckdb_unsafe_allow_mixed_transactions;

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -28,6 +28,7 @@ _PG_init(void) {
 	}
 
 	pgduckdb::InitGUC();
+	pgduckdb::InitGUCHooks();
 	DuckdbInitHooks();
 	DuckdbInitNode();
 	pgduckdb::InitBackgroundWorkersShmem();

--- a/test/regression/expected/timestamp_timestamptz.out
+++ b/test/regression/expected/timestamp_timestamptz.out
@@ -142,3 +142,146 @@ SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as 
 
 SELECT * FROM duckdb.query($$ SELECT '294247-01-01 00:00:00+00'::timestamptz as timestamptz $$);  -- out of range
 ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Out of Range Error: The TimestampTz value should be between min and max value (4714-11-24 (BC) 00:00:00 <-> 294247-01-01 00:00:00)
+set time zone 'Africa/Abidjan';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+   name   |     value      |      description      | input_type | scope 
+----------+----------------+-----------------------+------------+-------
+ TimeZone | Africa/Abidjan | The current time zone | VARCHAR    | LOCAL
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT '4714-11-24 (BC) 00:00:00+00'::timestamptz as timestamptz $$);
+           timestamptz           
+---------------------------------
+ Sun Nov 23 23:43:52 4714 LMT BC
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as timestamptz $$);
+          timestamptz           
+--------------------------------
+ Thu Dec 31 23:59:59 294246 GMT
+(1 row)
+
+select * from duckdb.query($$ select strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g %Z') $$) r;
+ strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g % 
+-----------------------------------------------------------------
+ Thu Jul 03 21:35:03.871 2025 GMT
+(1 row)
+
+SET TIME ZONE 'UTC';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+   name   | value |      description      | input_type | scope 
+----------+-------+-----------------------+------------+-------
+ TimeZone | UTC   | The current time zone | VARCHAR    | LOCAL
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT '4714-11-24 (BC) 00:00:00+00'::timestamptz as timestamptz $$);
+           timestamptz           
+---------------------------------
+ Mon Nov 24 00:00:00 4714 UTC BC
+(1 row)
+
+SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as timestamptz $$);
+          timestamptz           
+--------------------------------
+ Thu Dec 31 23:59:59 294246 UTC
+(1 row)
+
+select * from duckdb.query($$ select strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g %Z') $$) r;
+ strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g % 
+-----------------------------------------------------------------
+ Thu Jul 03 21:35:03.871 2025 UTC
+(1 row)
+
+CREATE TABLE t (
+    id int PRIMARY KEY,
+    d timestamp without time zone,
+    tz timestamp with time zone
+);
+SET TIME ZONE 'Asia/Shanghai';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+   name   |     value     |      description      | input_type | scope 
+----------+---------------+-----------------------+------------+-------
+ TimeZone | Asia/Shanghai | The current time zone | VARCHAR    | LOCAL
+(1 row)
+
+insert into t values (1,'2025-07-03 20:35:03.871', '2025-07-03 20:35:03.871');
+insert into t values (2,'2025-07-03 21:35:03.871', '2025-07-03 21:35:03.871');
+insert into t values (3,'2025-07-03 22:35:03.871', '2025-07-03 22:35:03.871');
+SET TIME ZONE 'UTC';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+   name   | value |      description      | input_type | scope 
+----------+-------+-----------------------+------------+-------
+ TimeZone | UTC   | The current time zone | VARCHAR    | LOCAL
+(1 row)
+
+insert into t values (4,'2025-07-03 23:35:03.871', '2025-07-03 23:35:03.871');
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  4 | Thu Jul 03 23:35:03.871 2025 | Thu Jul 03 23:35:03.871 2025 UTC
+(1 row)
+
+set duckdb.force_execution = on;
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  4 | Thu Jul 03 23:35:03.871 2025 | Thu Jul 03 23:35:03.871 2025 UTC
+(1 row)
+
+SET TIME ZONE 'Asia/Shanghai';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+   name   |     value     |      description      | input_type | scope 
+----------+---------------+-----------------------+------------+-------
+ TimeZone | Asia/Shanghai | The current time zone | VARCHAR    | LOCAL
+(1 row)
+
+set duckdb.force_execution = off;
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  1 | Thu Jul 03 20:35:03.871 2025 | Thu Jul 03 20:35:03.871 2025 CST
+  2 | Thu Jul 03 21:35:03.871 2025 | Thu Jul 03 21:35:03.871 2025 CST
+  3 | Thu Jul 03 22:35:03.871 2025 | Thu Jul 03 22:35:03.871 2025 CST
+(3 rows)
+
+set duckdb.force_execution = on;
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  1 | Thu Jul 03 20:35:03.871 2025 | Thu Jul 03 20:35:03.871 2025 CST
+  2 | Thu Jul 03 21:35:03.871 2025 | Thu Jul 03 21:35:03.871 2025 CST
+  3 | Thu Jul 03 22:35:03.871 2025 | Thu Jul 03 22:35:03.871 2025 CST
+(3 rows)
+
+drop extension pg_duckdb;
+SET TIME ZONE 'UTC';
+SHOW TIME ZONE;
+ TimeZone 
+----------
+ UTC
+(1 row)
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  4 | Thu Jul 03 23:35:03.871 2025 | Thu Jul 03 23:35:03.871 2025 UTC
+(1 row)
+
+SET TIME ZONE 'Asia/Shanghai';
+SHOW TIME ZONE;
+   TimeZone    
+---------------
+ Asia/Shanghai
+(1 row)
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+ id |              d               |                tz                
+----+------------------------------+----------------------------------
+  1 | Thu Jul 03 20:35:03.871 2025 | Thu Jul 03 20:35:03.871 2025 CST
+  2 | Thu Jul 03 21:35:03.871 2025 | Thu Jul 03 21:35:03.871 2025 CST
+  3 | Thu Jul 03 22:35:03.871 2025 | Thu Jul 03 22:35:03.871 2025 CST
+(3 rows)
+
+drop table t;
+SET TIME ZONE DEFAULT;
+create extension pg_duckdb;

--- a/test/regression/sql/timestamp_timestamptz.sql
+++ b/test/regression/sql/timestamp_timestamptz.sql
@@ -56,3 +56,67 @@ SELECT * FROM duckdb.query($$ SELECT '4714-11-24 (BC) 00:00:00+00'::timestamptz 
 SELECT * FROM duckdb.query($$ SELECT '4714-11-23 (BC) 23:59:59+00'::timestamptz as timestamptz $$);  -- out of range
 SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as timestamptz $$);
 SELECT * FROM duckdb.query($$ SELECT '294247-01-01 00:00:00+00'::timestamptz as timestamptz $$);  -- out of range
+
+set time zone 'Africa/Abidjan';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+SELECT * FROM duckdb.query($$ SELECT '4714-11-24 (BC) 00:00:00+00'::timestamptz as timestamptz $$);
+SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as timestamptz $$);
+select * from duckdb.query($$ select strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g %Z') $$) r;
+
+SET TIME ZONE 'UTC';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+SELECT * FROM duckdb.query($$ SELECT '4714-11-24 (BC) 00:00:00+00'::timestamptz as timestamptz $$);
+SELECT * FROM duckdb.query($$ SELECT '294246-12-31 23:59:59+00'::timestamptz as timestamptz $$);
+select * from duckdb.query($$ select strptime('2025-07-03 21:35:03.871 utc', '%Y-%m-%d %H:%M:%S.%g %Z') $$) r;
+
+CREATE TABLE t (
+    id int PRIMARY KEY,
+    d timestamp without time zone,
+    tz timestamp with time zone
+);
+
+SET TIME ZONE 'Asia/Shanghai';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+
+insert into t values (1,'2025-07-03 20:35:03.871', '2025-07-03 20:35:03.871');
+insert into t values (2,'2025-07-03 21:35:03.871', '2025-07-03 21:35:03.871');
+insert into t values (3,'2025-07-03 22:35:03.871', '2025-07-03 22:35:03.871');
+
+
+SET TIME ZONE 'UTC';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+
+insert into t values (4,'2025-07-03 23:35:03.871', '2025-07-03 23:35:03.871');
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+set duckdb.force_execution = on;
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+SET TIME ZONE 'Asia/Shanghai';
+select * from duckdb.query($$ SELECT * FROM duckdb_settings() WHERE name = 'TimeZone' $$) r;
+
+set duckdb.force_execution = off;
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+set duckdb.force_execution = on;
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+
+drop extension pg_duckdb;
+
+SET TIME ZONE 'UTC';
+SHOW TIME ZONE;
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+SET TIME ZONE 'Asia/Shanghai';
+SHOW TIME ZONE;
+
+SELECT * FROM t WHERE d IN (SELECT tz FROM t);
+
+drop table t;
+SET TIME ZONE DEFAULT;
+
+create extension pg_duckdb;


### PR DESCRIPTION
Inconsistent time zone  between Postgres and DuckDB can lead to   
unexpected results when performing some queries which use   
timestamptz data type. To avoid this, we should keep time zone  
same during execution.