### PR TITLE
chore: upgrade to debian 13

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && \
     postgresql-server-dev-${POSTGRES_VERSION} \
     build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev \
     libssl-dev libxml2-utils xsltproc pkg-config libc++-dev libc++abi-dev libglib2.0-dev \
-    libtinfo5 cmake libstdc++-12-dev liblz4-dev ccache ninja-build git libcurl4-openssl-dev && \
+    libtinfo6 cmake libstdc++-12-dev liblz4-dev ccache ninja-build git libcurl4-openssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ target "postgres" {
   inherits = ["shared"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:${POSTGRES_VERSION}-bookworm"
+    postgres_base = "docker-image://postgres:${POSTGRES_VERSION}-trixie"
   }
 
   args = {


### PR DESCRIPTION
### Chores
- Upgrade Debian 12 to 13
- Let Dependabot update docker-compose, github-actions and gitsubmodule
