### PR TITLE
Mark duckdb.force_execution as GUC_REPORT for PgBouncer integration

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,7 +6,7 @@
 
 ### `duckdb.force_execution`
 
-Forces queries to use DuckDB execution. This is only necessary when accessing only Postgres tables in a query. As soon as you use a DuckDB-only feature, DuckDB execution will be used automatically. DuckDB-only features include reading from DuckDB/MotherDuck tables, using DuckDB functions (like `read_parquet`), or `COPY` to remote storage (e.g., `s3://`).
+Forces queries to use DuckDB execution. This is only necessary when accessing only Postgres tables in a query. As soon as you use a DuckDB-only feature, DuckDB execution will be used automatically. DuckDB-only features include reading from DuckDB/MotherDuck tables, using DuckDB functions (like `read_parquet`), or `COPY` to remote storage (e.g., `s3://`). If you use PgBouncer you can add this setting to `track_extra_parameters` to make sure that PgBouncer correctly syncs this value across server connections based on what the client has set it to.
 
 - **Default**: `false`
 - **Access**: General

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -145,7 +145,8 @@ char *duckdb_azure_transport_option_type = strdup("");
 void
 InitGUC() {
 	/* pg_duckdb specific GUCs */
-	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution);
+	DefineCustomVariable("duckdb.force_execution", "Force queries to use DuckDB execution", &duckdb_force_execution,
+	                     PGC_USERSET, GUC_REPORT);
 
 	DefineCustomVariable("duckdb.unsafe_allow_execution_inside_functions", "Allow DuckDB execution inside functions",
 	                     &duckdb_unsafe_allow_execution_inside_functions, PGC_SUSET);


### PR DESCRIPTION
PgBonucer in transaction pooling mode only syncs certain settings by
default across connections. You can choose to sync more but that
currently requires some cooperation from that specific setting: It needs
to be marked as `GUC_REPORT`. Since `duckdb.force_excution` heavily
changes how queries get executed it's pretty important that it's not set
to unexpected values. So we set `GUC_REPORT` for this setting and
explain how to configure PgBouncer correctly.
