### PR TITLE
add duckdb.allowed_endpoint_suffixes GUC

### DIFF
--- a/include/pgduckdb/pgduckdb_guc.hpp
+++ b/include/pgduckdb/pgduckdb_guc.hpp
@@ -28,4 +28,5 @@ extern char *duckdb_max_temp_directory_size;
 extern char *duckdb_default_collation;
 extern char *duckdb_azure_transport_option_type;
 extern char *duckdb_custom_user_agent;
+extern char *duckdb_allowed_endpoint_suffixes;
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_secrets_helper.hpp
+++ b/include/pgduckdb/pgduckdb_secrets_helper.hpp
@@ -15,6 +15,8 @@ We validate by creating the query to create the SECRET in DuckDB and then execut
 This function throws a PG error if the secret is invalid.
 */
 void ValidateDuckDBSecret(const char *type, List *server_options, List *mapping_options = nullptr);
+void ValidateEndpointSuffix(List *options);
+void ValidateEndpointSuffix(const char *endpoint);
 
 /* Utility functions */
 UserMapping *FindUserMapping(Oid userid, Oid serverid, bool with_options = false);

--- a/src/pgduckdb_fdw.cpp
+++ b/src/pgduckdb_fdw.cpp
@@ -299,6 +299,7 @@ pgduckdb_fdw_validator(PG_FUNCTION_ARGS) {
 		if (AreStringEqual(server_type, "motherduck")) {
 			ValidateMotherduckServerFdw(options_list, catalog);
 		} else {
+			ValidateEndpointSuffix(options_list);
 			ValidateDuckDBSecret(server_type, options_list);
 		}
 

--- a/src/pgduckdb_guc.cpp
+++ b/src/pgduckdb_guc.cpp
@@ -142,6 +142,7 @@ char *duckdb_max_temp_directory_size = strdup("");
 char *duckdb_default_collation = strdup("");
 char *duckdb_azure_transport_option_type = strdup("");
 char *duckdb_custom_user_agent = strdup("");
+char *duckdb_allowed_endpoint_suffixes = strdup("");
 
 void
 InitGUC() {
@@ -247,6 +248,14 @@ InitGUC() {
 
 	DefineCustomDuckDBVariable("duckdb.custom_user_agent", "Additional user agent string to append to 'pg_duckdb'",
 	                           &duckdb_custom_user_agent, PGC_SUSET);
+
+	DefineCustomVariable(
+	    "duckdb.allowed_endpoint_suffixes",
+	    "Comma-separated list of hostname suffixes allowed as S3/GCS/Azure endpoints. "
+	    "When non-empty, CREATE SERVER and duckdb.create_simple_secret() reject any endpoint "
+	    "that does not end with one of the listed suffixes (e.g. 'storage.yandexcloud.net'). "
+	    "An empty string (default) disables the restriction.",
+	    &duckdb_allowed_endpoint_suffixes, PGC_SUSET);
 }
 
 #if PG_VERSION_NUM < 160000

--- a/src/pgduckdb_options.cpp
+++ b/src/pgduckdb_options.cpp
@@ -1,5 +1,6 @@
 #include "duckdb.hpp"
 
+#include "pgduckdb/pgduckdb_secrets_helper.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
 #include "pgduckdb/pgduckdb_background_worker.hpp"
 #include "pgduckdb/pgduckdb_duckdb.hpp"
@@ -165,9 +166,16 @@ DECLARE_PG_FUNCTION(pgduckdb_create_simple_secret) {
 		std::ostringstream create_server_query;
 		create_server_query << "CREATE SERVER " << server_name << " TYPE '" << type << "' FOREIGN DATA WRAPPER duckdb";
 
-		auto options = pgduckdb::pg::ReadOptions(
-		    fcinfo, 4, {"region", "url_style", "provider", "endpoint", "scope", "validation", "use_ssl"});
-		if (!options.empty()) {
+	/* Validate endpoint against duckdb.allowed_endpoint_suffixes before
+	 * creating the SERVER so errors are reported before any catalog changes. */
+	if (PG_NARGS() > 7 && !PG_ARGISNULL(7)) {
+		auto endpoint_arg = pgduckdb::pg::GetArgString(fcinfo, 7);
+		ValidateEndpointSuffix(endpoint_arg.empty() ? nullptr : endpoint_arg.c_str());
+	}
+
+	auto options = pgduckdb::pg::ReadOptions(
+	    fcinfo, 4, {"region", "url_style", "provider", "endpoint", "scope", "validation", "use_ssl"});
+	if (!options.empty()) {
 			create_server_query << " OPTIONS (" << options << ")";
 		}
 

--- a/src/pgduckdb_secrets_helper.cpp
+++ b/src/pgduckdb_secrets_helper.cpp
@@ -1,4 +1,5 @@
 #include "pgduckdb/pgduckdb_secrets_helper.hpp"
+#include "pgduckdb/pgduckdb_guc.hpp"
 
 #include "duckdb.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
@@ -222,6 +223,61 @@ GetQueryError(const char *query, List *server_options) {
 
 	con->Query("ROLLBACK;");
 	return pstrdup(oss.str().c_str());
+}
+
+/*
+ * ValidateEndpointSuffix - check that 'endpoint' matches one of the allowed
+ * suffixes in duckdb.allowed_endpoint_suffixes (comma-separated list).
+ *
+ * Does nothing when the GUC is empty (default) or when no endpoint option is
+ * present.  Called from both the FDW validator and create_simple_secret().
+ */
+static void
+ValidateEndpointSuffixValue(const char *endpoint) {
+	if (pgduckdb::duckdb_allowed_endpoint_suffixes == nullptr ||
+	    pgduckdb::duckdb_allowed_endpoint_suffixes[0] == '\0')
+		return;
+
+	if (endpoint == nullptr || endpoint[0] == '\0')
+		return;
+
+	/* Split GUC value on commas and check each suffix. */
+	char *suffixes_copy = pstrdup(pgduckdb::duckdb_allowed_endpoint_suffixes);
+	char *token;
+	char *saveptr = nullptr;
+	size_t ep_len = strlen(endpoint);
+
+	for (token = strtok_r(suffixes_copy, ",", &saveptr); token != nullptr;
+	     token = strtok_r(nullptr, ",", &saveptr)) {
+		/* Trim leading whitespace. */
+		while (*token == ' ')
+			token++;
+
+		size_t sfx_len = strlen(token);
+		if (sfx_len == 0)
+			continue;
+
+		if (ep_len >= sfx_len &&
+		    strcmp(endpoint + ep_len - sfx_len, token) == 0)
+			return; /* matched */
+	}
+
+	ereport(ERROR,
+	        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+	         errmsg("endpoint \"%s\" is not allowed", endpoint),
+	         errdetail("duckdb.allowed_endpoint_suffixes = '%s'",
+	                   pgduckdb::duckdb_allowed_endpoint_suffixes),
+	         errhint("Use an endpoint whose hostname ends with one of the allowed suffixes.")));
+}
+
+void
+ValidateEndpointSuffix(List *options) {
+	ValidateEndpointSuffixValue(FindOption(options, "endpoint"));
+}
+
+void
+ValidateEndpointSuffix(const char *endpoint) {
+	ValidateEndpointSuffixValue(endpoint);
 }
 
 void


### PR DESCRIPTION
Hi!

I'm a bit afraid of SSRF from my clusters. 
I have a wild idea to make a GUC to control where DuckDB can go. Like

```
duckdb.allowed_endpoint_suffixes = 'storage.yandexcloud.net,s3.amazonaws.com'
```

WDYT?