### PR TITLE
perf: DuckDB scans over Postgres heap tables

### DIFF
--- a/include/pgduckdb/pgduckdb_detoast.hpp
+++ b/include/pgduckdb/pgduckdb_detoast.hpp
@@ -1,11 +1,50 @@
 #pragma once
 
+#include <cstdint>
+#include <cstring>
+
 extern "C" {
 #include "postgres.h"
+#if PG_VERSION_NUM >= 160000
+#include "varatt.h"
+#endif
 }
 
 namespace pgduckdb {
 
 Datum DetoastPostgresDatum(struct varlena *value, bool *should_free);
+
+inline Datum
+DetoastIfExternal(Datum value, bool *should_free) {
+	auto *attr = reinterpret_cast<struct varlena *>(value);
+	if (VARATT_IS_EXTERNAL(attr) || VARATT_IS_COMPRESSED(attr)) {
+		return DetoastPostgresDatum(attr, should_free);
+	}
+	*should_free = false;
+	return value;
+}
+
+static constexpr size_t kShortRealignBufSize = 144;
+
+template <size_t BUF_SIZE>
+inline Datum
+DetoastPostgresDatumInline(Datum value, uint8_t (&stack_buf)[BUF_SIZE], bool *should_free) {
+	static_assert(BUF_SIZE >= kShortRealignBufSize, "stack buffer too small");
+	auto *attr = reinterpret_cast<struct varlena *>(value);
+	if (VARATT_IS_EXTERNAL(attr) || VARATT_IS_COMPRESSED(attr)) {
+		return DetoastPostgresDatum(attr, should_free);
+	}
+	*should_free = false;
+	if (!VARATT_IS_SHORT(attr)) {
+		return value;
+	}
+	const size_t data_size = VARSIZE_ANY_EXHDR(attr);
+	if (data_size + VARHDRSZ > BUF_SIZE) {
+		return DetoastPostgresDatum(attr, should_free);
+	}
+	SET_VARSIZE(stack_buf, data_size + VARHDRSZ);
+	memcpy(stack_buf + VARHDRSZ, VARDATA_ANY(attr), data_size);
+	return PointerGetDatum(stack_buf);
+}
 
 } // namespace pgduckdb

--- a/include/pgduckdb/pgduckdb_types.hpp
+++ b/include/pgduckdb/pgduckdb_types.hpp
@@ -37,7 +37,6 @@ int32_t GetPostgresDuckDBTypemod(const duckdb::LogicalType &type);
 duckdb::Value ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type);
 void ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, uint64_t offset);
 bool ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, uint64_t col);
-void InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot *slot);
 void InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot **slots,
                            int num_slots);
 

--- a/include/pgduckdb/scan/postgres_table_reader.hpp
+++ b/include/pgduckdb/scan/postgres_table_reader.hpp
@@ -12,10 +12,17 @@ class PostgresTableReader {
 public:
 	PostgresTableReader();
 	~PostgresTableReader();
-	TupleTableSlot *GetNextTuple();
 	void Init(const char *table_scan_query, bool count_tuples_only);
 	void Cleanup();
 	bool GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer);
+	// In-process variant (no parallel workers): runs the scan node and copies up to `max` tuples into
+	// `slots`, each of which takes ownership of its copy (freed on its next store). Returns the number of
+	// slots filled; a result < `max` means EOF was reached. Caller must hold GlobalProcessLock.
+	int GetNextInProcessTuples(TupleTableSlot **slots, int max);
+	// count_tuples_only variant: the aggregate node returns one tuple per call
+	// whose first attribute is the partial count. Returns false on EOF, otherwise
+	// sets *count_out to that partial count.
+	bool GetNextCount(uint64_t *count_out);
 	TupleTableSlot *InitTupleSlot();
 	int
 	NumWorkersLaunched() const {
@@ -30,7 +37,10 @@ private:
 	void InitRunWithParallelScan(PlannedStmt *, bool);
 	void CleanupUnsafe();
 
+	TupleTableSlot *GetNextTuple();
+	int GetNextInProcessTuplesUnsafe(TupleTableSlot **slots, int max);
 	TupleTableSlot *GetNextTupleUnsafe();
+	TupleTableSlot *ExecNextTupleUnsafe();
 	MinimalTuple GetNextWorkerTuple();
 	int ParallelWorkerNumber(Cardinality cardinality);
 	bool CanTableScanRunInParallel(Plan *plan);

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -2123,34 +2123,6 @@ ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, i
 	fn(result, value, offset);
 }
 
