### PR TITLE
Add support for DuckDB MAP functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -20,6 +20,16 @@ Note: `ALTER EXTENSION pg_duckdb WITH SCHEMA schema` is not currently supported.
 
 All of the DuckDB [json functions and aggregates](https://duckdb.org/docs/data/json/json_functions.html). Postgres JSON/JSONB functions are not supported.
 
+## MAP Functions
+
+All of the DuckDB [map functions](https://duckdb.org/docs/sql/data_types/map.html#map-functions). These functions work with DuckDB's MAP data type.
+
+| Name | Description |
+| :--- | :---------- |
+| [`map_extract`](#map_extract) | Extract a value from a map using a key |
+| [`map_keys`](#map_keys) | Get all keys from a map as a list |
+| [`map_values`](#map_values) | Get all values from a map as a list |
+
 ## Aggregates
 
 |Name|Description|
@@ -327,3 +337,47 @@ CALL duckdb.force_motherduck_sync(drop_with_cascade := true);
 ```
 
 NOTE: Dropping with cascade will drop all objects that depend on the MotherDuck tables. This includes all views, functions, and tables that depend on the MotherDuck tables. This can be a destructive operation, so use with caution.
+
+#### <a name="map_extract"></a>`map_extract(map_col duckdb.map, key TEXT) -> duckdb.unresolved_type`
+
+Extracts a value from a map using the specified key. If the key doesn't exist, returns NULL.
+
+```sql
+SELECT map_extract(MAP(['a', 'b'], [1, 2]), 'a');  -- Returns 1
+SELECT map_extract(MAP(['a', 'b'], [1, 2]), 'c');  -- Returns NULL
+```
+
+##### Required Arguments
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| map_col | duckdb.map | The map to extract from |
+| key | text | The key to look up in the map |
+
+#### <a name="map_keys"></a>`map_keys(map_col duckdb.map) -> duckdb.unresolved_type`
+
+Returns all keys from a map as a list.
+
+```sql
+SELECT map_keys(MAP(['a', 'b', 'c'], [1, 2, 3]));  -- Returns ['a', 'b', 'c']
+```
+
+##### Required Arguments
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| map_col | duckdb.map | The map to extract keys from |
+
+#### <a name="map_values"></a>`map_values(map_col duckdb.map) -> duckdb.unresolved_type`
+
+Returns all values from a map as a list.
+
+```sql
+SELECT map_values(MAP(['a', 'b', 'c'], [1, 2, 3]));  -- Returns [1, 2, 3]
+```
+
+##### Required Arguments
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| map_col | duckdb.map | The map to extract values from |

--- a/pg_duckdb.control
+++ b/pg_duckdb.control
@@ -1,5 +1,5 @@
 comment = 'DuckDB Embedded in Postgres'
-default_version = '1.0.0'
+default_version = '1.1.0'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false
 schema = public

--- a/sql/pg_duckdb--1.0.0--1.1.0.sql
+++ b/sql/pg_duckdb--1.0.0--1.1.0.sql
@@ -1,0 +1,44 @@
+-- Add MAP functions support
+-- These functions are already implemented in DuckDB, we just need to expose them in Postgres
+
+-- map_extract function - extracts a value from a map using a key
+CREATE FUNCTION @extschema@.map_extract(map_col duckdb.map, key text)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+-- map_extract function with unresolved_type for flexibility
+CREATE FUNCTION @extschema@.map_extract(map_col duckdb.unresolved_type, key text)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+-- map_keys function - returns all keys from a map as a list
+CREATE FUNCTION @extschema@.map_keys(map_col duckdb.map)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+-- map_keys function with unresolved_type for flexibility
+CREATE FUNCTION @extschema@.map_keys(map_col duckdb.unresolved_type)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+-- map_values function - returns all values from a map as a list
+CREATE FUNCTION @extschema@.map_values(map_col duckdb.map)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;
+
+-- map_values function with unresolved_type for flexibility
+CREATE FUNCTION @extschema@.map_values(map_col duckdb.unresolved_type)
+RETURNS duckdb.unresolved_type
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'duckdb_only_function'
+LANGUAGE C;

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -177,7 +177,10 @@ BuildDuckdbOnlyFunctions() {
 	                                "make_timestamptz",
 	                                "time_bucket",
 	                                "union_extract",
-	                                "union_tag"};
+	                                "union_tag",
+	                                "map_extract",
+	                                "map_keys",
+	                                "map_values"};
 
 	for (uint32_t i = 0; i < lengthof(function_names); i++) {
 		CatCList *catlist = SearchSysCacheList1(PROCNAMEARGSNSP, CStringGetDatum(function_names[i]));

--- a/test/regression/expected/map_functions.out
+++ b/test/regression/expected/map_functions.out
@@ -1,0 +1,66 @@
+-- Test MAP functions
+-- These tests verify that the MAP functions are properly exposed and working
+-- Test map_extract function
+SELECT map_extract(r['map_col'], 'a') as extracted_value FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+ extracted_value 
+-----------------
+ {1}
+(1 row)
+
+SELECT map_extract(r['map_col'], 'd') as missing_key FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+ missing_key 
+-------------
+ {}
+(1 row)
+
+SELECT map_extract(r['map_col'], 'key1') as string_value FROM duckdb.query($$ SELECT MAP(['key1', 'key2'], ['value1', 'value2']) as map_col $$) r;
+ string_value 
+--------------
+ {value1}
+(1 row)
+
+-- Test map_keys function
+SELECT map_keys(r['map_col']) as keys FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+  keys   
+---------
+ {a,b,c}
+(1 row)
+
+SELECT map_keys(r['map_col']) as empty_keys FROM duckdb.query($$ SELECT MAP([], []) as map_col $$) r;
+ empty_keys 
+------------
+ {}
+(1 row)
+
+-- Test map_values function
+SELECT map_values(r['map_col']) as values FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+ values  
+---------
+ {1,2,3}
+(1 row)
+
+SELECT map_values(r['map_col']) as empty_values FROM duckdb.query($$ SELECT MAP([], []) as map_col $$) r;
+ empty_values 
+--------------
+ {}
+(1 row)
+
+-- Test with unresolved_type for flexibility
+SELECT map_extract(r['map_col']::duckdb.unresolved_type, 'x') as flexible_extract FROM duckdb.query($$ SELECT MAP(['x', 'y'], [10, 20]) as map_col $$) r;
+ flexible_extract 
+------------------
+ {10}
+(1 row)
+
+SELECT map_keys(r['map_col']::duckdb.unresolved_type) as flexible_keys FROM duckdb.query($$ SELECT MAP(['p', 'q'], [100, 200]) as map_col $$) r;
+ flexible_keys 
+---------------
+ {p,q}
+(1 row)
+
+SELECT map_values(r['map_col']::duckdb.unresolved_type) as flexible_values FROM duckdb.query($$ SELECT MAP(['m', 'n'], [1000, 2000]) as map_col $$) r;
+ flexible_values 
+-----------------
+ {1000,2000}
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -52,6 +52,7 @@ test: transaction_isolation
 test: transactions
 test: type_support
 test: union_functions
+test: map_functions
 test: unresolved_type
 test: views
 test: parallel_postgres_scan

--- a/test/regression/sql/map_functions.sql
+++ b/test/regression/sql/map_functions.sql
@@ -1,0 +1,20 @@
+-- Test MAP functions
+-- These tests verify that the MAP functions are properly exposed and working
+
+-- Test map_extract function
+SELECT map_extract(r['map_col'], 'a') as extracted_value FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+SELECT map_extract(r['map_col'], 'd') as missing_key FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+SELECT map_extract(r['map_col'], 'key1') as string_value FROM duckdb.query($$ SELECT MAP(['key1', 'key2'], ['value1', 'value2']) as map_col $$) r;
+
+-- Test map_keys function
+SELECT map_keys(r['map_col']) as keys FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+SELECT map_keys(r['map_col']) as empty_keys FROM duckdb.query($$ SELECT MAP([], []) as map_col $$) r;
+
+-- Test map_values function
+SELECT map_values(r['map_col']) as values FROM duckdb.query($$ SELECT MAP(['a', 'b', 'c'], [1, 2, 3]) as map_col $$) r;
+SELECT map_values(r['map_col']) as empty_values FROM duckdb.query($$ SELECT MAP([], []) as map_col $$) r;
+
+-- Test with unresolved_type for flexibility
+SELECT map_extract(r['map_col']::duckdb.unresolved_type, 'x') as flexible_extract FROM duckdb.query($$ SELECT MAP(['x', 'y'], [10, 20]) as map_col $$) r;
+SELECT map_keys(r['map_col']::duckdb.unresolved_type) as flexible_keys FROM duckdb.query($$ SELECT MAP(['p', 'q'], [100, 200]) as map_col $$) r;
+SELECT map_values(r['map_col']::duckdb.unresolved_type) as flexible_values FROM duckdb.query($$ SELECT MAP(['m', 'n'], [1000, 2000]) as map_col $$) r;


### PR DESCRIPTION
- Add map_extract, map_keys, and map_values functions
- Create migration file pg_duckdb--1.0.0--1.1.0.sql
- Update metadata cache to recognize MAP functions
- Add comprehensive tests with edge cases
- Update documentation with usage examples
- Bump version to 1.1.0

Closes #774