### PR TITLE
build: add macOS knobs for Postgres.app and brew postgres builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,21 @@ endif
 
 DUCKDB_BUILD_DIR = third_party/duckdb/build/$(DUCKDB_BUILD_TYPE)
 
+# DuckDB's CMake produces .dylib on macOS, but PGXS' $(DLSUFFIX) is .so even on
+# macOS. Pick the right suffix for the DuckDB shared lib based on the host OS.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	DUCKDB_LIB_SUFFIX = .dylib
+else
+	DUCKDB_LIB_SUFFIX = $(DLSUFFIX)
+endif
+
 ifeq ($(DUCKDB_BUILD), ReleaseStatic)
 	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/libduckdb_bundle.a
-	PG_DUCKDB_LINK_FLAGS = $(FULL_DUCKDB_LIB) -lcurl
+	# httpfs (bundled into the static archive) needs OpenSSL symbols.
+	PG_DUCKDB_LINK_FLAGS = $(FULL_DUCKDB_LIB) -lcurl -lssl -lcrypto
 else
-	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/src/libduckdb$(DLSUFFIX)
+	FULL_DUCKDB_LIB = $(DUCKDB_BUILD_DIR)/src/libduckdb$(DUCKDB_LIB_SUFFIX)
 	PG_DUCKDB_LINK_FLAGS = -lduckdb
 endif
 
@@ -72,19 +82,67 @@ endif
 
 COMPILER_FLAGS=-Wno-sign-compare -Wshadow -Wswitch -Wunused-parameter -Wunreachable-code -Wno-unknown-pragmas -Wall -Wextra ${ERROR_ON_WARNING}
 
+# On macOS, allow overriding the deployment target and/or the SDK sysroot.
+# Both are appended LATE so they override any earlier value inherited from
+# pg_config (which may point at an SDK that no longer exists, or an older
+# deployment target than pg_duckdb's C++17 features need).
+#
+# MACOSX_VERSION_MIN: e.g. 11.0 (needed for std::filesystem)
+# MACOSX_SYSROOT: e.g. $(xcrun --show-sdk-path), or
+#                       /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+MACOSX_VERSION_MIN ?=
+ifneq ($(MACOSX_VERSION_MIN),)
+	MACOSX_VERSION_MIN_FLAG = -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+else
+	MACOSX_VERSION_MIN_FLAG =
+endif
+
+MACOSX_SYSROOT ?=
+ifneq ($(MACOSX_SYSROOT),)
+	MACOSX_SYSROOT_FLAG = -isysroot $(MACOSX_SYSROOT)
+else
+	MACOSX_SYSROOT_FLAG =
+endif
+
+MACOSX_EXTRA_FLAGS = $(MACOSX_VERSION_MIN_FLAG) $(MACOSX_SYSROOT_FLAG)
+
 override PG_CPPFLAGS += -Iinclude -isystem third_party/duckdb/src/include -isystem third_party/duckdb/third_party/re2 -isystem $(INCLUDEDIR_SERVER) ${COMPILER_FLAGS}
-override PG_CXXFLAGS += -std=c++17 ${DUCKDB_BUILD_CXX_FLAGS} ${COMPILER_FLAGS} -Wno-register -Weffc++
+override PG_CXXFLAGS += -std=c++17 ${DUCKDB_BUILD_CXX_FLAGS} ${COMPILER_FLAGS} -Wno-register -Weffc++ $(MACOSX_EXTRA_FLAGS)
 # Ignore declaration-after-statement warnings in our code. Postgres enforces
 # this because their ancient style guide requires it, but we don't care. It
 # would only apply to C files anyway, and we don't have many of those. The only
 # ones that we do have are vendored in from Postgres (ruleutils), and allowing
 # declarations to be anywhere is even a good thing for those as we can keep our
 # changes to the vendored code in one place.
-override PG_CFLAGS += -Wno-declaration-after-statement
+override PG_CFLAGS += -Wno-declaration-after-statement $(MACOSX_EXTRA_FLAGS)
 
 SHLIB_LINK += $(PG_DUCKDB_LINK_FLAGS)
 
 include Makefile.global
