### PR TITLE
Add support for azure transport option type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add support for MotherDuck views. You can now create views inside MotherDuck and query views that are already stored in MotherDuck. ([#822])
 - Add support for Postgres 18 Release Candidate 1. Since Postgres 18 has not had a final release yet, this is still considered an experimental feature. ([#788])
 - Add support for UUIDs in prepared statement arguments. ([#863])
+- Add `duckdb.azure_transport_option_type` setting to configure Azure extension transport options, which can be used to workaround [issue #882](https://github.com/duckdb/pg_duckdb/issues/882). ([#910])
 
 ## Changed
 
@@ -148,6 +149,7 @@
 [#872]: https://github.com/duckdb/pg_duckdb/pull/872
 [#877]: https://github.com/duckdb/pg_duckdb/pull/877
 [#863]: https://github.com/duckdb/pg_duckdb/pull/863
+[#910]: https://github.com/duckdb/pg_duckdb/pull/910
 
 # 0.3.1 (2025-02-13)
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -72,6 +72,13 @@ Allows DuckDB to access external resources (e.g., HTTP, S3). This setting is not
 - **Default**: `true`
 - **Access**: Superuser-only
 
+### `duckdb.azure_transport_option_type`
+
+Sets the azure_transport_option_type for DuckDB Azure extension. Can be used to workaround [issue #882](https://github.com/duckdb/pg_duckdb/issues/882) by setting it to `'curl'`. Only affects connections when the Azure extension is loaded.
+
+- **Default**: `""` (empty string)
+- **Access**: Superuser-only
+
 ## Resource Management
 
 Since any connection that uses DuckDB will have its own DuckDB instance, these settings are per-connection. When using `pg_duckdb` in many concurrent connections, it can be a good idea to set some of these more conservatively than their defaults.

--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -26,4 +26,5 @@ extern char *duckdb_temporary_directory;
 extern char *duckdb_extension_directory;
 extern char *duckdb_max_temp_directory_size;
 extern char *duckdb_default_collation;
+extern char *duckdb_azure_transport_option_type;
 } // namespace pgduckdb

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -294,6 +294,12 @@ DuckDBManager::RefreshConnectionState(duckdb::ClientContext &context) {
 		                                          duckdb::KeywordHelper::WriteQuoted(disabled_filesystems));
 	}
 
+	if (strlen(duckdb_azure_transport_option_type) > 0) {
+		pgduckdb::DuckDBQueryOrThrow(context,
+		                             "SET azure_transport_option_type=" +
+		                                 duckdb::KeywordHelper::WriteQuoted(duckdb_azure_transport_option_type));
+	}
+
 	const auto extensions_table_last_seq = GetSeqLastValue("extensions_table_seq");
 	if (IsExtensionsSeqLessThan(extensions_table_last_seq)) {
 		LoadExtensions(context);

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -139,6 +139,7 @@ char *duckdb_temporary_directory = MakeDirName("temp");
 char *duckdb_extension_directory = MakeDirName("extensions");
 char *duckdb_max_temp_directory_size = strdup("");
 char *duckdb_default_collation = strdup("");
+char *duckdb_azure_transport_option_type = strdup("");
 
 void
 InitGUC() {
@@ -235,6 +236,11 @@ InitGUC() {
 	DefineCustomDuckDBVariable("duckdb.disabled_filesystems",
 	                           "Disable specific file systems preventing access (e.g., LocalFileSystem)",
 	                           &duckdb_disabled_filesystems, PGC_SUSET);
+
+	DefineCustomDuckDBVariable("duckdb.azure_transport_option_type",
+	                           "Set the azure_transport_option_type for DuckDB Azure extension. Can be used to "
+	                           "workaround issue #882: https://github.com/duckdb/pg_duckdb/issues/882",
+	                           &duckdb_azure_transport_option_type, PGC_SUSET);
 }
 
 #if PG_VERSION_NUM < 160000


### PR DESCRIPTION
In issue #882 the fix for the problem turned out to be configurnig a specific duckdb-azure extension setting. This exposes that setting in pg_duckdb to make it easier to do so.
