### PR TITLE
Fix: Avoid duplicate 'LocalFileSystem' in duckdb_disabled_filesystems

### DIFF
--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -272,6 +272,15 @@ DisabledFileSystems() {
 		return "LocalFileSystem";
 	}
 
+	/* Ensure LocalFileSystem is added only when it's absent from duckdb_disabled_filesystems. */
+	std::vector<std::string> fs_list = duckdb::StringUtil::Split(duckdb_disabled_filesystems, ',');
+	for (auto &fs : fs_list) {
+		std::string trimmed_fs = fs;
+		duckdb::StringUtil::Trim(trimmed_fs);
+		if (duckdb::StringUtil::CIEquals(trimmed_fs, "LocalFileSystem")) {
+			return duckdb_disabled_filesystems;
+		}
+	}
 	return "LocalFileSystem," + std::string(duckdb_disabled_filesystems);
 }
 

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -112,7 +112,31 @@ SELECT * FROM duckdb.install_extension('iceberg');
 
 TRUNCATE duckdb.extensions;
 SET duckdb.force_execution = true;
+-- Test Issue #931
 RESET ROLE;
+CALL duckdb.recycle_ddb();
+ALTER SYSTEM SET duckdb.disabled_filesystems = 'LocalFileSystem';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+CREATE USER admin_user IN ROLE duckdb_group;
+SET ROLE admin_user;
+CREATE TEMP TABLE duckdb_tbl (id int) USING DUCKDB;
+DROP TABLE duckdb_tbl;
+-- Cleanup
+RESET ROLE;
+CALL duckdb.recycle_ddb();
+ALTER SYSTEM SET duckdb.disabled_filesystems = '';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+DROP USER admin_user;
 DROP TABLE t;
 DROP OWNED BY user1;
 DROP USER user1, user2, user3;

--- a/test/regression/sql/non_superuser.sql
+++ b/test/regression/sql/non_superuser.sql
@@ -89,7 +89,22 @@ SELECT * FROM duckdb.install_extension('iceberg');
 TRUNCATE duckdb.extensions;
 SET duckdb.force_execution = true;
 
+-- Test Issue #931
 RESET ROLE;
+CALL duckdb.recycle_ddb();
+ALTER SYSTEM SET duckdb.disabled_filesystems = 'LocalFileSystem';
+SELECT pg_reload_conf();
+CREATE USER admin_user IN ROLE duckdb_group;
+SET ROLE admin_user;
+CREATE TEMP TABLE duckdb_tbl (id int) USING DUCKDB;
+DROP TABLE duckdb_tbl;
+
+-- Cleanup
+RESET ROLE;
+CALL duckdb.recycle_ddb();
+ALTER SYSTEM SET duckdb.disabled_filesystems = '';
+SELECT pg_reload_conf();
+DROP USER admin_user;
 DROP TABLE t;
 DROP OWNED BY user1;
 DROP USER user1, user2, user3;


### PR DESCRIPTION
Ensures 'LocalFileSystem' is added only if not already present in the disabled filesystems list, resolving the error that blocked pg_duckdb usage for admin roles.