+
+# Append the sysroot override LATE in CPPFLAGS and LDFLAGS — pg_config may
+# carry a stale `-isysroot <path>` (e.g. an SDK that no longer exists). Clang
+# uses the LAST -isysroot on the command line, so we append after the PGXS
+# include to outrank pg_config's value at both compile and link time.
+ifneq ($(MACOSX_SYSROOT),)
+override CPPFLAGS += -isysroot $(MACOSX_SYSROOT)
+override LDFLAGS += -isysroot $(MACOSX_SYSROOT)
+endif
+
+# On macOS, allow filtering out unwanted -arch flags inherited from pg_config.
+# Needed when Postgres ships as a universal binary (e.g. Postgres.app) but
+# DuckDB is built single-arch for the host. Set e.g. MACOSX_STRIP_ARCHES="arm64"
+# on an Intel Mac or "x86_64" on Apple Silicon.
+# Single arch name (e.g. "arm64"). Use $(subst) so the two-token "-arch <name>"
+# is removed as a literal substring; $(filter-out) would strip "-arch" from the
+# arch we want to keep too.
+MACOSX_STRIP_ARCH ?=
+ifneq ($(MACOSX_STRIP_ARCH),)
+override CFLAGS := $(subst -arch $(MACOSX_STRIP_ARCH),,$(CFLAGS))
+override CXXFLAGS := $(subst -arch $(MACOSX_STRIP_ARCH),,$(CXXFLAGS))
+override LDFLAGS := $(subst -arch $(MACOSX_STRIP_ARCH),,$(LDFLAGS))
+override CFLAGS_SL := $(subst -arch $(MACOSX_STRIP_ARCH),,$(CFLAGS_SL))
+endif
 
 # Only pass the version define to the one file that needs it, so that ccache
 # doesn't invalidate everything on every commit.


### PR DESCRIPTION
# Build pg_duckdb on macOS against common PostgreSQL distributions

## Summary

`make install` doesn't work out of the box on macOS when targeting the two most common local Postgres distributions — **Postgres.app** and **`brew install postgresql@15`** — because PGXS inherits compile and link flags verbatim from `pg_config`, and those flags often don't match the host toolchain anymore. Symptoms include `std::filesystem` errors (deployment target too old), `ld: symbol(s) not found for architecture arm64` (universal-binary mismatch), and `'stdio.h' file not found` (stale SDK sysroot from a Command Line Tools upgrade).

This PR adds five opt-in build knobs so the user can override the offending flags without editing `Makefile`. All knobs are inert when their env vars are unset, so **Linux builds are unaffected**.

## The knobs

| Variable | What it does | When you need it |
|---|---|---|
| `MACOSX_VERSION_MIN` | Appends `-mmacosx-version-min=<value>` to `PG_CXXFLAGS`/`PG_CFLAGS`. Clang takes the last `-mmacosx-version-min`, so this outranks `pg_config`'s value. | When `pg_config --cflags` pins an older target than `std::filesystem` (used in `src/pgduckdb_duckdb.cpp`) requires. Postgres.app v15 pins `10.13`; the file needs ≥ `10.15`. |
| `MACOSX_SYSROOT` | Appends `-isysroot <path>` to `CPPFLAGS` and `LDFLAGS` *after* `include Makefile.global` so it outranks `pg_config`'s value at both compile and link time. | When `pg_config --cppflags` carries a stale `-isysroot` pointing at an SDK that no longer exists (e.g. the brew bottle was built on a machine with `MacOSX14.sdk` but the user has upgraded Command Line Tools). |
| `MACOSX_STRIP_ARCH` | Strips a single `-arch <name>` pair from `CFLAGS`/`CXXFLAGS`/`LDFLAGS`/`CFLAGS_SL` via `$(subst)`. | When Postgres ships as a universal binary (Postgres.app) but DuckDB builds single-arch for the host. The link otherwise produces fat object files whose non-host slice has no DuckDB symbols. |
| *(automatic)* `DUCKDB_LIB_SUFFIX` | Auto-detects `.dylib` on Darwin (PGXS' `$(DLSUFFIX)` is `.so` even on macOS, but DuckDB's CMake produces `.dylib`). | Always, on macOS — fixes the `install-duckdb` step. No user action needed. |
| `DUCKDB_BUILD=ReleaseStatic` | The static link now also pulls `-lssl -lcrypto`. | Always, when building static — the `httpfs` extension bundled into `libduckdb_bundle.a` needs OpenSSL symbols and previously failed to link. |

## Build recipes

### Postgres.app (universal binary, old deployment target)

```bash
git submodule update --init --recursive

# Dynamic
MACOSX_VERSION_MIN=11.0 MACOSX_STRIP_ARCH=arm64 \
  PG_CONFIG=/Applications/Postgres.app/Contents/Versions/15/bin/pg_config \
  make -j$(sysctl -n hw.ncpu) install

# Static (one self-contained .so, ~54 MB, no libduckdb.dylib dependency)
DUCKDB_BUILD=ReleaseStatic MACOSX_VERSION_MIN=11.0 MACOSX_STRIP_ARCH=arm64 \
  PG_CONFIG=/Applications/Postgres.app/Contents/Versions/15/bin/pg_config \
  make -j$(sysctl -n hw.ncpu) install
```

