### PR TITLE
Disable `allow_stream_result` to force a materialized DuckDB execution results

### DIFF
--- a/include/pgduckdb/pgduckdb_hooks.hpp
+++ b/include/pgduckdb/pgduckdb_hooks.hpp
@@ -6,7 +6,7 @@ namespace pgduckdb {
 extern int64_t executor_nest_level;
 bool IsAllowedStatement(Query *query, bool throw_error = false);
 bool IsCatalogTable(Relation rel);
-bool ContainsPostgresTable(const Query *query);
+bool ContainsPostgresTable(Node *node, void *context);
 bool NeedsDuckdbExecution(Query *query);
 bool ShouldTryToUseDuckdbExecution(Query *query);
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_hooks.hpp
+++ b/include/pgduckdb/pgduckdb_hooks.hpp
@@ -6,6 +6,7 @@ namespace pgduckdb {
 extern int64_t executor_nest_level;
 bool IsAllowedStatement(Query *query, bool throw_error = false);
 bool IsCatalogTable(Relation rel);
+bool ContainsPostgresTable(const Query *query);
 bool NeedsDuckdbExecution(Query *query);
 bool ShouldTryToUseDuckdbExecution(Query *query);
 } // namespace pgduckdb

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -143,6 +143,20 @@ namespace pgduckdb {
 int64_t executor_nest_level = 0;
 
 bool
+ContainsPostgresTable(const Query *query) {
+	List *rtable = query->rtable;
+	foreach_node(RangeTblEntry, rte, rtable) {
+		if (rte->relid == InvalidOid) {
+			continue;
+		}
+		if (!::IsDuckdbTable(rte->relid)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool
 ShouldTryToUseDuckdbExecution(Query *query) {
 	if (top_level_duckdb_ddl_type == DDLType::REFRESH_MATERIALIZED_VIEW) {
 		/* When refreshing materialized views, we only want to use DuckDB

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/common/exception.hpp"
 
+#include "pgduckdb/pgduckdb_hooks.hpp"
 #include "pgduckdb/pgduckdb_planner.hpp"
 #include "pgduckdb/pgduckdb_types.hpp"
 #include "pgduckdb/vendor/pg_explain.hpp"
@@ -193,11 +194,12 @@ ExecuteQuery(DuckdbScanState *state) {
 		named_values[duckdb::to_string(i + 1)] = duckdb::BoundParameterData(duckdb_param);
 	}
 
-	// Always set `allow_stream_result` to false to force a fully materialized DuckDB result.
-	// This is required for cases like CTAS from a Postgres table, where allowing streaming results
-	// could lead to race conditions on Postgres resources.
+	// Set `allow_stream_result` to false if the query contains a Postgres table to force a fully materialized DuckDB
+	// result. This is required for cases like CTAS from a Postgres table, where allowing streaming results could lead
+	// to race conditions on Postgres resources.
 	// Checkout discussion: https://github.com/duckdb/pg_duckdb/discussions/866
-	auto pending = prepared.PendingQuery(named_values, false);
+	bool allow_stream_result = !pgduckdb::ContainsPostgresTable(state->query);
+	auto pending = prepared.PendingQuery(named_values, allow_stream_result);
 	if (pending->HasError()) {
 		return pending->ThrowError();
 	}

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -198,7 +198,7 @@ ExecuteQuery(DuckdbScanState *state) {
 	// result. This is required for cases like CTAS from a Postgres table, where allowing streaming results could lead
 	// to race conditions on Postgres resources.
 	// Checkout discussion: https://github.com/duckdb/pg_duckdb/discussions/866
-	bool allow_stream_result = !pgduckdb::ContainsPostgresTable(state->query);
+	bool allow_stream_result = !pgduckdb::ContainsPostgresTable((Node *)state->query, NULL);
 	auto pending = prepared.PendingQuery(named_values, allow_stream_result);
 	if (pending->HasError()) {
 		return pending->ThrowError();

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -193,7 +193,11 @@ ExecuteQuery(DuckdbScanState *state) {
 		named_values[duckdb::to_string(i + 1)] = duckdb::BoundParameterData(duckdb_param);
 	}
 
-	auto pending = prepared.PendingQuery(named_values, true);
+	// Always set `allow_stream_result` to false to force a fully materialized DuckDB result.
+	// This is required for cases like CTAS from a Postgres table, where allowing streaming results
+	// could lead to race conditions on Postgres resources.
+	// Checkout discussion: https://github.com/duckdb/pg_duckdb/discussions/866
+	auto pending = prepared.PendingQuery(named_values, false);
 	if (pending->HasError()) {
 		return pending->ThrowError();
 	}

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -422,8 +422,6 @@ PostgresScanGlobalState::PostgresScanGlobalState(Snapshot _snapshot, Relation _r
     : snapshot(_snapshot), rel(_rel), table_tuple_desc(RelationGetDescr(rel)), count_tuples_only(false),
       output_columns(), total_row_count(0), registered_local_states(0), scan_query(),
       table_reader_global_state(nullptr), duckdb_scan_memory_ctx(nullptr), max_threads(1) {
-	PostgresScopedStackReset scoped_stack_reset;
-	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	ConstructTableScanQuery(input);
 	table_reader_global_state = duckdb::make_shared_ptr<PostgresTableReader>();
 	table_reader_global_state->Init(scan_query.str().c_str(), count_tuples_only);
@@ -580,7 +578,6 @@ ScanSingleTuple(duckdb::DataChunk &output, PostgresScanLocalState &local_state) 
 void
 PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb::TableFunctionInput &data,
                                                 duckdb::DataChunk &output) {
-	PostgresScopedStackReset scoped_stack_reset;
 	auto &local_state = data.local_state->Cast<PostgresScanLocalState>();
 
 	/* We have exhausted table scan */

--- a/test/regression/expected/postgres_table_etl.out
+++ b/test/regression/expected/postgres_table_etl.out
@@ -1,4 +1,5 @@
 -- Prepare source table
+SET duckdb.force_execution = off;
 CREATE TABLE tbl (id int, d float, c text);
 INSERT INTO tbl SELECT i, 0.1, 'hello world' FROM generate_series(1, 1000000) i;
 -- do CTAS using duckdb

--- a/test/regression/expected/postgres_table_etl.out
+++ b/test/regression/expected/postgres_table_etl.out
@@ -1,0 +1,16 @@
+-- Prepare source table
+CREATE TABLE tbl (id int, d float, c text);
+INSERT INTO tbl SELECT i, 0.1, 'hello world' FROM generate_series(1, 1000000) i;
+-- do CTAS using duckdb
+SET duckdb.force_execution = on;
+SET duckdb.max_workers_per_postgres_scan = 0;
+SET duckdb.threads = 4;
+CREATE TABLE tbl2 AS SELECT * FROM tbl;
+SELECT count(*) FROM tbl2;
+  count  
+---------
+ 1000000
+(1 row)
+
+-- TODO: add case for INSERT INTO <dest> SELECT * FROM <src>
+DROP TABLE tbl, tbl2;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -55,3 +55,4 @@ test: union_functions
 test: unresolved_type
 test: views
 test: parallel_postgres_scan
+test: postgres_table_etl

--- a/test/regression/sql/postgres_table_etl.sql
+++ b/test/regression/sql/postgres_table_etl.sql
@@ -1,0 +1,15 @@
+
+-- Prepare source table
+CREATE TABLE tbl (id int, d float, c text);
+INSERT INTO tbl SELECT i, 0.1, 'hello world' FROM generate_series(1, 1000000) i;
+
+-- do CTAS using duckdb
+SET duckdb.force_execution = on;
+SET duckdb.max_workers_per_postgres_scan = 0;
+SET duckdb.threads = 4;
+CREATE TABLE tbl2 AS SELECT * FROM tbl;
+SELECT count(*) FROM tbl2;
+
+-- TODO: add case for INSERT INTO <dest> SELECT * FROM <src>
+
+DROP TABLE tbl, tbl2;

--- a/test/regression/sql/postgres_table_etl.sql
+++ b/test/regression/sql/postgres_table_etl.sql
@@ -1,5 +1,6 @@
 
 -- Prepare source table
+SET duckdb.force_execution = off;
 CREATE TABLE tbl (id int, d float, c text);
 INSERT INTO tbl SELECT i, 0.1, 'hello world' FROM generate_series(1, 1000000) i;
 


### PR DESCRIPTION
We don't correctly take the global Postgres lock in the main Postgres thread when fetching rows one by one from the chunks in `Duckdb_ExecCustomScan_Cpp`. Background threads might be calling postgres functions (while holding the lock), but the main thread never takes the lock so race conditions are bound to happen when that's the case. Fixing this requires some refactoring and careful testing. So for now we work around the issue by disallowing streaming results, which makes sure that the only the background threads will call Postgres functions, and the main thread will only continue running when all background threads are finished. 

Discussion: https://github.com/duckdb/pg_duckdb/discussions/866