### PR TITLE
fix: suppress ::numeric cast for unqualified NUMERIC constants

### DIFF
--- a/src/pgduckdb_ruleutils.cpp
+++ b/src/pgduckdb_ruleutils.cpp
@@ -366,6 +366,11 @@ pgduckdb_show_type(Const *constval, int original_showtype) {
 	if (pgduckdb_is_fake_type(constval->consttype)) {
 		return -1;
 	}
+	/* DuckDB maps "::numeric" to DECIMAL(18,3); suppress for unqualified
+	 * NUMERIC so DuckDB infers the type from context instead. */
+	if (constval->consttype == NUMERICOID && constval->consttypmod == -1) {
+		return -1;
+	}
 	return original_showtype;
 }
 

--- a/test/regression/expected/wide_decimal_insert.out
+++ b/test/regression/expected/wide_decimal_insert.out
@@ -1,0 +1,15 @@
+-- Verify INSERT into wide DECIMAL columns works (previously failed because
+-- the deparse emitted "::numeric" which DuckDB mapped to DECIMAL(18,3)).
+CREATE TEMP TABLE t(n numeric(31,3)) USING duckdb;
+INSERT INTO t VALUES (1.7820000000000002e+16);
+INSERT INTO t VALUES (12345.678);
+INSERT INTO t VALUES (-99999999999999.999);
+SELECT * FROM t ORDER BY n;
+           n
+-----------------------
+   -99999999999999.999
+             12345.678
+ 17820000000000002.000
+(3 rows)
+
+DROP TABLE t;

--- a/test/regression/expected/wide_decimal_insert.out
+++ b/test/regression/expected/wide_decimal_insert.out
@@ -5,7 +5,7 @@ INSERT INTO t VALUES (1.7820000000000002e+16);
 INSERT INTO t VALUES (12345.678);
 INSERT INTO t VALUES (-99999999999999.999);
 SELECT * FROM t ORDER BY n;
-           n
+           n           
 -----------------------
    -99999999999999.999
              12345.678

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -7,6 +7,7 @@ test: basic
 test: case_insensitivity
 test: concurrency
 test: correct_null_conversions
+test: wide_decimal_insert
 test: create_schema
 test: create_table_as
 test: cte

--- a/test/regression/sql/wide_decimal_insert.sql
+++ b/test/regression/sql/wide_decimal_insert.sql
@@ -1,0 +1,8 @@
+-- Verify INSERT into wide DECIMAL columns works (previously failed because
+-- the deparse emitted "::numeric" which DuckDB mapped to DECIMAL(18,3)).
+CREATE TEMP TABLE t(n numeric(31,3)) USING duckdb;
+INSERT INTO t VALUES (1.7820000000000002e+16);
+INSERT INTO t VALUES (12345.678);
+INSERT INTO t VALUES (-99999999999999.999);
+SELECT * FROM t ORDER BY n;
+DROP TABLE t;


### PR DESCRIPTION
PG's unqualified NUMERIC is arbitrary precision, but DuckDB interprets "::numeric" as DECIMAL(18,3).  This causes overflow errors on INSERT for values exceeding 15 integer digits into columns with wider precision (e.g. DECIMAL(31,3)).

Suppress the "::numeric" type annotation when typmod is -1 (unqualified), letting DuckDB infer the type from context (e.g. target column type). Qualified casts like "::numeric(31,3)" are preserved since format_type_with_typemod produces the precision/scale DuckDB can parse.