### PR TITLE
revoke PUBLIC execute on raw_query

### DIFF
--- a/sql/pg_duckdb--1.0.0.sql
+++ b/sql/pg_duckdb--1.0.0.sql
@@ -1120,7 +1120,10 @@ CREATE AGGREGATE @extschema@.json_group_structure(duckdb.json)
     initcond = 0
 );
 
-GRANT ALL ON FUNCTION duckdb.raw_query(TEXT) TO PUBLIC;
+-- raw_query executes arbitrary DuckDB SQL and must not be public.
+-- The REVOKE at the top of this file is inadvertently overridden here;
+-- keep it revoked so only roles explicitly granted access can use it.
+REVOKE ALL ON FUNCTION duckdb.raw_query(TEXT) FROM PUBLIC;
 GRANT ALL ON PROCEDURE duckdb.recycle_ddb() TO PUBLIC;
 
 -- Ensure UTF8 encoding


### PR DESCRIPTION
raw_query(TEXT) executes arbitrary DuckDB SQL, including HTTP requests to any host and access to any S3 bucket the server can reach.  Leaving it callable by public might be dangerous.

I suppose the REVOKE on line 123 was inadvertently overridden by a later GRANT ALL TO PUBLIC near the aggregate definitions. Or do I misunderstand something?

I'm not sure, but maybe recycle_ddb() also deserves same treating.