### PR TITLE
Automatically set the module version based on git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: duckdb install-duckdb clean-duckdb clean-all lintcheck check-regression-duckdb clean-regression
 
+PG_DUCKDB_VERSION ?= $(shell git describe --always --dirty 2>/dev/null || echo "unknown")
+
 MODULE_big = pg_duckdb
 EXTENSION = pg_duckdb
 DATA = pg_duckdb.control $(wildcard sql/pg_duckdb--*.sql)
@@ -83,6 +85,10 @@ override PG_CFLAGS += -Wno-declaration-after-statement
 SHLIB_LINK += $(PG_DUCKDB_LINK_FLAGS)
 
 include Makefile.global
+
+# Only pass the version define to the one file that needs it, so that ccache
+# doesn't invalidate everything on every commit.
+src/pgduckdb.o: PG_CPPFLAGS += -DPG_DUCKDB_VERSION="\"$(PG_DUCKDB_VERSION)\""
 
 # We need the DuckDB header files to build our own .o files. We depend on the
 # duckdb submodule HEAD, because that target pulls in the submodule which

--- a/src/pgduckdb.cpp
+++ b/src/pgduckdb.cpp
@@ -15,7 +15,12 @@ extern "C" {
 extern "C" {
 
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "pg_duckdb", .version = "1.0.0");
+#ifndef PG_DUCKDB_VERSION
+// Should always be defined via build system, but keep a fallback here for
+// static analysis tools etc.
+#define PG_DUCKDB_VERSION "unknown"
+#endif
+PG_MODULE_MAGIC_EXT(.name = "pg_duckdb", .version = PG_DUCKDB_VERSION);
 #else
 PG_MODULE_MAGIC;
 #endif


### PR DESCRIPTION
In the last two releases I forgot to update the version number in
`PG_MODULE_MAGIC_EXT`. This stars assigning this version the value
reported by git describe. Without having committed these changes, that
looks like this:
```
> select * from pg_get_loaded_modules();
 module_name │         version          │  file_name
─────────────┼──────────────────────────┼──────────────
 pg_duckdb   │ v1.1.1-3-gc7c8fd1d-dirty │ pg_duckdb.so
```

For tagged releases it will be a plain version number, like `v1.1.2`.

Related to #993
