### PR TITLE
fix: prevent redefine FirstCommandId macro with PostgreSQL

### DIFF
--- a/include/pgduckdb/pg/transactions.hpp
+++ b/include/pgduckdb/pg/transactions.hpp
@@ -5,7 +5,9 @@
 extern "C" {
 extern bool IsSubTransaction(void);
 
+#ifndef FirstCommandId
 #define FirstCommandId ((CommandId)0)
+#endif
 
 /*
  * These enum definitions are vendored in so we can implement a postgres


### PR DESCRIPTION
Fix:

```
In file included from ../../src/include/postgres.h:45,
                 from src/pgduckdb_hooks.cpp:11:
../../src/include/c.h:668: warning: "FirstCommandId" redefined
  668 | #define FirstCommandId ((CommandId) 0)
      |
```