### PR TITLE
Detect unsupported Postgres types in more cases

### DIFF
--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -30,6 +30,7 @@ const duckdb::date_t PGDUCKDB_PG_MAX_DATE_VALUE = duckdb::Date::FromDate(PG_MAXY
 constexpr int64_t PGDUCKDB_MAX_TIMESTAMP_VALUE = 9223371244800000000;
 constexpr int64_t PGDUCKDB_MIN_TIMESTAMP_VALUE = -210866803200000000;
 
+void CheckForUnsupportedPostgresType(duckdb::LogicalType type);
 duckdb::LogicalType ConvertPostgresToDuckColumnType(Form_pg_attribute &attribute);
 Oid GetPostgresDuckDBType(const duckdb::LogicalType &type, bool throw_error = false);
 int32_t GetPostgresDuckDBTypemod(const duckdb::LogicalType &type);

--- a/include/pgduckdb/pgduckdb_unsupported_type_optimizer.hpp
+++ b/include/pgduckdb/pgduckdb_unsupported_type_optimizer.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace pgduckdb {
+
+class UnsupportedTypeOptimizer : public duckdb::LogicalOperatorVisitor {
+public:
+	//! Override VisitExpression to check for unsupported types
+	void VisitExpression(duckdb::unique_ptr<duckdb::Expression> *expression) override;
+
+	//! Get the optimizer extension to register with DuckDB
+	static duckdb::OptimizerExtension GetOptimizerExtension();
+
+private:
+	//! Check if an expression contains UnsupportedPostgresType
+	void CheckExpressionForUnsupportedTypes(duckdb::Expression &expr);
+
+	//! The main optimize function called by DuckDB
+	static void OptimizeFunction(duckdb::OptimizerExtensionInput &input,
+	                             duckdb::unique_ptr<duckdb::LogicalOperator> &plan);
+};
+
+} // namespace pgduckdb

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -55,7 +55,7 @@ CreatePlan(Query *query, bool throw_error) {
 	duckdb::unique_ptr<duckdb::PreparedStatement> prepared_query = DuckdbPrepare(query);
 
 	if (prepared_query->HasError()) {
-		elog(elevel, "(PGDuckDB/CreatePlan) Prepared query returned an error: '%s", prepared_query->GetError().c_str());
+		elog(elevel, "(PGDuckDB/CreatePlan) Prepared query returned an error: %s", prepared_query->GetError().c_str());
 		return nullptr;
 	}
 

--- a/src/pgduckdb_unsupported_type_optimizer.cpp
+++ b/src/pgduckdb_unsupported_type_optimizer.cpp
@@ -1,0 +1,45 @@
+#include "pgduckdb/pgduckdb_unsupported_type_optimizer.hpp"
+#include "pgduckdb/pgduckdb_types.hpp"
+
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/extension_type_info.hpp"
+
+extern "C" {
+#include "postgres.h"
+#include "utils/elog.h"
+}
+
+namespace pgduckdb {
+
+void
+UnsupportedTypeOptimizer::VisitExpression(duckdb::unique_ptr<duckdb::Expression> *expression) {
+	if (*expression) {
+		CheckExpressionForUnsupportedTypes(**expression);
+	}
+
+	// Call parent implementation to continue traversal
+	LogicalOperatorVisitor::VisitExpression(expression);
+}
+
+void
+UnsupportedTypeOptimizer::CheckExpressionForUnsupportedTypes(duckdb::Expression &expr) {
+	CheckForUnsupportedPostgresType(expr.return_type);
+}
+
+void
+UnsupportedTypeOptimizer::OptimizeFunction(duckdb::OptimizerExtensionInput & /* input */,
+                                           duckdb::unique_ptr<duckdb::LogicalOperator> &plan) {
+	UnsupportedTypeOptimizer visitor;
+	visitor.VisitOperator(*plan);
+}
+
+duckdb::OptimizerExtension
+UnsupportedTypeOptimizer::GetOptimizerExtension() {
+	duckdb::OptimizerExtension extension;
+	extension.optimize_function = OptimizeFunction;
+	return extension;
+}
+
+} // namespace pgduckdb

--- a/test/regression/expected/array_type_support.out
+++ b/test/regression/expected/array_type_support.out
@@ -308,7 +308,7 @@ INSERT INTO numeric_array_1d SELECT CAST(a as NUMERIC[]) FROM (VALUES
     ('{}')
 ) t(a);
 SELECT * FROM numeric_array_1d;
-WARNING:  Unsupported Postgres type: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Unsupported PostgreSQL type found in query: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
          a          
 --------------------
  {1.1,2.2,3.3}
@@ -596,7 +596,7 @@ INSERT INTO numeric_array_2d VALUES
     ('{}'),
     ('{{11.1,12.2},{NULL,14.4}}');
 SELECT * FROM numeric_array_2d;
-WARNING:  Unsupported Postgres type: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Unsupported PostgreSQL type found in query: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
                a                
 --------------------------------
  {{1.1,2.2},{3.3,4.4}}

--- a/test/regression/expected/domain.out
+++ b/test/regression/expected/domain.out
@@ -19,7 +19,7 @@ INSERT INTO basictest values ('88', 'haha', 'short', '123.1212');    -- Truncate
 -- not support. It will be converted to the following statement
 -- SELECT ('-5'::integer)::domainint4 AS domainint4 FROM pgduckdb.xxx.basictest
 SELECT (-5)::domainint4 FROM basictest;
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Type with name domainint4 does not exist!
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Type with name domainint4 does not exist!
 Did you mean "tinyint"?
 ERROR:  value for domain domainint4 violates check constraint "domainint4_check"
 select * from basictest;

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -11,7 +11,7 @@ LINE 1:  SELECT (a)::integer AS a FROM pgduckdb.public.int_as_varchar
 DROP TABLE int_as_varchar;
 \set VERBOSITY verbose
 select * from duckdb.raw_query('aaaaa');
-WARNING:  01000: (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Table Function with name raw_query does not exist!
+WARNING:  01000: (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name raw_query does not exist!
 Did you mean "main.pragma_user_agent"?
 
 LINE 1: SELECT raw_query FROM duckdb.raw_query('aaaaa'::text) raw_query(raw_query)

--- a/test/regression/expected/issue_730.out
+++ b/test/regression/expected/issue_730.out
@@ -18,7 +18,7 @@ BEGIN
 END;
 $$;
 SELECT * FROM f2();
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Table Function with name f2 does not exist!
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name f2 does not exist!
 Did you mean "sniff_csv"?
 
 LINE 1: SELECT f2 FROM f2() f2(f2)
@@ -27,7 +27,7 @@ ERROR:  DuckDB execution is not supported inside functions
 CONTEXT:  SQL statement "CREATE TEMP TABLE t_ddb3(a) USING duckdb AS SELECT 1"
 PL/pgSQL function f2() line 4 at SQL statement
 SELECT * FROM f2();
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Table Function with name f2 does not exist!
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name f2 does not exist!
 Did you mean "sniff_csv"?
 
 LINE 1: SELECT f2 FROM f2() f2(f2)

--- a/test/regression/expected/issue_749.out
+++ b/test/regression/expected/issue_749.out
@@ -7,7 +7,7 @@ SET duckdb.force_execution = true;
 -- This command used to crash due to DuckDB returning data in the json
 -- format instead of in jsonb format.
 SELECT * FROM ROWS FROM(get_users()) WITH ORDINALITY;
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: WITH ORDINALITY not implemented
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: WITH ORDINALITY not implemented
     data    | ordinality 
 ------------+------------
  {"a": 123} |          1

--- a/test/regression/expected/json_functions_duckdb.out
+++ b/test/regression/expected/json_functions_duckdb.out
@@ -35,7 +35,7 @@ SELECT json_exists('{"a": {"b": 1}}', '$.a.c') FROM duckdb.query($$ SELECT 1 $$)
 -- the query anymore. We should probably serialize this to the json type when
 -- we build the query.
 SELECT public.json_exists('{"a": {"b": 1}}'::jsonb, '$.a.c');
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Type with name jsonb does not exist!
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Type with name jsonb does not exist!
 Did you mean "blob"?
 -- </JSON_EXISTS>
 -- <JSON_EXTRACT>

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -29,7 +29,7 @@ ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Executor Error: (PGDuckDB/Init) permis
 SET duckdb.force_execution = true;
 -- read_csv from the local filesystem should be disallowed
 SELECT count(r['sepal.length']) FROM read_csv('../../data/iris.csv') r;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Permission Error: File system LocalFileSystem has been disabled by configuration
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Permission Error: File system LocalFileSystem has been disabled by configuration
 CALL duckdb.recycle_ddb();
 -- It's allowed for users with pg_read_server_files and pg_write_server_files.
 SET ROLE user4;
@@ -72,14 +72,14 @@ SELECT * FROM t;
 -- Should fall back to PG execution, because we don't support RLS
 SET ROLE user1;
 SELECT * FROM t;
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
  a 
 ---
 (0 rows)
 
 -- Should fail because we require duckdb execution so no fallback
 SELECT public.approx_count_distinct(a) FROM t;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.raw_query($$ SELECT * FROM pgduckdb.public.t $$);
 ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it

--- a/test/regression/expected/read_functions.out
+++ b/test/regression/expected/read_functions.out
@@ -356,7 +356,7 @@ SELECT r['sepal.length'], r['filename']
 (5 rows)
 
 SELECT * FROM read_csv('../../non-existing-file.csv');
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'IO Error: No files found that match the pattern "../../non-existing-file.csv"
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: IO Error: No files found that match the pattern "../../non-existing-file.csv"
 -- We override Postgres its default column name for subscript expressions. In
 -- the following example the column would normally be named "r", which is
 -- pretty non-descriptive especially when selecting multiple columns from the

--- a/test/regression/expected/temporary_tables.out
+++ b/test/regression/expected/temporary_tables.out
@@ -165,7 +165,7 @@ CREATE TEMP TABLE t(a int) WITH (fillfactor = 50);
 ERROR:  Storage options are not supported in DuckDB
 -- Should fail because user should specify the precision of the NUMERIC.
 CREATE TEMP TABLE large_numeric_tbl (a NUMERIC) USING duckdb;
-ERROR:  (PGDuckDB/duckdb_create_table_trigger_cpp) Not implemented Error: Unsupported Postgres type: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
+ERROR:  (PGDuckDB/duckdb_create_table_trigger_cpp) Not implemented Error: Unsupported PostgreSQL type found in query: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
 -- But it's fine if the user specifies the precision
 CREATE TEMP TABLE large_numeric_tbl_specified (a NUMERIC(38,20)) USING duckdb;
 -- CTAS is fine though, it will use duckdb its default

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -326,14 +326,23 @@ INSERT INTO numeric_as_double SELECT a FROM (VALUES
     (NULL),
     (458234502034234234234.000012)
 ) t(a);
+-- Should fail
 SELECT * FROM numeric_as_double;
-WARNING:  Unsupported Postgres type: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Unsupported PostgreSQL type found in query: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
               a               
 ------------------------------
                   0.234234234
                              
  458234502034234234234.000012
 (3 rows)
+
+-- Expressions involving such columns should also fail
+SELECT 'yes' FROM numeric_as_double WHERE a > 10;
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Unsupported PostgreSQL type found in query: DuckDB requires the precision of a NUMERIC to be set. You can choose to convert these NUMERICs to a DOUBLE by using 'SET duckdb.convert_unsupported_numeric_to_double = true'
+ ?column? 
+----------
+ yes
+(1 row)
 
 SET duckdb.convert_unsupported_numeric_to_double = true;
 SELECT * FROM numeric_as_double;

--- a/test/regression/expected/unresolved_type.out
+++ b/test/regression/expected/unresolved_type.out
@@ -39,13 +39,13 @@ select r['a'] NOT ILIKE '%X%' from duckdb.query($$ SELECT 'abc' a $$) r;
 -- Currently not working, we need to add the similar_to_escape function to
 -- DuckDB to make this work.
 select r['a'] SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Scalar Function with name similar_to_escape does not exist!
 Did you mean "list_sem"?
 
 LINE 1: SELECT (r.a ~ similar_to_escape('%b%'::text)) AS "?column?" FROM system...
                       ^
 select r['a'] NOT SIMILAR TO '%b%' from duckdb.query($$ SELECT 'abc' a $$) r;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: 'Catalog Error: Scalar Function with name similar_to_escape does not exist!
+ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Scalar Function with name similar_to_escape does not exist!
 Did you mean "list_sem"?
 
 LINE 1: SELECT (r.a !~ similar_to_escape('%b%'::text)) AS "?column?" FROM system...

--- a/test/regression/sql/type_support.sql
+++ b/test/regression/sql/type_support.sql
@@ -144,7 +144,10 @@ INSERT INTO numeric_as_double SELECT a FROM (VALUES
     (NULL),
     (458234502034234234234.000012)
 ) t(a);
+-- Should fail
 SELECT * FROM numeric_as_double;
+-- Expressions involving such columns should also fail
+SELECT 'yes' FROM numeric_as_double WHERE a > 10;
 SET duckdb.convert_unsupported_numeric_to_double = true;
 SELECT * FROM numeric_as_double;
 RESET duckdb.convert_unsupported_numeric_to_double;


### PR DESCRIPTION
Previously we would throw an error when a query returned an unsupported Postgres type (for instance a too wide decimal). Turns out this was not enough, because these types could also be used in a query without being returned from them. With the previous implementation this would cause DuckDB internal errors. With this change we do a final pass over the optimized query plan to see if any expressions use such an unsupported type, and error there too.

In passing this also removes an unintended `'` character from an error message.

Fixes #917
