### PR TITLE
Group and sort Python imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ norecursedirs = [
 
 [tool.ruff]
 extend-exclude = ["third_party"]
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/scripts/tpch/run.py
+++ b/scripts/tpch/run.py
@@ -8,17 +8,18 @@
 # ]
 # ///
 import argparse
+import csv
+import os
+import shlex
 import subprocess
 import sys
-import shlex
-import os
-import pandas as pd
-import matplotlib.pyplot as plt
 import time
-import csv
-import psycopg
 from contextlib import contextmanager
 from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import psycopg
 
 
 def eprint(*args, **kwargs):

--- a/test/pycheck/conftest.py
+++ b/test/pycheck/conftest.py
@@ -1,9 +1,10 @@
 import os
-import pytest
-import psycopg.errors
 
-from .utils import Postgres, Duckdb, make_new_duckdb_connection
+import psycopg.errors
+import pytest
+
 from .motherduck_token_helper import create_test_user
+from .utils import Duckdb, Postgres, make_new_duckdb_connection
 
 
 @pytest.fixture(scope="session")

--- a/test/pycheck/copy_test.py
+++ b/test/pycheck/copy_test.py
@@ -1,9 +1,10 @@
-from .utils import Cursor
-
-import pytest
-import psycopg.errors
-from pathlib import Path
 import json
+from pathlib import Path
+
+import psycopg.errors
+import pytest
+
+from .utils import Cursor
 
 
 def test_copy_to_local(cur: Cursor, tmp_path: Path):

--- a/test/pycheck/encoding_test.py
+++ b/test/pycheck/encoding_test.py
@@ -1,7 +1,7 @@
-from .utils import Cursor, Postgres
-
-import pytest
 import psycopg
+import pytest
+
+from .utils import Cursor, Postgres
 
 
 def test_non_utf8_encoding(pg: Postgres, cur: Cursor):

--- a/test/pycheck/explain_test.py
+++ b/test/pycheck/explain_test.py
@@ -6,10 +6,10 @@ contains timings, so the output is not deterministic.
 
 import json
 
-from .utils import Cursor
-
-import pytest
 import psycopg.errors
+import pytest
+
+from .utils import Cursor
 
 
 def test_explain(cur: Cursor):

--- a/test/pycheck/extension_test.py
+++ b/test/pycheck/extension_test.py
@@ -1,10 +1,10 @@
 import shutil
 
-from .utils import Cursor, Postgres
-
-import pytest
 import psycopg.errors
 import psycopg.sql
+import pytest
+
+from .utils import Cursor, Postgres
 
 
 def test_autoinstall_known_extensions(pg: Postgres, cur: Cursor):

--- a/test/pycheck/motherduck_test.py
+++ b/test/pycheck/motherduck_test.py
@@ -7,21 +7,20 @@ library for that purpose.
 """
 
 import datetime
-import duckdb
 import uuid
+from contextlib import suppress
 
-from .utils import wait_until, Cursor, Postgres, Duckdb, PG_MAJOR_VERSION
+import duckdb
+import psycopg.errors
+import pytest
+
 from .motherduck_token_helper import (
     can_run_md_multi_user_tests,
     can_run_md_tests,
     create_read_scaling_token,
 )
 from .multi_duckdb_helper import MDClient
-from contextlib import suppress
-
-import pytest
-import psycopg.errors
-
+from .utils import PG_MAJOR_VERSION, Cursor, Duckdb, Postgres, wait_until
 
 if not can_run_md_tests():
     pytestmark = pytest.mark.skip(reason="Skipping all motherduck tests")

--- a/test/pycheck/motherduck_token_helper.py
+++ b/test/pycheck/motherduck_token_helper.py
@@ -1,6 +1,6 @@
-from urllib.request import urlopen, Request
 import json
 import os
+from urllib.request import Request, urlopen
 
 # Remove any normal user token from the environment so that we don't
 # accidentally use it.

--- a/test/pycheck/multi_duckdb_helper.py
+++ b/test/pycheck/multi_duckdb_helper.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
-from threading import Thread
 from queue import Queue
+from threading import Thread
 
 from .motherduck_token_helper import create_test_user
 from .utils import make_new_duckdb_connection

--- a/test/pycheck/non_superuser_test.py
+++ b/test/pycheck/non_superuser_test.py
@@ -1,8 +1,8 @@
-from .utils import Postgres
-
-import pytest
 import psycopg.errors
 import psycopg.sql
+import pytest
+
+from .utils import Postgres
 
 
 def test_community_extensions(pg: Postgres):

--- a/test/pycheck/prepared_test.py
+++ b/test/pycheck/prepared_test.py
@@ -1,9 +1,10 @@
-from .utils import Cursor, Connection
-
 import datetime
+import uuid
+
 import psycopg.types.json
 import pytest
-import uuid
+
+from .utils import Connection, Cursor
 
 
 def test_prepared(cur: Cursor):

--- a/test/pycheck/temporary_table_test.py
+++ b/test/pycheck/temporary_table_test.py
@@ -1,7 +1,7 @@
-from .utils import Cursor, PG_MAJOR_VERSION
-
-import pytest
 import psycopg.errors
+import pytest
+
+from .utils import PG_MAJOR_VERSION, Cursor
 
 
 def test_temporary_table_alter_table(cur: Cursor):

--- a/test/pycheck/utils.py
+++ b/test/pycheck/utils.py
@@ -1,26 +1,24 @@
-import subprocess
-from contextlib import closing, contextmanager, asynccontextmanager, suppress
-from pathlib import Path
-
 import asyncio
 import os
 import platform
 import re
 import shlex
 import socket
+import subprocess
 import sys
 import time
 import typing
-from typing import Any
+from contextlib import asynccontextmanager, closing, contextmanager, suppress
+from pathlib import Path
 from tempfile import gettempdir
-
-import filelock
-import psycopg
-import psycopg.sql
-import psycopg.conninfo
-from psycopg import sql
+from typing import Any
 
 import duckdb
+import filelock
+import psycopg
+import psycopg.conninfo
+import psycopg.sql
+from psycopg import sql
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 os.chdir(TEST_DIR)


### PR DESCRIPTION
Group and sort Python imports in accordance with [PEP 8](https://peps.python.org/pep-0008/#imports) (Style Guide for Python Code).