### PR TITLE
Use empty collation by default

### DIFF
--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -136,7 +136,7 @@ bool duckdb_autoload_known_extensions = true;
 char *duckdb_temporary_directory = MakeDirName("temp");
 char *duckdb_extension_directory = MakeDirName("extensions");
 char *duckdb_max_temp_directory_size = strdup("");
-char *duckdb_default_collation = strdup("C");
+char *duckdb_default_collation = strdup("");
 
 void
 InitGUC() {


### PR DESCRIPTION
Specifying `C` or `BINARY` as the `default_collation` causes duckdb to
disable various optimizations. Arguably that's a bug, but to work around
that, we now leave the default empty.

Resolves #898 