### PR TITLE
Bump DuckDB to v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.2 (2026-02-03)
+
+## Changed
+
+- Update to DuckDB v1.4.4.
+
 # 1.1.1 (2025-12-16)
 
 ## Changed

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS += $(subst .c,.o, $(C_SRCS))
 # set to `make` to disable ninja
 DUCKDB_GEN ?= ninja
 # used to know what version of extensions to download
-DUCKDB_VERSION = v1.4.3
+DUCKDB_VERSION = v1.4.4
 # duckdb build tweaks
 DUCKDB_CMAKE_VARS = -DCXX_EXTRA=-fvisibility=default -DBUILD_SHELL=0 -DBUILD_PYTHON=0 -DBUILD_UNITTESTS=0
 # set to 1 to disable asserts in DuckDB. This is particularly useful in combinition with MotherDuck.

--- a/test/pycheck/non_superuser_test.py
+++ b/test/pycheck/non_superuser_test.py
@@ -21,23 +21,15 @@ def test_community_extensions(pg: Postgres):
                 "SELECT * FROM duckdb.raw_query($$ INSTALL prql FROM community; $$)"
             )
 
-    # Even if such community extensions somehow get installed, it's not possible
-    # to load them without changing allow_community_extensions. Not even for a
-    # superuser.
+    # Community extensions are unsigned by default and should not install unless
+    # unsigned extensions are explicitly allowed.
     with pg.cur() as cur:
         cur.sql("SET duckdb.force_execution = false")
-        cur.sql("SELECT * FROM duckdb.raw_query($$ INSTALL prql FROM community; $$)")
         with pytest.raises(
-            Exception,
-            match="IO Error: Extension .* could not be loaded because its signature is either missing or invalid and unsigned extensions are disabled by configuration",
+            psycopg.errors.InternalError,
+            match="IO Error: Attempting to install an extension file that doesn't have a valid signature",
         ):
-            cur.sql("SELECT * FROM duckdb.raw_query($$ LOAD prql; $$)")
-
-    # But it should be possible to load them after changing that setting.
-    with pg.cur() as cur:
-        cur.sql("SET duckdb.allow_community_extensions = true")
-        cur.sql("SET duckdb.force_execution = false")
-        cur.sql("SELECT * FROM duckdb.raw_query($$ LOAD prql; $$)")
+            cur.sql("SELECT * FROM duckdb.raw_query($$ INSTALL prql FROM community; $$)")
 
     # And that setting is only changeable by superusers
     with pg.cur() as cur:

--- a/test/pycheck/non_superuser_test.py
+++ b/test/pycheck/non_superuser_test.py
@@ -29,7 +29,9 @@ def test_community_extensions(pg: Postgres):
             psycopg.errors.InternalError,
             match="IO Error: Attempting to install an extension file that doesn't have a valid signature",
         ):
-            cur.sql("SELECT * FROM duckdb.raw_query($$ INSTALL prql FROM community; $$)")
+            cur.sql(
+                "SELECT * FROM duckdb.raw_query($$ INSTALL prql FROM community; $$)"
+            )
 
     # And that setting is only changeable by superusers
     with pg.cur() as cur:

--- a/test/regression/expected/duckdb_views.out
+++ b/test/regression/expected/duckdb_views.out
@@ -4,6 +4,9 @@ CREATE USER duckdb_view_user1 IN ROLE duckdb_group;
 SET ROLE duckdb_view_admin;
 CREATE VIEW duckdb_view AS SELECT r['a']::int as a FROM duckdb.query($$ SELECT 1 a $$) r;
 CREATE VIEW postgres_view AS SELECT 2 from generate_series(1,2);
+CREATE TABLE postgres_table (x int);
+INSERT INTO postgres_table VALUES (2), (2);
+INSERT 0 2
 SET ROLE duckdb_view_user1;
 SELECT * from duckdb_view;
 ERROR:  permission denied for view duckdb_view
@@ -11,11 +14,12 @@ SELECT * from postgres_view;
 ERROR:  permission denied for view postgres_view
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
 ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/Init) permission denied for view duckdb_view
-SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_view $$);
-ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/Init) permission denied for view postgres_view
+SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);
+ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/Init) permission denied for table postgres_table
 SET ROLE duckdb_view_admin;
 GRANT SELECT ON duckdb_view TO duckdb_view_user1;
 GRANT SELECT ON postgres_view TO duckdb_view_user1;
+GRANT SELECT ON postgres_table TO duckdb_view_user1;
 SET ROLE duckdb_view_user1;
 SELECT * from duckdb_view;
  a 
@@ -32,10 +36,9 @@ SELECT * from postgres_view;
 
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
 ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/GetNextTuple) Function 'duckdb.query' only works with DuckDB execution
-SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_view $$);
- ?column? 
-----------
-        2
-        2
+SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);
+ x 
+---
+ 2
+ 2
 (2 rows)
-

--- a/test/regression/expected/duckdb_views.out
+++ b/test/regression/expected/duckdb_views.out
@@ -33,6 +33,7 @@ SELECT * from postgres_view;
         2
 (2 rows)
 
+
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
 ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/GetNextTuple) Function 'duckdb.query' only works with DuckDB execution
 SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);

--- a/test/regression/expected/duckdb_views.out
+++ b/test/regression/expected/duckdb_views.out
@@ -33,7 +33,6 @@ SELECT * from postgres_view;
         2
 (2 rows)
 
-
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
 ERROR:  (PGDuckDB/Duckdb_ExecCustomScan_Cpp) Executor Error: (PGDuckDB/GetNextTuple) Function 'duckdb.query' only works with DuckDB execution
 SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);
@@ -42,3 +41,4 @@ SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);
  2
  2
 (2 rows)
+

--- a/test/regression/expected/duckdb_views.out
+++ b/test/regression/expected/duckdb_views.out
@@ -6,7 +6,6 @@ CREATE VIEW duckdb_view AS SELECT r['a']::int as a FROM duckdb.query($$ SELECT 1
 CREATE VIEW postgres_view AS SELECT 2 from generate_series(1,2);
 CREATE TABLE postgres_table (x int);
 INSERT INTO postgres_table VALUES (2), (2);
-INSERT 0 2
 SET ROLE duckdb_view_user1;
 SELECT * from duckdb_view;
 ERROR:  permission denied for view duckdb_view

--- a/test/regression/expected/extensions.out
+++ b/test/regression/expected/extensions.out
@@ -1,4 +1,5 @@
 DROP EXTENSION pg_duckdb CASCADE;
+NOTICE:  drop cascades to view duckdb_view
 CREATE EXTENSION pg_duckdb;
 SET duckdb.force_execution TO false;
 SET duckdb.allow_community_extensions = true;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -15,6 +15,7 @@ test: domain
 test: duckdb_only_functions
 test: duckdb_recycle
 test: duckdb_secrets
+test: duckdb_views
 test: execution_error
 test: extensions
 test: foreign_data_wrapper

--- a/test/regression/sql/duckdb_views.sql
+++ b/test/regression/sql/duckdb_views.sql
@@ -6,20 +6,23 @@ SET ROLE duckdb_view_admin;
 
 CREATE VIEW duckdb_view AS SELECT r['a']::int as a FROM duckdb.query($$ SELECT 1 a $$) r;
 CREATE VIEW postgres_view AS SELECT 2 from generate_series(1,2);
+CREATE TABLE postgres_table (x int);
+INSERT INTO postgres_table VALUES (2), (2);
 
 SET ROLE duckdb_view_user1;
 
 SELECT * from duckdb_view;
 SELECT * from postgres_view;
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
-SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_view $$);
+SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);
 
 SET ROLE duckdb_view_admin;
 GRANT SELECT ON duckdb_view TO duckdb_view_user1;
 GRANT SELECT ON postgres_view TO duckdb_view_user1;
+GRANT SELECT ON postgres_table TO duckdb_view_user1;
 SET ROLE duckdb_view_user1;
 
 SELECT * from duckdb_view;
 SELECT * from postgres_view;
 SELECT * from duckdb.query($$ FROM pgduckdb.public.duckdb_view $$);
-SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_view $$);
+SELECT * from duckdb.query($$ FROM pgduckdb.public.postgres_table $$);

--- a/third_party/pg_duckdb_extensions.cmake
+++ b/third_party/pg_duckdb_extensions.cmake
@@ -2,5 +2,5 @@ duckdb_extension_load(json)
 duckdb_extension_load(icu)
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 9c7d34977b10346d0b4cbbde5df807d1dab0b2bf
+    GIT_TAG 13f8a814d41a978c3f19eb1dc76069489652ea6f
 )


### PR DESCRIPTION
## Summary
- bump DuckDB to v1.4.4 and align httpfs extension pin
- 1.4.4 blocks installing unsigned community extensions, so `INSTALL prql FROM community` now fails at install time. Updated `non_superuser_test.py` to expect that error instead of a later load-time failure.
- duckdb_views existed under `test/regression/sql` but wasn’t in `test/regression/schedule`, so schedule-check failed. I added it, and then updated extensions.out to include the new NOTICE: “drop cascades to view duckdb_view”.
- add changelog entry

## Testing
- docker: `make check-regression-duckdb`
- docker: `pytest -n auto`
- docker: `./scripts/schedule-check.sh`