### PR TITLE
Don't sync motherduck views without supported columns

### DIFF
--- a/src/pgduckdb_background_worker.cpp
+++ b/src/pgduckdb_background_worker.cpp
@@ -625,6 +625,12 @@ CreatePgViewString(duckdb::CreateViewInfo &info, bool is_default_db) {
 		oss << " AS " << duckdb::KeywordHelper::WriteQuoted(*it_names, '"');
 	}
 
+	if (first) {
+		elog(WARNING, "Skipping view %s.%s.%s because none of its columns had supported types", info.catalog.c_str(),
+		     info.schema.c_str(), info.view_name.c_str());
+		return "";
+	}
+
 	oss << " FROM duckdb.view(";
 	oss << duckdb::KeywordHelper::WriteQuoted(info.catalog) << ", ";
 	oss << duckdb::KeywordHelper::WriteQuoted(info.schema) << ", ";


### PR DESCRIPTION
There was a bug where if a motherduck view only contained tables that
were not supported by pg_duckdb, then we would generate an invalid
postgres query to create the view.

This simply skips creating such views.
