### PR TITLE
Fix crash in timezone assign hook

### DIFF
--- a/test/regression/expected/issue_975.out
+++ b/test/regression/expected/issue_975.out
@@ -1,0 +1,11 @@
+-- Initialize duckdb in this session
+SELECT * FROM duckdb.query($$ SELECT 1 $$);
+ 1 
+---
+ 1
+(1 row)
+
+-- Have the timezone change be rolled back at the end transaction
+BEGIN;
+SET TimeZone TO 'UTC';
+ROLLBACK;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -29,6 +29,7 @@ test: issue_789
 test: issue_796
 test: issue_802
 test: issue_813
+test: issue_975
 test: json_functions_duckdb
 test: materialized_view
 test: non_superuser

--- a/test/regression/sql/issue_975.sql
+++ b/test/regression/sql/issue_975.sql
@@ -1,0 +1,6 @@
+-- Initialize duckdb in this session
+SELECT * FROM duckdb.query($$ SELECT 1 $$);
+-- Have the timezone change be rolled back at the end transaction
+BEGIN;
+SET TimeZone TO 'UTC';
+ROLLBACK;


### PR DESCRIPTION
The timezone assign hook could sometimes be run outside of a
Postgres transaction context and this would then cause a crash. This
fixes that.

Fixes #975
Fixes #938