-void
-InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot *slot) {
-
-	auto scan_global_state = scan_local_state.global_state;
-
-	if (scan_global_state->count_tuples_only) {
-		/* COUNT(*) returned tuple will have only one value returned as first tuple element. */
-		scan_global_state->total_row_count += slot->tts_values[0];
-		scan_local_state.output_vector_size += slot->tts_values[0];
-		return;
-	}
-	/* Write tuple columns in output vector. */
-	for (int duckdb_output_index = 0; duckdb_output_index < slot->tts_tupleDescriptor->natts; duckdb_output_index++) {
-		auto &result = output.data[duckdb_output_index];
-		if (slot->tts_isnull[duckdb_output_index]) {
-			auto &array_mask = duckdb::FlatVector::Validity(result);
-			array_mask.SetInvalid(scan_local_state.output_vector_size);
-		} else {
-			auto attr = TupleDescAttr(slot->tts_tupleDescriptor, duckdb_output_index);
-			auto convert_fn = GetPostgresToDuckValueFn(attr->atttypid, result);
-			convert_fn(result, slot->tts_values[duckdb_output_index], scan_local_state.output_vector_size);
-		}
-	}
-
-	scan_local_state.output_vector_size++;
-	scan_global_state->total_row_count++;
-}
-
 /*
  * Returns true if the given type can be converted from a Postgres datum to a DuckDB value
  * without requiring any Postgres-specific functions or memory allocations (such as palloc).
@@ -2168,15 +2140,22 @@ IsThreadSafeTypeForPostgresToDuckDB(Oid attr_type, duckdb::LogicalTypeId duckdb_
 }
 
 /*
- * Insert batch of tuples into chunk. This function is thread-safe and is meant for multi-threaded scans.
+ * Insert batch of tuples into chunk.
  *
- * Global lock & PG memory context are handled for unsafe types, e.g., JSONB/LIST/VARBIT.
+ * The slots only need to hold a (minimal) tuple; this function deforms them. Global lock & PG memory
+ * context are handled for unsafe types, e.g., JSONB/LIST/VARBIT.
  */
 void
 InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_local_state, TupleTableSlot **slots,
                       int num_slots) {
 	if (num_slots == 0) {
 		return;
+	}
+
+	// Deform every slot up front so the column-major loop below can read tts_values/tts_isnull. slot_getallattrs
+	// is idempotent and allocation-free for minimal slots, so it is safe to call without the global lock.
+	for (int row = 0; row < num_slots; row++) {
+		slot_getallattrs(slots[row]);
 	}
 
 	auto scan_global_state = scan_local_state.global_state;

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -533,8 +533,22 @@ ConvertMapDatum(const duckdb::Value &value) {
 	return ConvertToStringDatum(value);
 }
 
-static duckdb::interval_t
-DatumGetInterval(Datum value) {
+template <class T>
+static inline T DatumGet(Datum value);
+
+// clang-format off
+template <> inline bool      DatumGet<bool>(Datum value)      { return DatumGetBool(value); }
+template <> inline int16_t   DatumGet<int16_t>(Datum value)   { return DatumGetInt16(value); }
+template <> inline int32_t   DatumGet<int32_t>(Datum value)   { return DatumGetInt32(value); }
+template <> inline uint32_t  DatumGet<uint32_t>(Datum value)  { return DatumGetUInt32(value); }
+template <> inline int64_t   DatumGet<int64_t>(Datum value)   { return DatumGetInt64(value); }
+template <> inline float     DatumGet<float>(Datum value)     { return DatumGetFloat4(value); }
+template <> inline double    DatumGet<double>(Datum value)    { return DatumGetFloat8(value); }
+// clang-format on
+
+template <>
+inline duckdb::interval_t
+DatumGet<duckdb::interval_t>(Datum value) {
 	Interval *pg_interval = DatumGetIntervalP(value);
 	duckdb::interval_t duck_interval;
 	duck_interval.months = pg_interval->month;
@@ -554,15 +568,17 @@ DatumGetBitString(Datum value) {
 	return std::string(pgduckdb::pg::VarbitToString(value));
 }
 
-static duckdb::dtime_t
-DatumGetTime(Datum value) {
+template <>
+inline duckdb::dtime_t
+DatumGet<duckdb::dtime_t>(Datum value) {
 	const TimeADT pg_time = DatumGetTimeADT(value);
 	duckdb::dtime_t duckdb_time {pg_time};
 	return duckdb_time;
 }
 
-static duckdb::dtime_tz_t
-DatumGetTimeTz(Datum value) {
+template <>
+inline duckdb::dtime_tz_t
+DatumGet<duckdb::dtime_tz_t>(Datum value) {
 	TimeTzADT *tzt = static_cast<TimeTzADT *>(DatumGetTimeTzADTP(value));
 	// pg and duckdb stores timezone with different signs, for example, for TIMETZ 01:02:03+05, duckdb stores offset =
 	// 18000, while pg stores zone = -18000.
@@ -572,8 +588,9 @@ DatumGetTimeTz(Datum value) {
 	return duck_time_tz;
 }
 
-static hugeint_t
-DatumGetUUID(Datum value) {
+template <>
+inline hugeint_t
+DatumGet<hugeint_t>(Datum value) {
 	const Pointer pg_uuid = DatumGetPointer(value);
 	hugeint_t duck_uuid;
 	D_ASSERT(UUID_LEN == sizeof(hugeint_t));
@@ -582,6 +599,23 @@ DatumGetUUID(Datum value) {
 	}
 	duck_uuid.upper ^= (uint64_t(1) << 63);
 	return duck_uuid;
+}
+
+static inline duckdb::interval_t
+DatumGetInterval(Datum value) {
+	return DatumGet<duckdb::interval_t>(value);
+}
+static inline duckdb::dtime_t
+DatumGetTime(Datum value) {
+	return DatumGet<duckdb::dtime_t>(value);
+}
+static inline duckdb::dtime_tz_t
+DatumGetTimeTz(Datum value) {
+	return DatumGet<duckdb::dtime_tz_t>(value);
+}
+static inline hugeint_t
+DatumGetUUID(Datum value) {
+	return DatumGet<hugeint_t>(value);
 }
 
 template <int32_t OID>
@@ -1647,24 +1681,67 @@ Append(duckdb::Vector &result, T value, idx_t offset) {
 	data[offset] = value;
 }
 
+template <class T>
 static void
-AppendString(duckdb::Vector &result, Datum value, idx_t offset, bool is_bpchar) {
-	const char *text = VARDATA_ANY(value);
+AppendDatum(duckdb::Vector &result, Datum value, idx_t offset) {
+	Append<T>(result, DatumGet<T>(value), offset);
+}
+
+template <bool IS_BPCHAR>
+static void
+AppendString(duckdb::Vector &result, Datum value, idx_t offset) {
+	bool should_free = false;
+	Datum v = DetoastIfExternal(value, &should_free);
+	const char *text = VARDATA_ANY(v);
 	/* Remove the padding of a BPCHAR type. DuckDB expects unpadded value. */
-	auto len = is_bpchar ? bpchartruelen(VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value)) : VARSIZE_ANY_EXHDR(value);
+	auto len = IS_BPCHAR ? bpchartruelen(VARDATA_ANY(v), VARSIZE_ANY_EXHDR(v)) : VARSIZE_ANY_EXHDR(v);
 	duckdb::string_t str(text, len);
 
 	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(result);
 	data[offset] = duckdb::StringVector::AddString(result, str);
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
 }
 
 static void
 AppendJsonb(duckdb::Vector &result, Datum value, idx_t offset) {
-	auto jsonb = DatumGetJsonbP(value);
+	alignas(int32) uint8_t buf[kShortRealignBufSize];
+	bool should_free = false;
+	Datum v = DetoastPostgresDatumInline(value, buf, &should_free);
+	auto jsonb = DatumGetJsonbP(v);
 	StringInfo str = PostgresFunctionGuard(makeStringInfo);
 	auto json_str = PostgresFunctionGuard(JsonbToCString, str, &jsonb->root, VARSIZE(jsonb));
 	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(result);
 	data[offset] = duckdb::StringVector::AddString(result, json_str, str->len);
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
+}
+
+static void
+AppendBit(duckdb::Vector &result, Datum value, idx_t offset) {
+	alignas(int32) uint8_t buf[kShortRealignBufSize];
+	bool should_free = false;
+	Datum v = DetoastPostgresDatumInline(value, buf, &should_free);
+	Append<duckdb::bitstring_t>(result, duckdb::Bit::ToBit(DatumGetBitString(v)), offset);
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
+}
+
+static void
+AppendBlob(duckdb::Vector &result, Datum value, idx_t offset) {
+	bool should_free = false;
+	Datum v = DetoastIfExternal(value, &should_free);
+	const char *bytea_data = VARDATA_ANY(v);
+	size_t bytea_length = VARSIZE_ANY_EXHDR(v);
+	const duckdb::string_t s(bytea_data, bytea_length);
+	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(result);
+	data[offset] = duckdb::StringVector::AddStringOrBlob(result, s);
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
 }
 
 static void
@@ -1793,6 +1870,102 @@ ConvertDecimal(const NumericVar &numeric) {
 	return numeric.sign == NUMERIC_NEG ? -base_res : base_res;
 }
 
+template <class T>
+static void
+AppendDecimal(duckdb::Vector &result, Datum value, idx_t offset) {
+	alignas(int32) uint8_t buf[kShortRealignBufSize];
+	bool should_free = false;
+	Datum v = DetoastPostgresDatumInline(value, buf, &should_free);
+	auto numeric_var = FromNumeric(DatumGetNumeric(v));
+	if constexpr (std::is_same_v<T, hugeint_t>) {
+		Append<T>(result, ConvertDecimal<T, DecimalConversionHugeint>(numeric_var), offset);
+	} else if constexpr (std::is_same_v<T, double>) {
+		Append<T>(result, ConvertDecimal<T, DecimalConversionDouble>(numeric_var), offset);
+	} else {
+		Append<T>(result, ConvertDecimal<T>(numeric_var), offset);
+	}
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(v));
+	}
+}
+
+static void
+AppendList(duckdb::Vector &result, Datum value, idx_t offset) {
+	alignas(int32) uint8_t buf[kShortRealignBufSize];
+	bool should_free = false;
+	Datum detoasted_value = DetoastPostgresDatumInline(value, buf, &should_free);
+	auto array = DatumGetArrayTypeP(detoasted_value);
+
+	auto ndims = ARR_NDIM(array);
+	int *dims = ARR_DIMS(array);
+	auto elem_type = ARR_ELEMTYPE(array);
+
+	int16 typlen;
+	bool typbyval;
+	char typalign;
+	PostgresFunctionGuard(get_typlenbyvalalign, elem_type, &typlen, &typbyval, &typalign);
+
+	int nelems;
+	Datum *elems;
+	bool *nulls;
+	// Deconstruct the array into Datum elements
+	PostgresFunctionGuard(deconstruct_array, array, elem_type, typlen, typbyval, typalign, &elems, &nulls, &nelems);
+
+	if (ndims == -1) {
+		throw duckdb::InternalException("Array type has an ndims of -1, so it's actually not an array??");
+	}
+	// Set the list_entry_t metadata
+	duckdb::Vector *vec = &result;
+	int write_offset = offset;
+	for (int dim = 0; dim < ndims; dim++) {
+		auto previous_dimension = dim ? dims[dim - 1] : 1;
+		auto dimension = dims[dim];
+		if (vec->GetType().id() != duckdb::LogicalTypeId::LIST) {
+			throw duckdb::InvalidInputException(
+			    "Dimensionality of the schema and the data does not match, data contains more dimensions than the "
+			    "amount of dimensions specified by the schema");
+		}
+		auto child_offset = duckdb::ListVector::GetListSize(*vec);
+		auto list_data = duckdb::FlatVector::GetData<duckdb::list_entry_t>(*vec);
+		for (int entry = 0; entry < previous_dimension; entry++) {
+			list_data[write_offset + entry] = duckdb::list_entry_t(
+			    // All lists in a postgres row are enforced to have the same dimension
+			    // [[1,2],[2,3,4]] is not allowed, second list has 3 elements instead of 2
+			    child_offset + (dimension * entry), dimension);
+		}
+		auto new_child_size = child_offset + (dimension * previous_dimension);
+		duckdb::ListVector::Reserve(*vec, new_child_size);
+		duckdb::ListVector::SetListSize(*vec, new_child_size);
+		write_offset = child_offset;
+		auto &child = duckdb::ListVector::GetEntry(*vec);
+		vec = &child;
+	}
+	if (ndims == 0) {
+		D_ASSERT(nelems == 0);
+		auto child_offset = duckdb::ListVector::GetListSize(*vec);
+		auto list_data = duckdb::FlatVector::GetData<duckdb::list_entry_t>(*vec);
+		list_data[write_offset] = duckdb::list_entry_t(child_offset, 0);
+		vec = &duckdb::ListVector::GetEntry(*vec);
+	} else if (vec->GetType().id() == duckdb::LogicalTypeId::LIST) {
+		throw duckdb::InvalidInputException(
+		    "Dimensionality of the schema and the data does not match, data contains fewer dimensions than the "
+		    "amount of dimensions specified by the schema");
+	}
+
+	for (int i = 0; i < nelems; i++) {
+		idx_t dest_idx = write_offset + i;
+		if (nulls[i]) {
+			auto &array_mask = duckdb::FlatVector::Validity(*vec);
+			array_mask.SetInvalid(dest_idx);
+			continue;
+		}
+		ConvertPostgresToDuckValue(elem_type, elems[i], *vec, dest_idx);
+	}
+	if (should_free) {
+		duckdb_free(reinterpret_cast<void *>(detoasted_value));
+	}
+}
+
 /*
  * Convert a Postgres Datum to a DuckDB Value. This is meant to be used to
  * covert query parameters in a prepared statement to its DuckDB equivalent.
@@ -1846,194 +2019,108 @@ ConvertPostgresParameterToDuckValue(Datum value, Oid postgres_type) {
 	}
 }
 
-void
-ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, idx_t offset) {
+using PostgresToDuckValueFn = void (*)(duckdb::Vector &result, Datum value, idx_t offset);
+
+#define ASSERT_FIXED_LEN_PG_TYPE(attr_type) D_ASSERT(PostgresFunctionGuard(get_typlen, (attr_type)) > 0)
+
+static PostgresToDuckValueFn
+GetPostgresToDuckValueFn(Oid attr_type, duckdb::Vector &result) {
 	auto &type = result.GetType();
 	switch (type.id()) {
 	case duckdb::LogicalTypeId::BOOLEAN:
-		Append<bool>(result, DatumGetBool(value), offset);
-		break;
-	case duckdb::LogicalTypeId::TINYINT: {
-		Append<int16_t>(result, DatumGetInt16(value), offset);
-		break;
-	}
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<bool>;
+	case duckdb::LogicalTypeId::TINYINT:
 	case duckdb::LogicalTypeId::SMALLINT:
-		Append<int16_t>(result, DatumGetInt16(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<int16_t>;
 	case duckdb::LogicalTypeId::INTEGER:
-		Append<int32_t>(result, DatumGetInt32(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<int32_t>;
 	case duckdb::LogicalTypeId::UINTEGER:
-		Append<uint32_t>(result, DatumGetUInt32(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<uint32_t>;
 	case duckdb::LogicalTypeId::BIGINT:
-		Append<int64_t>(result, DatumGetInt64(value), offset);
-		break;
-	case duckdb::LogicalTypeId::VARCHAR: {
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<int64_t>;
+	case duckdb::LogicalTypeId::VARCHAR:
 		// NOTE: This also handles JSON
 		if (attr_type == JSONBOID) {
-			AppendJsonb(result, value, offset);
-			break;
+			return &AppendJsonb;
+		} else if (attr_type == BPCHAROID) {
+			return &AppendString<true>;
 		} else {
-			AppendString(result, value, offset, attr_type == BPCHAROID);
+			return &AppendString<false>;
 		}
-		break;
-	}
 	case duckdb::LogicalTypeId::DATE:
-		AppendDate(result, value, offset);
-		break;
-
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDate;
 	case duckdb::LogicalTypeId::TIMESTAMP_SEC:
 	case duckdb::LogicalTypeId::TIMESTAMP_MS:
 	case duckdb::LogicalTypeId::TIMESTAMP_NS:
 	case duckdb::LogicalTypeId::TIMESTAMP:
-		AppendTimestamp(result, value, offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendTimestamp;
 	case duckdb::LogicalTypeId::TIMESTAMP_TZ:
-		AppendTimestampTz(result, value, offset); // Timestamp and Timestamptz are basically same in PG
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendTimestampTz;
 	case duckdb::LogicalTypeId::INTERVAL:
-		Append<duckdb::interval_t>(result, DatumGetInterval(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<duckdb::interval_t>;
 	case duckdb::LogicalTypeId::BIT:
-		Append<duckdb::bitstring_t>(result, duckdb::Bit::ToBit(DatumGetBitString(value)), offset);
-		break;
+		return &AppendBit;
 	case duckdb::LogicalTypeId::TIME:
-		Append<duckdb::dtime_t>(result, DatumGetTime(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<duckdb::dtime_t>;
 	case duckdb::LogicalTypeId::TIME_TZ:
-		Append<duckdb::dtime_tz_t>(result, DatumGetTimeTz(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<duckdb::dtime_tz_t>;
 	case duckdb::LogicalTypeId::FLOAT:
-		Append<float>(result, DatumGetFloat4(value), offset);
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<float>;
 	case duckdb::LogicalTypeId::DOUBLE: {
 		auto aux_info = type.GetAuxInfoShrPtr();
-		if (aux_info && dynamic_cast<NumericAsDouble *>(aux_info.get())) {
-			// This NUMERIC could not be converted to a DECIMAL, convert it as DOUBLE instead
-			auto numeric = DatumGetNumeric(value);
-			auto numeric_var = FromNumeric(numeric);
-			auto double_val = ConvertDecimal<double, DecimalConversionDouble>(numeric_var);
-			Append<double>(result, double_val, offset);
-		} else {
-			Append<double>(result, DatumGetFloat8(value), offset);
+		if (attr_type == NUMERICOID && aux_info && dynamic_cast<NumericAsDouble *>(aux_info.get())) {
+			return &AppendDecimal<double>;
 		}
-		break;
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<double>;
 	}
 	case duckdb::LogicalTypeId::DECIMAL: {
 		auto physical_type = type.InternalType();
-		auto numeric = DatumGetNumeric(value);
-		auto numeric_var = FromNumeric(numeric);
 		switch (physical_type) {
-		case duckdb::PhysicalType::INT16: {
-			Append(result, ConvertDecimal<int16_t>(numeric_var), offset);
-			break;
-		}
-		case duckdb::PhysicalType::INT32: {
-			Append(result, ConvertDecimal<int32_t>(numeric_var), offset);
-			break;
-		}
-		case duckdb::PhysicalType::INT64: {
-			Append(result, ConvertDecimal<int64_t>(numeric_var), offset);
-			break;
-		}
-		case duckdb::PhysicalType::INT128: {
-			Append(result, ConvertDecimal<hugeint_t, DecimalConversionHugeint>(numeric_var), offset);
-			break;
-		}
+		case duckdb::PhysicalType::INT16:
+			return &AppendDecimal<int16_t>;
+		case duckdb::PhysicalType::INT32:
+			return &AppendDecimal<int32_t>;
+		case duckdb::PhysicalType::INT64:
+			return &AppendDecimal<int64_t>;
+		case duckdb::PhysicalType::INT128:
+			return &AppendDecimal<hugeint_t>;
 		default:
 			throw duckdb::InternalException("Unrecognized physical type (%s) for DECIMAL value",
 			                                duckdb::EnumUtil::ToString(physical_type));
 		}
-		break;
 	}
-	case duckdb::LogicalTypeId::UUID: {
-		Append(result, DatumGetUUID(value), offset);
-		break;
-	}
-	case duckdb::LogicalTypeId::BLOB: {
-		const char *bytea_data = VARDATA_ANY(value);
-		size_t bytea_length = VARSIZE_ANY_EXHDR(value);
-		const duckdb::string_t s(bytea_data, bytea_length);
-		auto data = duckdb::FlatVector::GetData<duckdb::string_t>(result);
-		data[offset] = duckdb::StringVector::AddStringOrBlob(result, s);
-		break;
-	}
-	case duckdb::LogicalTypeId::LIST: {
-		// Convert Datum to ArrayType
-		auto array = DatumGetArrayTypeP(value);
-
-		auto ndims = ARR_NDIM(array);
-		int *dims = ARR_DIMS(array);
-		auto elem_type = ARR_ELEMTYPE(array);
-
-		int16 typlen;
-		bool typbyval;
-		char typalign;
-		PostgresFunctionGuard(get_typlenbyvalalign, elem_type, &typlen, &typbyval, &typalign);
-
-		int nelems;
-		Datum *elems;
-		bool *nulls;
-		// Deconstruct the array into Datum elements
-		PostgresFunctionGuard(deconstruct_array, array, elem_type, typlen, typbyval, typalign, &elems, &nulls, &nelems);
-
-		if (ndims == -1) {
-			throw duckdb::InternalException("Array type has an ndims of -1, so it's actually not an array??");
-		}
-		// Set the list_entry_t metadata
-		duckdb::Vector *vec = &result;
-		int write_offset = offset;
-		for (int dim = 0; dim < ndims; dim++) {
-			auto previous_dimension = dim ? dims[dim - 1] : 1;
-			auto dimension = dims[dim];
-			if (vec->GetType().id() != duckdb::LogicalTypeId::LIST) {
-				throw duckdb::InvalidInputException(
-				    "Dimensionality of the schema and the data does not match, data contains more dimensions than the "
-				    "amount of dimensions specified by the schema");
-			}
-			auto child_offset = duckdb::ListVector::GetListSize(*vec);
-			auto list_data = duckdb::FlatVector::GetData<duckdb::list_entry_t>(*vec);
-			for (int entry = 0; entry < previous_dimension; entry++) {
-				list_data[write_offset + entry] = duckdb::list_entry_t(
-				    // All lists in a postgres row are enforced to have the same dimension
-				    // [[1,2],[2,3,4]] is not allowed, second list has 3 elements instead of 2
-				    child_offset + (dimension * entry), dimension);
-			}
-			auto new_child_size = child_offset + (dimension * previous_dimension);
-			duckdb::ListVector::Reserve(*vec, new_child_size);
-			duckdb::ListVector::SetListSize(*vec, new_child_size);
-			write_offset = child_offset;
-			auto &child = duckdb::ListVector::GetEntry(*vec);
-			vec = &child;
-		}
-		if (ndims == 0) {
-			D_ASSERT(nelems == 0);
-			auto child_offset = duckdb::ListVector::GetListSize(*vec);
-			auto list_data = duckdb::FlatVector::GetData<duckdb::list_entry_t>(*vec);
-			list_data[write_offset] = duckdb::list_entry_t(child_offset, 0);
-			vec = &duckdb::ListVector::GetEntry(*vec);
-		} else if (vec->GetType().id() == duckdb::LogicalTypeId::LIST) {
-			throw duckdb::InvalidInputException(
-			    "Dimensionality of the schema and the data does not match, data contains fewer dimensions than the "
-			    "amount of dimensions specified by the schema");
-		}
-
-		for (int i = 0; i < nelems; i++) {
-			idx_t dest_idx = write_offset + i;
-			if (nulls[i]) {
-				auto &array_mask = duckdb::FlatVector::Validity(*vec);
-				array_mask.SetInvalid(dest_idx);
-				continue;
-			}
-			ConvertPostgresToDuckValue(elem_type, elems[i], *vec, dest_idx);
-		}
-		break;
-	}
+	case duckdb::LogicalTypeId::UUID:
+		ASSERT_FIXED_LEN_PG_TYPE(attr_type);
+		return &AppendDatum<hugeint_t>;
+	case duckdb::LogicalTypeId::BLOB:
+		return &AppendBlob;
+	case duckdb::LogicalTypeId::LIST:
+		return &AppendList;
 	default:
-		throw duckdb::NotImplementedException("(DuckDB/ConvertPostgresToDuckValue) Unsupported pgduckdb type: %s",
-		                                      result.GetType().ToString().c_str());
+		throw duckdb::NotImplementedException("(DuckDB/GetPostgresToDuckValueFn) Unsupported pgduckdb type: %s",
+		                                      type.ToString().c_str());
 	}
+}
+
+#undef ASSERT_FIXED_LEN_PG_TYPE
+
+void
+ConvertPostgresToDuckValue(Oid attr_type, Datum value, duckdb::Vector &result, idx_t offset) {
+	auto fn = GetPostgresToDuckValueFn(attr_type, result);
+	fn(result, value, offset);
 }
 
 void
@@ -2055,19 +2142,8 @@ InsertTupleIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_loc
 			array_mask.SetInvalid(scan_local_state.output_vector_size);
 		} else {
 			auto attr = TupleDescAttr(slot->tts_tupleDescriptor, duckdb_output_index);
-			if (attr->attlen == -1) {
-				bool should_free = false;
-				Datum detoasted_value = DetoastPostgresDatum(
-				    reinterpret_cast<varlena *>(slot->tts_values[duckdb_output_index]), &should_free);
-				ConvertPostgresToDuckValue(attr->atttypid, detoasted_value, result,
-				                           scan_local_state.output_vector_size);
-				if (should_free) {
-					duckdb_free(reinterpret_cast<void *>(detoasted_value));
-				}
-			} else {
-				ConvertPostgresToDuckValue(attr->atttypid, slot->tts_values[duckdb_output_index], result,
-				                           scan_local_state.output_vector_size);
-			}
+			auto convert_fn = GetPostgresToDuckValueFn(attr->atttypid, result);
+			convert_fn(result, slot->tts_values[duckdb_output_index], scan_local_state.output_vector_size);
 		}
 	}
 
@@ -2111,6 +2187,9 @@ InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_lo
 		auto &result = output.data[duckdb_output_index];
 		auto attr = TupleDescAttr(slots[0]->tts_tupleDescriptor, duckdb_output_index);
 		bool is_safe_type = IsThreadSafeTypeForPostgresToDuckDB(attr->atttypid, result.GetType().id());
+		auto convert_fn = GetPostgresToDuckValueFn(attr->atttypid, result);
+		auto &validity = duckdb::FlatVector::Validity(result);
+		const idx_t base_offset = scan_local_state.output_vector_size;
 
 		std::unique_ptr<std::lock_guard<std::recursive_mutex>> lock_guard;
 		MemoryContext old_ctx = NULL;
@@ -2121,22 +2200,9 @@ InsertTuplesIntoChunk(duckdb::DataChunk &output, PostgresScanLocalState &scan_lo
 
 		for (int row = 0; row < num_slots; row++) {
 			if (slots[row]->tts_isnull[duckdb_output_index]) {
-				auto &array_mask = duckdb::FlatVector::Validity(result);
-				array_mask.SetInvalid(scan_local_state.output_vector_size + row);
+				validity.SetInvalid(base_offset + row);
 			} else {
-				if (attr->attlen == -1) {
-					bool should_free = false;
-					Datum detoasted_value = DetoastPostgresDatum(
-					    reinterpret_cast<varlena *>(slots[row]->tts_values[duckdb_output_index]), &should_free);
-					ConvertPostgresToDuckValue(attr->atttypid, detoasted_value, result,
-					                           scan_local_state.output_vector_size + row);
-					if (should_free) {
-						duckdb_free(reinterpret_cast<void *>(detoasted_value));
-					}
-				} else {
-					ConvertPostgresToDuckValue(attr->atttypid, slots[row]->tts_values[duckdb_output_index], result,
-					                           scan_local_state.output_vector_size + row);
-				}
+				convert_fn(result, slots[row]->tts_values[duckdb_output_index], base_offset + row);
 			}
 		}
 

--- a/src/scan/postgres_scan.cpp
+++ b/src/scan/postgres_scan.cpp
@@ -477,9 +477,11 @@ PostgresScanLocalState::PostgresScanLocalState(PostgresScanGlobalState *_global_
     : global_state(_global_state), output_vector_size(0), exhausted_scan(false) {
 	std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
 	bool registered = global_state->RegisterLocalState();
-	if (!registered || global_state->MaxThreads() <= 1) {
+	if (!registered) {
 		return;
 	}
+	// Both single-thread and parallel scans now stage tuples through these slots before
+	// handing them to the batched converter.
 	for (int i = 0; i < LOCAL_STATE_SLOT_BATCH_SIZE; i++) {
 		slots[i] = global_state->table_reader_global_state->InitTupleSlot();
 	}
@@ -550,35 +552,11 @@ SetOutputCardinality(duckdb::DataChunk &output, PostgresScanLocalState &local_st
 	local_state.output_vector_size -= output_cardinality;
 }
 
-/*
- * Fetches a single tuple from the underlying PostgreSQL table and appends it to the DuckDB output chunk.
- * This function is intended for use in single-threaded scans.
- *
- * @return True if a tuple was successfully fetched and inserted; false if there are no more tuples to scan.
- */
-static bool
-ScanSingleTuple(duckdb::DataChunk &output, PostgresScanLocalState &local_state) {
-	TupleTableSlot *slot = local_state.global_state->table_reader_global_state->GetNextTuple();
-	if (pgduckdb::TupleIsNull(slot)) {
-		return false;
-	}
-
-	SlotGetAllAttrs(slot);
-	// This memory context is used as a scratchpad space for any allocation required to add the tuple
-	// into the chunk, such as decoding jsonb columns to their json string representation. We need to
-	// only use this memory context here, and not for the full loop, because GetNextTuple() needs the
-	// actual tuple to survive until the next call to GetNextTuple(), to be able to do index scans.
-	// Cf. issue 796 and 802
-	MemoryContext old_context = pg::MemoryContextSwitchTo(local_state.global_state->duckdb_scan_memory_ctx);
-	InsertTupleIntoChunk(output, local_state, slot);
-	pg::MemoryContextSwitchTo(old_context);
-	return true;
-}
-
 void
 PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb::TableFunctionInput &data,
                                                 duckdb::DataChunk &output) {
 	auto &local_state = data.local_state->Cast<PostgresScanLocalState>();
+	auto &global_state = *local_state.global_state;
 
 	/* We have exhausted table scan */
 	if (local_state.exhausted_scan) {
@@ -589,49 +567,66 @@ PostgresScanTableFunction::PostgresScanFunction(duckdb::ClientContext &, duckdb:
 	local_state.output_vector_size = 0;
 
 	D_ASSERT(STANDARD_VECTOR_SIZE % LOCAL_STATE_SLOT_BATCH_SIZE == 0);
-	bool is_parallel_scan = local_state.global_state->MaxThreads() > 1;
-	size_t batch_size = is_parallel_scan ? LOCAL_STATE_SLOT_BATCH_SIZE : STANDARD_VECTOR_SIZE;
-	size_t num_batches = STANDARD_VECTOR_SIZE / batch_size;
+	const size_t num_batches = STANDARD_VECTOR_SIZE / LOCAL_STATE_SLOT_BATCH_SIZE;
+	auto &table_reader = *global_state.table_reader_global_state;
 
-	// For single-threaded scans, only one batch is processed and the global lock is acquired for each batch.
-	// For parallel scans, multiple batches are processed; the global lock is held only during tuple retrieval
-	// from the PostgreSQL parallel worker, allowing the rest of the processing to proceed concurrently.
-	for (size_t batch_idx = 0; batch_idx < num_batches; batch_idx++) {
-		size_t valid_slots = 0;
-		{
-			std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
-			for (size_t i = 0; i < batch_size; i++) {
-				bool ret = is_parallel_scan
-				               ? local_state.global_state->table_reader_global_state->GetNextMinimalWorkerTuple(
-				                     local_state.minimal_tuple_buffer[i])
-				               : ScanSingleTuple(output, local_state);
-				if (!ret) {
-					local_state.exhausted_scan = true;
-					break;
+	if (global_state.count_tuples_only) {
+		// COUNT(*): the aggregate node hands back one partial count per call; accumulate them into the
+		// output cardinality. There are no columns to convert.
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+		uint64_t count = 0;
+		while (table_reader.GetNextCount(&count)) {
+			global_state.total_row_count += count;
+			local_state.output_vector_size += count;
+		}
+		local_state.exhausted_scan = true;
+	} else if (table_reader.NumWorkersLaunched() > 0) {
+		// Parallel Postgres workers produce the tuples and several DuckDB threads consume them. Hold the
+		// global lock only while copying a batch of worker tuples (whose memory lives in transient shared
+		// queues) into per-slot byte buffers, then materialize and convert outside the lock so the other
+		// DuckDB threads can drain concurrently.
+		for (size_t batch_idx = 0; batch_idx < num_batches; batch_idx++) {
+			size_t valid_slots = 0;
+			{
+				std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+				for (size_t i = 0; i < LOCAL_STATE_SLOT_BATCH_SIZE; i++) {
+					if (!table_reader.GetNextMinimalWorkerTuple(local_state.minimal_tuple_buffer[i])) {
+						local_state.exhausted_scan = true;
+						break;
+					}
+					++valid_slots;
 				}
-
-				++valid_slots;
 			}
-
-			if (!is_parallel_scan) {
-				pg::MemoryContextReset(local_state.global_state->duckdb_scan_memory_ctx);
-				D_ASSERT(num_batches == 1);
+			for (size_t i = 0; i < valid_slots; i++) {
+				MinimalTuple minimal_tuple = reinterpret_cast<MinimalTuple>(local_state.minimal_tuple_buffer[i].data());
+				local_state.slots[i] = ExecStoreMinimalTupleUnsafe(minimal_tuple, local_state.slots[i], false);
+			}
+			InsertTuplesIntoChunk(output, local_state, local_state.slots, valid_slots);
+			if (local_state.exhausted_scan) {
 				break;
 			}
 		}
-
-		// The follow-up convertion logic is thread-safe.
-		D_ASSERT(is_parallel_scan);
-		for (size_t i = 0; i < valid_slots; i++) {
-			MinimalTuple minmal_tuple = reinterpret_cast<MinimalTuple>(local_state.minimal_tuple_buffer[i].data());
-			local_state.slots[i] = ExecStoreMinimalTupleUnsafe(minmal_tuple, local_state.slots[i], false);
-			SlotGetAllAttrs(local_state.slots[i]);
+	} else {
+		// In-process scan: exactly one DuckDB thread consumes this scan, so the global lock is uncontended.
+		// Take it once for the whole chunk and convert under it -- releasing early buys nothing without a
+		// second consumer, and one acquisition avoids re-locking per batch. Each tuple is copied straight into
+		// its slot (the slot owns the copy), so there is no staging buffer or per-tuple free. We do NOT switch
+		// memory contexts around the fetch: ExecProcNode allocates per-tuple executor state (e.g. index scans)
+		// in the caller context that must survive across calls -- see issue 796 and 802. InsertTuplesIntoChunk
+		// switches into the scratchpad on its own for the columns that need it.
+		std::lock_guard<std::recursive_mutex> lock(GlobalProcessLock::GetLock());
+		for (size_t batch_idx = 0; batch_idx < num_batches; batch_idx++) {
+			int valid_slots = table_reader.GetNextInProcessTuples(local_state.slots, LOCAL_STATE_SLOT_BATCH_SIZE);
+			InsertTuplesIntoChunk(output, local_state, local_state.slots, valid_slots);
+			if (valid_slots < LOCAL_STATE_SLOT_BATCH_SIZE) {
+				local_state.exhausted_scan = true;
+				break;
+			}
 		}
-		InsertTuplesIntoChunk(output, local_state, local_state.slots, valid_slots);
 	}
 
 	if (local_state.exhausted_scan) {
-		local_state.global_state->UnregisterLocalState();
+		global_state.UnregisterLocalState();
 	}
 	SetOutputCardinality(output, local_state);
 }

--- a/src/scan/postgres_table_reader.cpp
+++ b/src/scan/postgres_table_reader.cpp
@@ -293,11 +293,24 @@ PostgresTableReader::GetNextTupleUnsafe() {
 		}
 	}
 
+	return ExecNextTupleUnsafe();
+}
+
+TupleTableSlot *
+PostgresTableReader::ExecNextTupleUnsafe() {
 	PostgresScopedStackReset scoped_stack_reset;
 	table_scan_query_desc->estate->es_query_dsa = parallel_executor_info ? parallel_executor_info->area : NULL;
 	TupleTableSlot *thread_scan_slot = ExecProcNode(table_scan_planstate);
 	table_scan_query_desc->estate->es_query_dsa = NULL;
 	return TupIsNull(thread_scan_slot) ? ExecClearTuple(slot) : thread_scan_slot;
+}
+
+static inline void
+CopyMinimalTuple(MinimalTuple src_minimal_tuple, std::vector<uint8_t> &dst_buffer) {
+	// Deep-copy the minimal tuple's bytes into the destination buffer.
+	Size tuple_size = src_minimal_tuple->t_len + MINIMAL_TUPLE_DATA_OFFSET;
+	dst_buffer.resize(tuple_size);
+	memcpy(dst_buffer.data(), src_minimal_tuple, tuple_size);
 }
 
 /*
@@ -313,15 +326,45 @@ bool
 PostgresTableReader::GetNextMinimalWorkerTuple(std::vector<uint8_t> &minimal_tuple_buffer) {
 	MinimalTuple worker_minmal_tuple = GetNextWorkerTuple();
 	if (HeapTupleIsValid(worker_minmal_tuple)) {
-		// deep copy worker_minmal_tuple to destination buffer
-		Size tuple_size = worker_minmal_tuple->t_len + MINIMAL_TUPLE_DATA_OFFSET;
-		minimal_tuple_buffer.resize(tuple_size);
-		memcpy(minimal_tuple_buffer.data(), worker_minmal_tuple, tuple_size);
+		CopyMinimalTuple(worker_minmal_tuple, minimal_tuple_buffer);
 		return true;
 	}
 
 	minimal_tuple_buffer.resize(0);
 	return false;
+}
+
+int
+PostgresTableReader::GetNextInProcessTuples(TupleTableSlot **slots, int max) {
+	return PostgresMemberGuard(PostgresTableReader::GetNextInProcessTuplesUnsafe, slots, max);
+}
+
+int
+PostgresTableReader::GetNextInProcessTuplesUnsafe(TupleTableSlot **slots, int max) {
+	// One guard (set up by GetNextInProcessTuples) covers the whole batch instead of one per tuple.
+	int count = 0;
+	for (; count < max; count++) {
+		TupleTableSlot *thread_scan_slot = ExecNextTupleUnsafe();
+		if (TupIsNull(thread_scan_slot)) {
+			break;
+		}
+		// Each slot is a minimal-tuple slot; ExecCopySlot makes it take ownership of the copy (freed on its
+		// next store), so there is no per-tuple allocation for the caller to free. The copy is required
+		// because the scan node reuses `thread_scan_slot` on the next ExecProcNode call.
+		ExecCopySlot(slots[count], thread_scan_slot);
+	}
+	return count;
+}
+
+bool
+PostgresTableReader::GetNextCount(uint64_t *count_out) {
+	TupleTableSlot *next_slot = GetNextTuple();
+	if (TupIsNull(next_slot)) {
+		return false;
+	}
+	slot_getallattrs(next_slot);
+	*count_out = next_slot->tts_values[0];
+	return true;
 }
 
 MinimalTuple


### PR DESCRIPTION
# Key Changes

## Cut Datum->Vector conversion overhead

- `switch-case` duckdb type **per column** instead of **per value**.
- Move detoast into each converter so the row loop is uniform.
- varlen tuple value (e.g. NUMERIC) use `DetoastPostgresDatumInline` to avoid `duckdb_malloc`/`duckdb_free`.

## Unify the converter across single-thread + parallel scans

Both paths now feed one batched, column-major converter (`InsertTuplesIntoChunk`), which fires the per-column picker once per batch instead of once per row.

# Result

`select * from lineitem order by 1 limit 1` on TPCH SF=20 (17GB).

| config | main | PR | speedup |
|--|--|--|--|
| 0w1t | 63s | ~37.4s | 1.7x |
| 2w1t | 62s | ~33.5s | 1.85x |
| 4w1t | 63s | ~33.5s | 1.87x |
| 2w2t (default) | 32s | ~21.1s | 1.5x |
| 4w4t | 22s | ~19.0s | 1.16x |

w = `duckdb.max_workers_per_postgres_scan`
t = `duckdb.threads_for_postgres_scan`
