### PR TITLE
Fix buffer over-read when copying parallel worker minimal tuples

### DIFF
--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -6,6 +6,7 @@
 extern "C" {
 #include "postgres.h"
 #include "miscadmin.h"
+#include "access/htup_details.h"
 #include "access/xact.h"
 #include "commands/explain.h"
 #if PG_VERSION_NUM >= 180000
@@ -27,6 +28,40 @@ extern "C" {
 #include "pgduckdb/vendor/pg_list.hpp"
 
 #include <cmath>
+#include <sstream>
+
+namespace {
+
+/*
+ * Bytes in a minimal tuple message from TupleQueueReaderNext (see tqueue.c).
+ * Do not add MINIMAL_TUPLE_DATA_OFFSET; queued tuples are not palloc-sized tuples.
+ */
+inline Size
+ParallelQueueMinimalTupleSize(MinimalTuple mtup) {
+	return mtup->t_len;
+}
+
+inline Size
+MaxAllowedParallelQueueTupleSize() {
+	return MaxHeapTupleSize;
+}
+
+void
+ValidateParallelQueueTupleSize(Size tuple_size) {
+	if (tuple_size < sizeof(uint32)) {
+		std::ostringstream oss;
+		oss << "parallel worker minimal tuple length " << tuple_size << " is too small";
+		throw duckdb::Exception(duckdb::ExceptionType::INTERNAL, oss.str().c_str());
+	}
+	if (tuple_size > MaxAllowedParallelQueueTupleSize()) {
+		std::ostringstream oss;
+		oss << "parallel worker minimal tuple length " << tuple_size << " exceeds maximum "
+		    << MaxAllowedParallelQueueTupleSize();
+		throw duckdb::Exception(duckdb::ExceptionType::INTERNAL, oss.str().c_str());
+	}
+}
+
+} // namespace
 
 namespace pgduckdb {
 
@@ -288,6 +323,7 @@ PostgresTableReader::GetNextTupleUnsafe() {
 	if (nreaders > 0) {
 		MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
 		if (HeapTupleIsValid(worker_minmal_tuple)) {
+			/* Queue pointer is valid for ParallelQueueMinimalTupleSize() bytes only. */
 			ExecStoreMinimalTuple(worker_minmal_tuple, slot, false);
 			return slot;
 		}
@@ -313,8 +349,11 @@ bool
 PostgresTableReader::GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer) {
 	MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
 	if (HeapTupleIsValid(worker_minmal_tuple)) {
-		// deep copy worker_minmal_tuple to destination buffer
-		Size tuple_size = worker_minmal_tuple->t_len + MINIMAL_TUPLE_DATA_OFFSET;
+		Size tuple_size = ParallelQueueMinimalTupleSize(worker_minmal_tuple);
+		ValidateParallelQueueTupleSize(tuple_size);
+#ifdef USE_ASSERT_CHECKING
+		Assert(tuple_size <= MaxAllowedParallelQueueTupleSize());
+#endif
 		minimal_tuple_buffer.resize(tuple_size);
 		memcpy(minimal_tuple_buffer.data(), worker_minmal_tuple, tuple_size);
 		return true;

--- a/test/regression/expected/issue_976.out
+++ b/test/regression/expected/issue_976.out
@@ -1,0 +1,21 @@
+SET duckdb.force_execution = true;
+SET duckdb.threads_for_postgres_scan = 2;
+CREATE TABLE issue_976_src (four int, ten int);
+INSERT INTO issue_976_src
+SELECT (i % 4), (i % 10)
+FROM generate_series(1, 200000) AS i;
+-- Parallel Postgres scan with multi-threaded DuckDB consumption (GetNextMinimalWorkerTuple).
+-- Order-independent checks: parallel scans do not guarantee global ORDER BY semantics.
+SELECT count(*)::bigint, count(DISTINCT (four, ten))::bigint FROM issue_976_src;
+ count  | count 
+--------+-------
+ 200000 |    20
+(1 row)
+
+SELECT count(*)::bigint FROM (SELECT DISTINCT ten, four FROM issue_976_src) ss;
+ count 
+-------
+    20
+(1 row)
+
+DROP TABLE issue_976_src;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -30,6 +30,7 @@ test: issue_796
 test: issue_802
 test: issue_813
 test: issue_975
+test: issue_976
 test: json_functions_duckdb
 test: materialized_view
 test: non_superuser

--- a/test/regression/sql/issue_976.sql
+++ b/test/regression/sql/issue_976.sql
@@ -1,0 +1,14 @@
+SET duckdb.force_execution = true;
+SET duckdb.threads_for_postgres_scan = 2;
+
+CREATE TABLE issue_976_src (four int, ten int);
+INSERT INTO issue_976_src
+SELECT (i % 4), (i % 10)
+FROM generate_series(1, 200000) AS i;
+
+-- Parallel Postgres scan with multi-threaded DuckDB consumption (GetNextMinimalWorkerTuple).
+-- Order-independent checks: parallel scans do not guarantee global ORDER BY semantics.
+SELECT count(*)::bigint, count(DISTINCT (four, ten))::bigint FROM issue_976_src;
+SELECT count(*)::bigint FROM (SELECT DISTINCT ten, four FROM issue_976_src) ss;
+
+DROP TABLE issue_976_src;


### PR DESCRIPTION
# Fix buffer over-read when copying parallel worker minimal tuples

> Local copy for opening/editing the PR. Do not commit this file.

## Summary

- Fix a heap buffer over-read in `GetNextMinimalWorkerTuple` when reading tuples from Postgres parallel workers.
- Parallel tuple queues deliver exactly `t_len` bytes per tuple; the copy size incorrectly included `MINIMAL_TUPLE_DATA_OFFSET`, which is not part of queued messages.
- Add regression test `issue_976` for parallel Postgres scan with `duckdb.threads_for_postgres_scan > 1`.

## Reproduction (issue #976)

Reporter query (crashes under ASAN with the old copy size):

```sql
SELECT four, ten,
       sum(ten) OVER (PARTITION BY four ORDER BY ten),
       last_value(ten) OVER (PARTITION BY four ORDER BY ten)
FROM (SELECT DISTINCT ten, four FROM tenk1) ss;
```

Stack trace points at `GetNextMinimalWorkerTuple` → `memcpy` while scanning the `DISTINCT` subquery via parallel Postgres workers, not inside window-function evaluation. The regression test exercises that same code path (`GetNextMinimalWorkerTuple`) with order-independent aggregates on a parallel scan.

## Problem

Fixes #976.

When DuckDB uses multiple threads to consume results from a parallel Postgres table scan ([#762](https://github.com/duckdb/pg_duckdb/pull/762)), `GetNextMinimalWorkerTuple` deep-copies each worker tuple before the next `TupleQueueReaderNext` call invalidates the shared-memory pointer.

The copy used `t_len + MINIMAL_TUPLE_DATA_OFFSET` bytes:

| Context | Tuple size |
|--------|------------|
| **Parallel queue** (`tqueue.c`) | `shm_mq_send(..., tuple->t_len, ...)`; receive asserts `tuple->t_len == nbytes` |
| **`heap_copy_minimal_tuple`** | `memcpy(result, mtup, mtup->t_len)` |
| **`MINIMAL_TUPLE_DATA_OFFSET`** | Used when skipping leading padding (e.g. tuplesort/tuplestore), **not** for `tqueue` messages |

The extra bytes read past the end of the queue buffer. ASAN reports a `memcpy` heap buffer over-read; non-ASAN builds have undefined behavior.

## Solution

Copy `worker_minmal_tuple->t_len` bytes only, matching `heap_copy_minimal_tuple` and Postgres `tqueue.c`.

`GetNextTupleUnsafe` still passes the queue pointer through in place without the extra offset; only the multi-threaded deep-copy path had the wrong size.

## Testing

CI builds normal Postgres (no ASAN); the fix follows the queue contract, not sanitizer-specific behavior. The regression test would fail on unfixed code under ASAN Postgres (as in the report).

Assertions in `issue_976` use counts, not row order, because parallel scans do not guarantee global `ORDER BY` semantics.

- [x] `make format`
- [x] `make installcheck TEST=issue_976`
- [x] Related parallel-scan regressions: `issue_796`, `issue_802`, `parallel_postgres_scan`, `issue_975`
- [x] `make pycheck`
- [ ] Full CI matrix on PR (Postgres 14–18)
