### PR TITLE
Benchmarks: Use the --host flag for the psql commands during data generation

### DIFF
--- a/scripts/tpch/run.py
+++ b/scripts/tpch/run.py
@@ -94,7 +94,13 @@ def build_pg_env(username, password):
 
 
 def create_tables(
-    host, database_name, schema_name, username, password, no_indexes=False, pk_only=False
+    host,
+    database_name,
+    schema_name,
+    username,
+    password,
+    no_indexes=False,
+    pk_only=False,
 ):
     """Create tables using SQL files"""
     pg_env = build_pg_env(username, password)

--- a/scripts/tpch/run.py
+++ b/scripts/tpch/run.py
@@ -94,7 +94,7 @@ def build_pg_env(username, password):
 
 
 def create_tables(
-    database_name, schema_name, username, password, no_indexes=False, pk_only=False
+    host, database_name, schema_name, username, password, no_indexes=False, pk_only=False
 ):
     """Create tables using SQL files"""
     pg_env = build_pg_env(username, password)
@@ -105,6 +105,8 @@ def create_tables(
             "psql",
             "-d",
             database_name,
+            "-h",
+            host,
             "-c",
             f'CREATE SCHEMA IF NOT EXISTS "{schema_name}"',
         ],
@@ -130,6 +132,8 @@ def create_tables(
     run(
         [
             "psql",
+            "-h",
+            host,
             "-d",
             database_name,
             "-v",
@@ -567,6 +571,7 @@ def run_benchmark(args, engine, results_suffix="", timeout_seconds=300):
     if engine != "motherduck" and not args.skip_load:
         # Create schema using SQL files
         create_tables(
+            args.host,
             database_name,
             schema_name,
             username,
@@ -582,6 +587,8 @@ def run_benchmark(args, engine, results_suffix="", timeout_seconds=300):
             run(
                 [
                     "psql",
+                    "-h",
+                    args.host,
                     "-d",
                     database_name,
                     "-v",


### PR DESCRIPTION
I was running the benchmark scripts and wasn't able to connect to the host I was passing to the script. I found that the subprocess calls to `psql` didn't pass the `--host` flag: it was only used for executing the queries in `execute_tpch_queries()`. This PR adds the flag to the subcommands that create the tables and load the data.