### PR TITLE
Update docker-compose volume to /var/lib/postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${PASSWORD:-duckdb}
     volumes:
-      - pgduckdb_data:/var/lib/postgresql/data
+      - pgduckdb_data:/var/lib/postgresql
       - ./docker/postgresql.conf:/etc/postgresql/postgresql.conf
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     restart: always


### PR DESCRIPTION
This is a recent change in Postgres 18.

Without this change there's the following error when trying to start the docker container:
```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.

       See also https://github.com/docker-library/postgres/pull/1259

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.

       See https://github.com/docker-library/postgres/issues/37 for a (long)
       discussion around this process, and suggestions for how to do so.
```

<img width="1314" height="687" alt="image" src="https://github.com/user-attachments/assets/880792d0-5f31-4f30-9135-122dcc1d5920" />
