### PR TITLE
Fix a backwards compatibility issue with 1.0.0 create_simple_secret

### DIFF
--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -55,6 +55,9 @@ ReadOptions(FunctionCallInfo fcinfo, int start, const std::vector<std::string> &
 	std::ostringstream oss;
 	int opt_idx = start;
 	for (const auto &name : names) {
+		if (opt_idx >= PG_NARGS()) {
+			break;
+		}
 		auto value = GetArgString(fcinfo, opt_idx++);
 		if (value.empty()) {
 			continue;

--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -225,6 +225,27 @@ SELECT duckdb.create_simple_secret('GCS', 'my third key', 'my secret'); -- No se
 -- Invalid
 SELECT duckdb.create_simple_secret('BadType', '-', '-');
 ERROR:  Invalid type 'BadType': this helper only supports 's3', 'gcs' or 'r2'. Please refer to the documentation to create advanced secrets.
+-- Test backwards compatibility with 1.0.0 SQL signature (9 parameters instead of 11)
+CREATE FUNCTION create_simple_secret_v1_0_0(
+    type          TEXT,
+    key_id        TEXT,
+    secret        TEXT,
+    session_token TEXT DEFAULT '',
+    region        TEXT DEFAULT '',
+    url_style     TEXT DEFAULT '',
+    provider      TEXT DEFAULT '',
+    endpoint      TEXT DEFAULT '',
+    scope         TEXT DEFAULT ''
+)
+RETURNS TEXT
+LANGUAGE C AS 'pg_duckdb', 'pgduckdb_create_simple_secret';
+SELECT create_simple_secret_v1_0_0('S3', 'compat-key', 'compat-secret', '', 'us-west-2');
+ create_simple_secret_v1_0_0 
+-----------------------------
+ simple_s3_secret_4
+(1 row)
+
+DROP FUNCTION create_simple_secret_v1_0_0;
 -- 2. Azure
 SELECT duckdb.create_azure_secret('hello world', scope := 'az://myaccount.blob.core.windows.net/');
  create_azure_secret 
@@ -237,20 +258,22 @@ SELECT fs.srvname, fs.srvtype, fs.srvoptions, um.umoptions
 FROM pg_foreign_server fs
 INNER JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 LEFT JOIN pg_user_mapping um ON um.umserver = fs.oid
-WHERE fdw.fdwname = 'duckdb' AND fs.srvtype != 'motherduck';
+WHERE fdw.fdwname = 'duckdb' AND fs.srvtype != 'motherduck'
+ORDER BY fs.srvname;
        srvname       | srvtype |                                                srvoptions                                                 |                                  umoptions                                  
 ---------------------+---------+-----------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------
+ azure_secret        | azure   | {scope=az://myaccount.blob.core.windows.net/}                                                             | {"connection_string=hello world"}
+ simple_gcs_secret   | GCS     | {region=my-region-42}                                                                                     | {"key_id=my first key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_1 | GCS     |                                                                                                           | {"key_id=my other key","secret=my secret","session_token=my session token"}
+ simple_gcs_secret_2 | GCS     |                                                                                                           | {"key_id=my third key","secret=my secret"}
+ simple_r2_secret    | R2      | {region=my-region-42}                                                                                     | {"key_id=my r2 key1","secret=my secret","session_token=my session token"}
+ simple_r2_secret_1  | R2      |                                                                                                           | {"key_id=my r2 key2","secret=my secret"}
  simple_s3_secret    | S3      | {region=my-region-42}                                                                                     | {"key_id=my first key","secret=my secret","session_token=my session token"}
  simple_s3_secret_1  | S3      |                                                                                                           | {"key_id=my other key","secret=my secret","session_token=my session token"}
  simple_s3_secret_2  | S3      |                                                                                                           | {"key_id=my third key","secret=my secret"}
  simple_s3_secret_3  | S3      | {url_style=true,provider=credential_chain,endpoint=my_other_endoint,scope=s3://my-bucket,validation=none} | {"key_id=my named key","secret=a better secret",session_token=foo}
- simple_r2_secret    | R2      | {region=my-region-42}                                                                                     | {"key_id=my r2 key1","secret=my secret","session_token=my session token"}
- simple_r2_secret_1  | R2      |                                                                                                           | {"key_id=my r2 key2","secret=my secret"}
- simple_gcs_secret   | GCS     | {region=my-region-42}                                                                                     | {"key_id=my first key","secret=my secret","session_token=my session token"}
- simple_gcs_secret_1 | GCS     |                                                                                                           | {"key_id=my other key","secret=my secret","session_token=my session token"}
- simple_gcs_secret_2 | GCS     |                                                                                                           | {"key_id=my third key","secret=my secret"}
- azure_secret        | azure   | {scope=az://myaccount.blob.core.windows.net/}                                                             | {"connection_string=hello world"}
-(10 rows)
+ simple_s3_secret_4  | S3      | {region=us-west-2}                                                                                        | {key_id=compat-key,secret=compat-secret}
+(11 rows)
 
 SELECT * FROM duckdb.query($$
     SELECT
@@ -287,7 +310,8 @@ $$);
  pgduckdb_secret_simple_s3_secret_1  | s3    | my other key |              | redacted      | redacted | 
  pgduckdb_secret_simple_s3_secret_2  | s3    | my third key |              |               | redacted | 
  pgduckdb_secret_simple_s3_secret_3  | s3    | my named key | us-east-1    | redacted      | redacted | 
-(10 rows)
+ pgduckdb_secret_simple_s3_secret_4  | s3    | compat-key   | us-west-2    |               | redacted | 
+(11 rows)
 
 set client_min_messages=WARNING; -- suppress NOTICE that include username
 DROP SERVER
@@ -295,6 +319,7 @@ DROP SERVER
     simple_s3_secret_1,
     simple_s3_secret_2,
     simple_s3_secret_3,
+    simple_s3_secret_4,
     simple_r2_secret,
     simple_r2_secret_1,
     simple_gcs_secret,

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -24,4 +24,4 @@ LINE 1: aaaaa
 
 LINE 1: aaaaa
         ^
-LOCATION:  pgduckdb_raw_query_cpp, pgduckdb_options.cpp:77
+LOCATION:  pgduckdb_raw_query_cpp, pgduckdb_options.cpp:80


### PR DESCRIPTION
For 1.1.0 we added some additional parameters to the
create_simple_secret function. The C++ code was not compatible anymore
with the 1.0.0 definitions of the SQL definition. So, if people wouldn't
upgrade their SQL part of the extension using:

```sql
ALTER EXTENSION pg_duckdb UPDATE
```

Then they would be getting an error like this:

```
ERROR:  XX000: (PGDuckDB/pgduckdb_create_simple_secret_cpp) Invalid Input Error: argument 9 is required
LOCATION:  pgduckdb_create_simple_secret_cpp, pgduckdb_options.cpp:145
```

This fixes that and adds a regression test to avoid breaking it in the
future.
