### PR TITLE
Undo required changes for a PG18 commit that got reverted

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -52,12 +52,8 @@ jobs:
           type: ReleaseStatic
         - version: REL_17_STABLE
           type: Debug
-        - version: REL_18_BETA1
+        - version: REL_18_STABLE
           type: Release
-
-        # Not enabled for now (waiting for April 2025 code freeze)
-        # - version: master
-        #   type: Release
 
     runs-on: ubuntu-24.04
 

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -331,31 +331,18 @@ DuckdbExecutorStartHook_Cpp(QueryDesc *queryDesc) {
 	pgduckdb::ClaimCurrentCommandId();
 }
 
-#if PG_VERSION_NUM >= 180000
-static bool
-#else
 static void
-#endif
 DuckdbExecutorStartHook(QueryDesc *queryDesc, int eflags) {
 	pgduckdb::executor_nest_level++;
 	if (!pgduckdb::IsExtensionRegistered()) {
 		pgduckdb::MarkStatementNotTopLevel();
-		return prev_executor_start_hook(queryDesc, eflags);
+		prev_executor_start_hook(queryDesc, eflags);
+		return;
 	}
 
-#if PG_VERSION_NUM >= 180000
-	if (!prev_executor_start_hook(queryDesc, eflags)) {
-		return false;
-	}
-#else
 	prev_executor_start_hook(queryDesc, eflags);
-#endif
 
 	InvokeCPPFunc(DuckdbExecutorStartHook_Cpp, queryDesc);
-
-#if PG_VERSION_NUM >= 180000
-	return true;
-#endif
 }
 
 /*

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -65,13 +65,8 @@ PostgresTableReader::InitUnsafe(const char *table_scan_query, bool count_tuples_
 
 	PlannedStmt *planned_stmt = standard_planner(query, table_scan_query, 0, nullptr);
 
-#if PG_VERSION_NUM >= 180000
-	table_scan_query_desc = CreateQueryDesc(planned_stmt, nullptr, table_scan_query, GetActiveSnapshot(),
-	                                        InvalidSnapshot, None_Receiver, nullptr, nullptr, 0);
-#else
 	table_scan_query_desc = CreateQueryDesc(planned_stmt, table_scan_query, GetActiveSnapshot(), InvalidSnapshot,
 	                                        None_Receiver, nullptr, nullptr, 0);
-#endif
 
 	ExecutorStart(table_scan_query_desc, 0);
 


### PR DESCRIPTION
This makes pg_duckdb compile with the latest PG18 commit.
