### PR TITLE
Add mixed rw and read-only support in the same database

### DIFF
--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -20,6 +20,7 @@
 #include "pgduckdb/pgduckdb_utils.hpp"
 #include "pgduckdb/pg/relations.hpp"
 #include "pgduckdb/utility/cpp_wrapper.hpp"
+#include "pgduckdb/pg/string_utils.hpp"
 #include <string>
 #include <unordered_map>
 #include <sys/file.h>
@@ -1001,15 +1002,10 @@ DropRelation(const char *fully_qualified_table, char relation_kind, bool drop_wi
  */
 static bool
 GrantAccessToSchema(const char *postgres_schema_name) {
-	if (pgduckdb::MotherDuckPostgresUserOid() == BOOTSTRAP_SUPERUSERID) {
-		/*
-		 * We don't need to grant access to the bootstrap superuser. It already
-		 * has every access it might need.
-		 */
-		return true;
-	}
-
-	/* Grant access to the schema to the duckdb user on the tables */
+	/*
+	 * Grant full access to the schema to the motherduck postgres user so that
+	 * it can create and drop the tables.
+	 */
 	const char *grant_query = psprintf("GRANT ALL ON SCHEMA %s TO %s", quote_identifier(postgres_schema_name),
 	                                   quote_identifier(MotherDuckPostgresUserName()));
 	if (!SPI_run_utility_command(grant_query)) {
@@ -1018,6 +1014,25 @@ GrantAccessToSchema(const char *postgres_schema_name) {
 		         errdetail("While executing command: %s", grant_query), errhint("See previous WARNING for details")));
 		return false;
 	}
+
+	/*
+	 * Grant USAGE on the schema to duckdb.postgres_role so that members of
+	 * that role can SELECT from the synced tables. The MotherDuckPostgresUser
+	 * owns the tables, but regular users who are members of duckdb.postgres_role
+	 * need USAGE on the schema to access them.
+	 */
+	if (!IsEmptyString(duckdb_postgres_role) && !AreStringEqual(duckdb_postgres_role, MotherDuckPostgresUserName())) {
+		grant_query = psprintf("GRANT USAGE ON SCHEMA %s TO %s", quote_identifier(postgres_schema_name),
+		                       quote_identifier(duckdb_postgres_role));
+		if (!SPI_run_utility_command(grant_query)) {
+			ereport(WARNING, (errmsg("Failed to grant USAGE on MotherDuck schema %s to %s", postgres_schema_name,
+			                         duckdb_postgres_role),
+			                  errdetail("While executing command: %s", grant_query),
+			                  errhint("See previous WARNING for details")));
+			return false;
+		}
+	}
+
 	return true;
 }
 

--- a/test/pycheck/motherduck_token_helper.py
+++ b/test/pycheck/motherduck_token_helper.py
@@ -61,7 +61,7 @@ def create_test_user():
     user = make_request(
         uri="/tuc/createTestUser",
         headers={"Content-Type": "application/json"},
-        data_json={"token": token},
+        data_json={"token": token, "region": "aws-us-east-1"},
     )
     print(f"Created user with email='{user['testEmail']}' and id='{user['id']}'")
     return user


### PR DESCRIPTION
With this change we add support for different users using different
tokens within the same Postgres database.

Resolves #829
Resolves #711 