### PR TITLE
Remove pgxman from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,6 @@ hydra
 
 ### Package Managers
 
-**pgxman (apt):**
-```bash
-pgxman install pg_duckdb
-```
-
 **Compile from source:**
 
 ```bash


### PR DESCRIPTION
It's not kept up to date anymore. We can add it back when that happens
again.

Fixes #944
