### PR TITLE
Allow reading from Postgres tables with RLS

### DIFF
--- a/src/pg/relations.cpp
+++ b/src/pg/relations.cpp
@@ -82,12 +82,6 @@ ExecStoreMinimalTupleUnsafe(MinimalTuple minmal_tuple, TupleTableSlot *slot, boo
 
 Relation
 OpenRelation(Oid relationId) {
-	if (PostgresFunctionGuard(check_enable_rls, relationId, InvalidOid, false) == RLS_ENABLED) {
-		throw duckdb::NotImplementedException(
-		    "Cannot use \"%s\" relation in a DuckDB query, because RLS is enabled on it",
-		    PostgresFunctionGuard(get_rel_name, relationId));
-	}
-
 	/*
 	 * We always open & close the relation using the
 	 * TopTransactionResourceOwner to avoid having to close the relation

--- a/src/utility/copy.cpp
+++ b/src/utility/copy.cpp
@@ -56,16 +56,6 @@ AppendCreateRelationCopyString(StringInfo info, ParseState *pstate, CopyStmt *co
 
 	table_close(rel, AccessShareLock);
 
-	/*
-	 * RLS for relation. We should probably bail out at this point.
-	 */
-	if (check_enable_rls(relid, InvalidOid, false) == RLS_ENABLED) {
-		ereport(ERROR,
-		        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		         errmsg("(PGDuckDB/CreateRelationCopyString) RLS enabled on \"%s\", cannot use DuckDB based COPY",
-		                RelationGetRelationName(rel))));
-	}
-
 	appendStringInfoString(info, pgduckdb_relation_name(relid));
 	if (!copy_stmt->attlist) {
 		return;

--- a/test/regression/expected/non_superuser.out
+++ b/test/regression/expected/non_superuser.out
@@ -65,27 +65,42 @@ SELECT * FROM t;
 SET duckdb.force_execution = true;
 -- Let's add RLS
 RESET ROLE;
+INSERT INTO t VALUES (1), (2), (3);
 ALTER TABLE t ENABLE ROW LEVEL SECURITY;
--- Should still be allowed, we're superuser
+CREATE POLICY t_policy ON t FOR SELECT USING (a <= 2);
+-- Should still see all rows, superusers bypass RLS
 SELECT * FROM t;
  a 
 ---
-(0 rows)
+ 1
+ 2
+ 3
+(3 rows)
 
--- Should fall back to PG execution, because we don't support RLS
+-- Should only see rows where a <= 2 due to RLS policy
 SET ROLE user1;
 SELECT * FROM t;
-WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
  a 
 ---
-(0 rows)
+ 1
+ 2
+(2 rows)
 
--- Should fail because we require duckdb execution so no fallback
-SELECT public.approx_count_distinct(a) FROM t;
-ERROR:  (PGDuckDB/CreatePlan) Prepared query returned an error: Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
+-- Should also enforce RLS via raw_query
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.raw_query($$ SELECT * FROM pgduckdb.public.t $$);
-ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Not implemented Error: Cannot use "t" relation in a DuckDB query, because RLS is enabled on it
+NOTICE:  result: a	
+INTEGER	
+[ Rows: 2]
+1
+2
+
+
+ raw_query 
+-----------
+ 
+(1 row)
+
 SET duckdb.force_execution = true;
 -- Extension installation
 SET duckdb.force_execution = false;

--- a/test/regression/sql/non_superuser.sql
+++ b/test/regression/sql/non_superuser.sql
@@ -48,17 +48,17 @@ SET duckdb.force_execution = true;
 
 -- Let's add RLS
 RESET ROLE;
+INSERT INTO t VALUES (1), (2), (3);
 ALTER TABLE t ENABLE ROW LEVEL SECURITY;
--- Should still be allowed, we're superuser
+CREATE POLICY t_policy ON t FOR SELECT USING (a <= 2);
+-- Should still see all rows, superusers bypass RLS
 SELECT * FROM t;
 
--- Should fall back to PG execution, because we don't support RLS
+-- Should only see rows where a <= 2 due to RLS policy
 SET ROLE user1;
 SELECT * FROM t;
 
--- Should fail because we require duckdb execution so no fallback
-SELECT public.approx_count_distinct(a) FROM t;
-
+-- Should also enforce RLS via raw_query
 SET duckdb.force_execution = false;
 SELECT * FROM duckdb.raw_query($$ SELECT * FROM pgduckdb.public.t $$);
 SET duckdb.force_execution = true;


### PR DESCRIPTION
A long time ago when we were using custom code to to read data from
Postgres tables we disallowed reading from tables with RLS enabled,
because we did not honor the RLS rules. Now that we go through Postgres
its normal SPI API to read data from tables there's no need for that
anymore.
