### PR TITLE
Add allowed_directories to GUC

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -12,6 +12,7 @@ extern bool duckdb_log_pg_explain;
 extern int duckdb_maximum_threads;
 extern int duckdb_maximum_memory;
 extern char *duckdb_disabled_filesystems;
+extern char *duckdb_allowed_directories;
 extern bool duckdb_enable_external_access;
 extern bool duckdb_allow_community_extensions;
 extern bool duckdb_allow_unsigned_extensions;

--- a/src/pgduckdb_duckdb.cpp
+++ b/src/pgduckdb_duckdb.cpp
@@ -114,7 +114,6 @@ DuckDBManager::Initialize() {
 	config.SetOptionByName("default_null_order", "postgres");
 
 	SET_DUCKDB_OPTION(allow_unsigned_extensions);
-	SET_DUCKDB_OPTION(enable_external_access);
 	SET_DUCKDB_OPTION(allow_community_extensions);
 	SET_DUCKDB_OPTION(autoinstall_known_extensions);
 	SET_DUCKDB_OPTION(autoload_known_extensions);
@@ -221,6 +220,27 @@ DuckDBManager::Initialize() {
 		InstallExtensions(context);
 	}
 	LoadExtensions(context);
+
+	/* Set allowed_directories and enable_external_access AFTER loading extensions
+	 * (extensions need filesystem access to install/load). Set allowed_directories
+	 * BEFORE disabling external access (DuckDB rejects changes to
+	 * allowed_directories when external access is disabled). */
+	if (!IsEmptyString(duckdb_allowed_directories)) {
+		auto dirs = duckdb::StringUtil::Split(duckdb_allowed_directories, ',');
+		auto list_str = "[" +
+		                duckdb::StringUtil::Join(dirs, dirs.size(), ", ",
+		                                         [](const std::string &dir) {
+			                                         auto trimmed = dir;
+			                                         duckdb::StringUtil::Trim(trimmed);
+			                                         return duckdb::KeywordHelper::WriteQuoted(trimmed);
+		                                         }) +
+		                "]";
+		pgduckdb::DuckDBQueryOrThrow(context, "SET allowed_directories=" + list_str);
+	}
+
+	if (!duckdb_enable_external_access) {
+		pgduckdb::DuckDBQueryOrThrow(context, "SET enable_external_access=false");
+	}
 }
 
 void

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -131,6 +131,7 @@ bool duckdb_force_motherduck_views = false;
 int duckdb_maximum_threads = -1;
 int duckdb_maximum_memory = 4096; /* 4GB in MB */
 char *duckdb_disabled_filesystems = strdup("");
+char *duckdb_allowed_directories = strdup("");
 bool duckdb_enable_external_access = true;
 bool duckdb_allow_community_extensions = false;
 bool duckdb_allow_unsigned_extensions = false;
@@ -239,6 +240,12 @@ InitGUC() {
 	DefineCustomDuckDBVariable("duckdb.disabled_filesystems",
 	                           "Disable specific file systems preventing access (e.g., LocalFileSystem)",
 	                           &duckdb_disabled_filesystems, PGC_SUSET);
+
+	DefineCustomDuckDBVariable("duckdb.allowed_directories",
+	                           "Comma-separated list of directories and URL prefixes that are always "
+	                           "allowed for file access, even when enable_external_access is false "
+	                           "(e.g., '/data/,s3://mybucket/')",
+	                           &duckdb_allowed_directories, PGC_SUSET);
 
 	DefineCustomDuckDBVariable("duckdb.azure_transport_option_type",
 	                           "Set the azure_transport_option_type for DuckDB Azure extension. Can be used to "

--- a/test/regression/expected/allowed_directories.out
+++ b/test/regression/expected/allowed_directories.out
@@ -1,0 +1,38 @@
+-- Test duckdb.allowed_directories GUC with comma-separated values
+-- Recycle DuckDB first so GucCheckDuckDBNotInitdHook allows SET
+CALL duckdb.recycle_ddb();
+SET duckdb.allowed_directories = 's3://test-bucket/data/, /tmp/duckdb-test/';
+SET duckdb.enable_external_access = false;
+-- Should be blocked (not in allowed dirs)
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('/etc/passwd') $$);
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name raw_query does not exist!
+Did you mean "main.pragma_user_agent"?
+
+LINE 1: SELECT raw_query FROM duckdb.raw_query(' SELECT * FROM read_csv(''/etc/passwd...
+                              ^
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Permission Error: Cannot access file "/etc/passwd" - file system operations are disabled by configuration
+
+LINE 1:  SELECT * FROM read_csv('/etc/passwd') 
+                       ^
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('https://example.com/test.csv') $$);
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name raw_query does not exist!
+Did you mean "main.pragma_user_agent"?
+
+LINE 1: SELECT raw_query FROM duckdb.raw_query(' SELECT * FROM read_csv(''https://example...
+                              ^
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Permission Error: Cannot access file "https://example.com/test.csv" - file system operations are disabled by configuration
+
+LINE 1:  SELECT * FROM read_csv('https://example.com/test.csv') 
+                       ^
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('s3://other-bucket/secret.csv') $$);
+WARNING:  (PGDuckDB/CreatePlan) Prepared query returned an error: Catalog Error: Table Function with name raw_query does not exist!
+Did you mean "main.pragma_user_agent"?
+
+LINE 1: SELECT raw_query FROM duckdb.raw_query(' SELECT * FROM read_csv(''s3://other-bucket...
+                              ^
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Permission Error: Cannot access file "s3://other-bucket/secret.csv" - file system operations are disabled by configuration
+
+LINE 1:  SELECT * FROM read_csv('s3://other-bucket/secret.csv') 
+                       ^
+-- Cleanup: recycle to clear restrictions for subsequent tests
+CALL duckdb.recycle_ddb();

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -60,3 +60,4 @@ test: views
 test: parallel_postgres_scan
 test: postgres_table_etl
 test: order_by
+test: allowed_directories

--- a/test/regression/sql/allowed_directories.sql
+++ b/test/regression/sql/allowed_directories.sql
@@ -1,0 +1,13 @@
+-- Test duckdb.allowed_directories GUC with comma-separated values
+-- Recycle DuckDB first so GucCheckDuckDBNotInitdHook allows SET
+CALL duckdb.recycle_ddb();
+SET duckdb.allowed_directories = 's3://test-bucket/data/, /tmp/duckdb-test/';
+SET duckdb.enable_external_access = false;
+
+-- Should be blocked (not in allowed dirs)
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('/etc/passwd') $$);
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('https://example.com/test.csv') $$);
+SELECT * FROM duckdb.raw_query($$ SELECT * FROM read_csv('s3://other-bucket/secret.csv') $$);
+
+-- Cleanup: recycle to clear restrictions for subsequent tests
+CALL duckdb.recycle_ddb();


### PR DESCRIPTION
Similar to #884 and #699, this adds `allowed_directories` to the GUC.

Note that DuckDB rejects changes to `allowed_directories` after external access is disabled. I've therefore moved `enable_external_access` from `DBConfig` struct to a SQL SET in Initialize() so `allowed_directories` can be applied first. Let me know if this is not desirable.

Update: [CI is passing on our side](https://github.com/golithus/pg_duckdb/actions/runs/22954773102)