### PR TITLE
Add GUC to allow DuckDB execution inside functions

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -5,6 +5,7 @@ void InitGUC();
 void InitGUCHooks();
 
 extern bool duckdb_force_execution;
+extern bool duckdb_unsafe_allow_execution_inside_functions;
 extern bool duckdb_unsafe_allow_mixed_transactions;
 extern bool duckdb_convert_unsupported_numeric_to_double;
 extern bool duckdb_log_pg_explain;

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -116,6 +116,7 @@ DefineCustomDuckDBVariable(const char *name, const char *short_desc, T *var, T m
 } // namespace
 
 bool duckdb_force_execution = false;
+bool duckdb_unsafe_allow_execution_inside_functions = false;
 bool duckdb_unsafe_allow_mixed_transactions = false;
 bool duckdb_convert_unsupported_numeric_to_double = false;
 bool duckdb_log_pg_explain = false;
@@ -142,6 +143,9 @@ void
 InitGUC() {
 	/* pg_duckdb specific GUCs */
 	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution);
+
+	DefineCustomVariable("duckdb.unsafe_allow_execution_inside_functions", "Allow DuckDB execution inside functions",
+	                     &duckdb_unsafe_allow_execution_inside_functions);
 
 	DefineCustomVariable("duckdb.unsafe_allow_mixed_transactions",
 	                     "Allow mixed transactions between DuckDB and Postgres",

--- a/src/pgduckdb_hooks.cpp
+++ b/src/pgduckdb_hooks.cpp
@@ -211,7 +211,7 @@ IsAllowedStatement(Query *query, bool throw_error) {
 		}
 	}
 
-	if (pgduckdb::executor_nest_level > 0) {
+	if (pgduckdb::executor_nest_level > 0 && !duckdb_unsafe_allow_execution_inside_functions) {
 		elog(elevel, "DuckDB execution is not supported inside functions");
 		return false;
 	}

--- a/test/regression/expected/transactions.out
+++ b/test/regression/expected/transactions.out
@@ -1,5 +1,6 @@
 -- For this test we duckdb set execution to false
 SET duckdb.force_execution = false;
+SET duckdb.unsafe_allow_execution_inside_functions = true;
 CREATE TABLE t(a int);
 INSERT INTO t VALUES (1);
 CREATE TEMP TABLE t_ddb(a int) USING duckdb;
@@ -117,9 +118,8 @@ $$;
 -- After executing the function the table should not contain the value 8,
 -- because that change was rolled back
 SELECT * FROM f(true);
-ERROR:  DuckDB execution is not supported inside functions
-CONTEXT:  SQL statement "INSERT INTO t_ddb VALUES (8)"
-PL/pgSQL function f(boolean) line 3 at SQL statement
+ERROR:  fail
+CONTEXT:  PL/pgSQL function f(boolean) line 5 at RAISE
 SELECT * FROM t_ddb ORDER BY a;
  a 
 ---
@@ -136,9 +136,11 @@ SELECT * FROM t_ddb ORDER BY a;
 
 -- But if the function succeeds we should see the new value
 SELECT * FROM f(false);
-ERROR:  DuckDB execution is not supported inside functions
-CONTEXT:  SQL statement "INSERT INTO t_ddb VALUES (8)"
-PL/pgSQL function f(boolean) line 3 at SQL statement
+ f 
+---
+ 
+(1 row)
+
 SELECT * FROM t_ddb ORDER BY a;
  a 
 ---
@@ -151,7 +153,8 @@ SELECT * FROM t_ddb ORDER BY a;
  5
  5
  6
-(9 rows)
+ 8
+(10 rows)
 
 -- DuckDB DDL in transactions is allowed
 BEGIN;
@@ -191,11 +194,12 @@ BEGIN
 END;
 $$;
 SELECT * FROM f2();
-ERROR:  DuckDB execution is not supported inside functions
-CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1"
-PL/pgSQL function f2() line 4 at SQL statement
+ f2 
+----
+ 
+(1 row)
+
 DROP TABLE t_ddb4;
-ERROR:  table "t_ddb4" does not exist
 -- ...unless there's also PG only changes happing in the same transaction (no matter the order of statements).
 BEGIN;
     CREATE TABLE t_x(a int);

--- a/test/regression/sql/transactions.sql
+++ b/test/regression/sql/transactions.sql
@@ -1,5 +1,6 @@
 -- For this test we duckdb set execution to false
 SET duckdb.force_execution = false;
+SET duckdb.unsafe_allow_execution_inside_functions = true;
 CREATE TABLE t(a int);
 INSERT INTO t VALUES (1);
 


### PR DESCRIPTION
DuckDB execution inside functions was disallowed in https://github.com/duckdb/pg_duckdb/pull/764 for good reason
However, some users depend on running analytics with pg_duckdb inside functions

Given that (1) the problematic cases are rare, and (2) pg_duckdb is mostly used for read queries, failures are limited to crashing the current session and can be recovered by restarting the session without data loss. This change introduces an unsafe GUC to restore this capability for users who need it