### PR TITLE
Fix crash during background worker shutdown

### DIFF
--- a/include/pgduckdb/pgduckdb_duckdb.hpp
+++ b/include/pgduckdb/pgduckdb_duckdb.hpp
@@ -51,7 +51,7 @@ public:
 		return *database;
 	}
 
-	void Reset();
+	static void Reset();
 
 private:
 	DuckDBManager()

--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -234,6 +234,9 @@ BgwMainLoop() {
 		ResetLatch(MyLatch);
 	}
 
+	ddb_connection.reset();
+	DuckDBManager::Reset();
+
 	elog(LOG, "pg_duckdb background worker for database '%s' (%u) has now terminated.", db_name, MyDatabaseId);
 }
 

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -211,9 +211,9 @@ DuckDBManager::LoadFunctions(duckdb::ClientContext &context) {
 
 void
 DuckDBManager::Reset() {
-	connection = nullptr;
-	delete database;
-	database = nullptr;
+	manager_instance.connection = nullptr;
+	delete manager_instance.database;
+	manager_instance.database = nullptr;
 	UnclaimBgwSessionHint();
 }
 

--- a/src/pgduckdb_metadata_cache.cpp
+++ b/src/pgduckdb_metadata_cache.cpp
@@ -283,7 +283,7 @@ IsExtensionRegistered() {
 		 * like a good moment to clean that up if that's the case.
 		 */
 		if (pgduckdb::DuckDBManager::IsInitialized()) {
-			pgduckdb::DuckDBManager::Get().Reset();
+			pgduckdb::DuckDBManager::Reset();
 		}
 		elog(DEBUG1, "pgduckdb: extension is not registered in database '%s'", get_database_name(MyDatabaseId));
 	}

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -255,7 +255,7 @@ DECLARE_PG_FUNCTION(pgduckdb_recycle_ddb) {
 	 * violate our assumptions about DuckDB its transaction lifecycle
 	 */
 	pgduckdb::pg::PreventInTransactionBlock("duckdb.recycle_ddb()");
-	pgduckdb::DuckDBManager::Get().Reset();
+	pgduckdb::DuckDBManager::Reset();
 	PG_RETURN_BOOL(true);
 }
 


### PR DESCRIPTION
When users would disable MotherDuck it was possible for the background worker to crash due to cleanup of the global connection object happening too late. This explicitly cleans up the connection and the database before the background worker exits.