Use `MACOSX_STRIP_ARCH=x86_64` on Apple Silicon (your host's slice is the one you want to keep; strip the *other* one).

### Homebrew `postgresql@15` (stale SDK sysroot in pg_config)

```bash
git submodule update --init --recursive

# Dynamic
MACOSX_SYSROOT="$(xcrun --show-sdk-path)" \
  PG_CONFIG=/usr/local/opt/postgresql@15/bin/pg_config \
  make -j$(sysctl -n hw.ncpu) install

# Static
DUCKDB_BUILD=ReleaseStatic MACOSX_SYSROOT="$(xcrun --show-sdk-path)" \
  PG_CONFIG=/usr/local/opt/postgresql@15/bin/pg_config \
  make -j$(sysctl -n hw.ncpu) install
```

`MACOSX_VERSION_MIN` is not needed for brew Postgres because its `pg_config` doesn't set `-mmacosx-version-min`. `MACOSX_STRIP_ARCH` is not needed because brew's binary is already single-arch for the host.

**Alternative for brew users:** `brew reinstall --build-from-source postgresql@15` rebuilds Postgres against your current SDK, after which the build works without `MACOSX_SYSROOT`. A plain `brew reinstall` only re-pours the bottle and doesn't help.

## Verification

Built and `CREATE EXTENSION pg_duckdb;` successfully against Postgres.app 15.14 (Intel Mac, universal binary, `-mmacosx-version-min=10.13`). Both dynamic and static builds. Built successfully against Homebrew `postgresql@15` 15.18 (bottle).

`otool -L` summary:

```
# Dynamic
@rpath/libduckdb.dylib
/usr/lib/libc++.1.dylib
.../liblz4.1.dylib
/usr/lib/libSystem.B.dylib

# Static (no @rpath/libduckdb.dylib)
/usr/lib/libcurl.4.dylib
.../libssl.3.dylib
.../libcrypto.3.dylib
/usr/lib/libc++.1.dylib
.../liblz4.1.dylib
/usr/lib/libSystem.B.dylib
```

## Test plan

- [ ] `make install` against Postgres.app v15 with `MACOSX_VERSION_MIN=11.0 MACOSX_STRIP_ARCH=arm64` (Intel)
- [ ] `make install` against Postgres.app v15 with `MACOSX_VERSION_MIN=11.0 MACOSX_STRIP_ARCH=x86_64` (Apple Silicon)
- [ ] `DUCKDB_BUILD=ReleaseStatic make install` against Postgres.app v15
- [ ] `make install` against `brew postgresql@15` with `MACOSX_SYSROOT="$(xcrun --show-sdk-path)"`
- [ ] `make install` on Linux (no env vars set) — should be byte-for-byte unchanged in behavior

## Related issues and PRs

- **[#997 — Compilation docs: clarify macOS DLSUFFIX mismatch](https://github.com/duckdb/pg_duckdb/pull/997)** (open, docs-only). Documents the same `libduckdb.so` vs `libduckdb.dylib` install failure that the auto-detect in this PR fixes programmatically. #997 recommends "use PostgreSQL 16+ as a workaround". This PR fixes the underlying bug for *all* supported Postgres majors (14–18) by picking the right suffix on Darwin in the Makefile. If this PR is merged, #997 can either be closed or kept as a friendly docs note.
- **[#848 — Build fails on GCC 8 due to missing `-lstdc++fs` when using `std::filesystem`](https://github.com/duckdb/pg_duckdb/issues/848)** (open). Same `std::filesystem` usage in `src/pgduckdb_duckdb.cpp`, different platform. The existing GCC 8 workaround at `Makefile:66-74` addresses the Linux side; this PR's `MACOSX_VERSION_MIN` knob addresses the macOS side where the symptom is "`'create_directories' is unavailable: introduced in macOS 10.15`" because `pg_config` inherits a deployment target older than 10.15.
- **Lineage of earlier macOS compile fixes** — [#568](https://github.com/duckdb/pg_duckdb/pull/568), [#645](https://github.com/duckdb/pg_duckdb/pull/645), [#671](https://github.com/duckdb/pg_duckdb/pull/671) (all merged). Those were *source-code* fixes for Clang strictness on macOS. This PR is in the same family but at the *toolchain/Makefile* layer rather than the source layer — it does not change any `.cpp` files.
- **Not addressed**: [#1002 — Regress tests stuck on macOS arm64](https://github.com/duckdb/pg_duckdb/issues/1002). That's a runtime hang in `make installcheck`, not a build issue, and is orthogonal to this PR.

## Notes for reviewers

- The Makefile additions are all conditional on the new env vars being set, so Linux/CI builds are unaffected. The only unconditional change is the `Darwin`-gated `.dylib`/`.so` auto-detect for the DuckDB lib path, which fixes a latent bug in `install-duckdb` on macOS (the bug #997 documents).
- The `MACOSX_SYSROOT` override applies to both `CPPFLAGS` (compile) and `LDFLAGS` (link) because both inherit a stale `-isysroot` from `pg_config`. It's placed *after* `include Makefile.global` because PGXS injects `pg_config`'s flags later than `PG_CPPFLAGS`/`PG_CXXFLAGS`, and Clang uses the last `-isysroot`.
- `MACOSX_STRIP_ARCH` uses `$(subst -arch X,,...)` rather than `$(filter-out)` because `-arch X` is a two-token sequence — `$(filter-out)` would strip the bare `-arch` from the arch you want to keep.
- Could be extended to auto-detect host arch and auto-strip the other one on macOS; left explicit to avoid surprising users who deliberately want a universal build (e.g. by also building DuckDB with `-DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'`).