### PR TITLE
Use duckdb column aliases for all top level duckdb subscripts

### DIFF
--- a/include/pgduckdb/pgduckdb_ruleutils.h
+++ b/include/pgduckdb/pgduckdb_ruleutils.h
@@ -22,7 +22,7 @@ bool pgduckdb_is_unresolved_type(Oid type_oid);
 bool pgduckdb_is_fake_type(Oid type_oid);
 bool pgduckdb_var_is_duckdb_row(Var *var);
 bool pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc);
-Var *pgduckdb_duckdb_row_subscript_var(Expr *expr);
+Var *pgduckdb_duckdb_subscript_var(Expr *expr);
 bool pgduckdb_reconstruct_star_step(StarReconstructionContext *ctx, ListCell *tle_cell);
 bool pgduckdb_replace_subquery_with_view(Query *query, StringInfo buf);
 int pgduckdb_show_type(Const *constval, int original_showtype);

--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -99,6 +99,27 @@ pgduckdb_is_fake_type(Oid type_oid) {
 }
 
 bool
+pgduckdb_is_duckdb_subscript_type(Oid type_oid) {
+	if (pgduckdb_is_unresolved_type(type_oid)) {
+		return true;
+	}
+
+	if (pgduckdb_is_duckdb_row(type_oid)) {
+		return true;
+	}
+
+	if (pgduckdb::DuckdbStructOid() == type_oid) {
+		return true;
+	}
+
+	if (pgduckdb::DuckdbMapOid() == type_oid) {
+		return true;
+	}
+
+	return false;
+}
+
+bool
 pgduckdb_var_is_duckdb_row(Var *var) {
 	if (!var) {
 		return false;
@@ -122,11 +143,11 @@ pgduckdb_func_returns_duckdb_row(RangeTblFunction *rtfunc) {
 }
 
 /*
- * Returns NULL if the expression is not a subscript on a duckdb row. Returns
- * the Var of the duckdb row if it is.
+ * Returns NULL if the expression is a subscript on a duckdb specific type.
+ * Returns the Var of the duckdb row if it is.
  */
 Var *
-pgduckdb_duckdb_row_subscript_var(Expr *expr) {
+pgduckdb_duckdb_subscript_var(Expr *expr) {
 	if (!expr) {
 		return NULL;
 	}
@@ -143,9 +164,10 @@ pgduckdb_duckdb_row_subscript_var(Expr *expr) {
 
 	Var *refexpr = (Var *)subscript->refexpr;
 
-	if (!pgduckdb_var_is_duckdb_row(refexpr)) {
+	if (!pgduckdb_is_duckdb_subscript_type(refexpr->vartype)) {
 		return NULL;
 	}
+
 	return refexpr;
 }
 

--- a/src/vendor/pg_ruleutils_14.c
+++ b/src/vendor/pg_ruleutils_14.c
@@ -6075,7 +6075,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_15.c
+++ b/src/vendor/pg_ruleutils_15.c
@@ -6156,7 +6156,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_16.c
+++ b/src/vendor/pg_ruleutils_16.c
@@ -6115,7 +6115,7 @@ get_target_list(List *targetList, deparse_context *context,
 			* to the column name are still valid.
 			*/
 		if (!duckdb_skip_as && outermost_targetlist) {
-				Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+				Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 				if (subscript_var) {
 						/*
 							* This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_17.c
+++ b/src/vendor/pg_ruleutils_17.c
@@ -6129,7 +6129,7 @@ get_target_list(List *targetList, deparse_context *context,
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/src/vendor/pg_ruleutils_18.c
+++ b/src/vendor/pg_ruleutils_18.c
@@ -6333,7 +6333,7 @@ get_target_list(List *targetList, deparse_context *context)
 		 * to the column name are still valid.
 		 */
 		if (!duckdb_skip_as && outermost_targetlist) {
-			Var *subscript_var = pgduckdb_duckdb_row_subscript_var(tle->expr);
+			Var *subscript_var = pgduckdb_duckdb_subscript_var(tle->expr);
 			if (subscript_var) {
 				/*
 				 * This cannot be moved to pgduckdb_ruleutils, because of

--- a/test/regression/expected/read_functions.out
+++ b/test/regression/expected/read_functions.out
@@ -41,9 +41,9 @@ SELECT jsoncol[1], arraycol[2] FROM (
     SELECT r['jsoncol'] jsoncol, r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
- jsoncol | arraycol 
----------+----------
- "d"     |       22
+ jsoncol[1] | arraycol[2] 
+------------+-------------
+ "d"        |          22
 (1 row)
 
 -- And the same for slice subscripts
@@ -57,8 +57,8 @@ SELECT arraycol[1:2] FROM (
     SELECT r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
- arraycol 
-----------
+ arraycol[1:2] 
+---------------
  {11,22}
 (1 row)
 
@@ -72,8 +72,8 @@ SELECT arraycol[:] FROM (
     SELECT r['arraycol'] arraycol
     FROM read_parquet('../../data/indexable.parquet') r
 ) q;
-  arraycol  
-------------
+ arraycol[:] 
+-------------
  {11,22,33}
 (1 row)
 


### PR DESCRIPTION
We were using the nicer duckdb aliases for top level subscripts for
`duckdb.row` subscripts, but now that we have other types it makes sense
to include it there too. We only do it for Postgres types so queries
using `duckdb.force_execution` still return the same column names.
