### PR TITLE
Pass CXX_EXTRA=-fvisibility=default to duckdb submodule (#890)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DUCKDB_GEN ?= ninja
 # used to know what version of extensions to download
 DUCKDB_VERSION = v1.3.2
 # duckdb build tweaks
-DUCKDB_CMAKE_VARS = -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
+DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 # set to 1 to disable asserts in DuckDB. This is particularly useful in combinition with MotherDuck.
 # When asserts are enabled the released motherduck extension will fail some of
 # those asserts. By disabling asserts it's possible to run a debug build of


### PR DESCRIPTION
Add extra parameter `CXX_EXTRA=-fvisibility=default` in Makefile to pass it to `pg_duckdb/third_party/duckdb/CMakeLists.txt` without duckdb submodule modification.

Fixes https://github.com/duckdb/pg_duckdb/issues/890