### PR TITLE
feat: allow installation in a non-public schema

### DIFF
--- a/pg_duckdb.control
+++ b/pg_duckdb.control
@@ -2,4 +2,3 @@ comment = 'DuckDB Embedded in Postgres'
 default_version = '1.1.0'
 module_pathname = '$libdir/pg_duckdb'
 relocatable = false
-schema = public

--- a/sql/pg_duckdb--1.0.0.sql
+++ b/sql/pg_duckdb--1.0.0.sql
@@ -7,7 +7,9 @@ LOAD 'pg_duckdb';
 -- we'll put into @extschema@ so that in normal usage they get put into the
 -- public schema and are thus more easily usable. This is the case for the
 -- read_csv, read_parquet and iceberg functions. It would be sad for usability
--- if people would have to prefix those with duckdb.read_csv
+-- if people would have to prefix those with duckdb.read_csv. The extension can 
+-- also be installed in a non-public schema in which case those functions will 
+-- require a schema qualified name.
 CREATE SCHEMA duckdb;
 -- Allow users to see the objects in the duckdb schema. We'll manually revoke rights
 -- for the dangerous ones.


### PR DESCRIPTION
## Overview

Removes `schema = public` from `pg_duckdb.control` to allow installing the extension in a non-public schema.

Default behavior is unchanged, `CREATE EXTENSION pg_duckdb` without a `SCHEMA` clause still installs into `public`.

In general I agree with the original sentiment:
```
It would be sad for usability if people would have to prefix those with duckdb.read_csv
```

but it would be nice if users can configure this if they want