### PR TITLE
fix: numeric result-type corruption in the extended query protocol

### DIFF
--- a/include/pgduckdb/pg/types.hpp
+++ b/include/pgduckdb/pg/types.hpp
@@ -8,6 +8,8 @@ bool IsDomainType(Oid type_oid);
 bool IsArrayDomainType(Oid type_oid);
 Oid GetBaseTypeAndTypmod(Oid attribute_type_oid, int32_t *type_modifier);
 Datum StringToNumeric(const char *str);
+Datum DoubleToNumeric(double value, int32_t typmod);
+Datum FloatToNumeric(float value, int32_t typmod);
 Datum StringToVarbit(const char *str);
 const char *VarbitToString(Datum pg_varbit);
 } // namespace pgduckdb::pg

--- a/src/pg/types.cpp
+++ b/src/pg/types.cpp
@@ -72,6 +72,41 @@ StringToNumeric(const char *str) {
 	return PostgresFunctionGuard(StringToNumeric_C, str);
 }
 
+/*
+ * Convert a floating point value to a Postgres numeric Datum, mirroring
+ * Postgres' own float8::numeric / float4::numeric casts. This is used when the
+ * Postgres parser types a result column as numeric but DuckDB computed it as a
+ * floating point value. A non-negative typmod is applied to match an explicit
+ * numeric(p,s) declaration.
+ */
+static Datum
+DoubleToNumeric_C(double value, int32 typmod) {
+	Datum num = DirectFunctionCall1(float8_numeric, Float8GetDatum(value));
+	if (typmod != -1) {
+		num = DirectFunctionCall2(numeric, num, Int32GetDatum(typmod));
+	}
+	return num;
+}
+
+Datum
+DoubleToNumeric(double value, int32 typmod) {
+	return PostgresFunctionGuard(DoubleToNumeric_C, value, typmod);
+}
+
+static Datum
+FloatToNumeric_C(float value, int32 typmod) {
+	Datum num = DirectFunctionCall1(float4_numeric, Float4GetDatum(value));
+	if (typmod != -1) {
+		num = DirectFunctionCall2(numeric, num, Int32GetDatum(typmod));
+	}
+	return num;
+}
+
+Datum
+FloatToNumeric(float value, int32 typmod) {
+	return PostgresFunctionGuard(FloatToNumeric_C, value, typmod);
+}
+
 static Datum
 StringToVarbit_C(const char *str) {
 	return DirectFunctionCall3(varbit_in, CStringGetDatum(str), /*typelen=*/ObjectIdGetDatum(VARBITOID),

--- a/src/pgduckdb_node.cpp
+++ b/src/pgduckdb_node.cpp
@@ -123,7 +123,16 @@ Duckdb_BeginCustomScan_Cpp(CustomScanState *cscanstate, EState *estate, int /*ef
 	if (!is_explain_query) {
 		auto &prepared_result_types = prepared_query->GetTypes();
 
-		size_t target_list_length = static_cast<size_t>(list_length(duckdb_scan_state->custom_scan->custom_scan_tlist));
+		/*
+		 * The plan's Var types are the parser-assigned Postgres types (see
+		 * CreatePlan), so we compare against the DuckDB-derived Oids that we
+		 * stashed in custom_private at planning time to detect a DuckDB
+		 * result-type change between planning and execution (e.g. a CSV/Parquet
+		 * file whose inferred types changed).
+		 */
+		List *plan_duckdb_column_oids = (List *)lsecond(duckdb_scan_state->custom_scan->custom_private);
+
+		size_t target_list_length = static_cast<size_t>(list_length(plan_duckdb_column_oids));
 
 		if (prepared_result_types.size() != target_list_length) {
 			elog(ERROR,
@@ -133,14 +142,11 @@ Duckdb_BeginCustomScan_Cpp(CustomScanState *cscanstate, EState *estate, int /*ef
 		}
 
 		for (size_t i = 0; i < prepared_result_types.size(); i++) {
-			Oid postgres_column_oid = pgduckdb::GetPostgresDuckDBType(prepared_result_types[i], true);
-
-			TargetEntry *target_entry =
-			    list_nth_node(TargetEntry, duckdb_scan_state->custom_scan->custom_scan_tlist, i);
-			Var *var = castNode(Var, target_entry->expr);
-			if (var->vartype != postgres_column_oid) {
+			Oid exec_column_oid = pgduckdb::GetPostgresDuckDBType(prepared_result_types[i], true);
+			Oid plan_column_oid = list_nth_oid(plan_duckdb_column_oids, i);
+			if (plan_column_oid != exec_column_oid) {
 				elog(ERROR, "Types returned by duckdb query changed between planning and execution, expected %d got %d",
-				     var->vartype, postgres_column_oid);
+				     plan_column_oid, exec_column_oid);
 			}
 		}
 	}

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -92,8 +92,8 @@ CreatePlan(Query *query, bool throw_error) {
 	 * DuckDB can resolve. We also need the parser target list to line up 1:1
 	 * with DuckDB's columns (it does not when e.g. a duckdb.row expands to "*").
 	 */
-	List *result_tlist = (query->commandType != CMD_SELECT && query->returningList != NIL) ? query->returningList
-	                                                                                        : query->targetList;
+	List *result_tlist =
+	    (query->commandType != CMD_SELECT && query->returningList != NIL) ? query->returningList : query->targetList;
 	List *parser_tes = NIL;
 	foreach_node(TargetEntry, tle, result_tlist) {
 		if (!tle->resjunk) {

--- a/src/pgduckdb_planner.cpp
+++ b/src/pgduckdb_planner.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include "catalog/pg_type.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodes.h"
+#include "nodes/nodeFuncs.h"
 #include "nodes/params.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/planner.h"
@@ -71,24 +72,79 @@ CreatePlan(Query *query, bool throw_error) {
 
 	auto &prepared_result_types = prepared_query->GetTypes();
 
+	/*
+	 * Postgres freezes the result column types of a query from the parser's
+	 * point of view (PlanCacheComputeResultDesc -> ExecCleanTypeFromTL over the
+	 * non-junk target list), and uses those types for the RowDescription in the
+	 * extended query protocol / cached plans. DuckDB may type the same
+	 * expression differently (e.g. ROUND(AVG(int) / c, n) is numeric in Postgres
+	 * but double in DuckDB). If our plan declared the DuckDB type, the simple
+	 * protocol would work but the extended protocol would emit the value under
+	 * the parser's type, reinterpreting the bytes and corrupting the result.
+	 *
+	 * So to behave like Postgres in both protocols we declare the
+	 * parser-assigned type for numeric columns -- the case where DuckDB and
+	 * Postgres systematically disagree (DuckDB computes a double/decimal while
+	 * Postgres' parser says numeric) -- and coerce DuckDB's value to numeric at
+	 * execution time. Every other column keeps the DuckDB-derived type, which is
+	 * what makes the simple protocol work today; the parser type for those is
+	 * either identical or a placeholder (duckdb.row / unresolved_type) that only
+	 * DuckDB can resolve. We also need the parser target list to line up 1:1
+	 * with DuckDB's columns (it does not when e.g. a duckdb.row expands to "*").
+	 */
+	List *result_tlist = (query->commandType != CMD_SELECT && query->returningList != NIL) ? query->returningList
+	                                                                                        : query->targetList;
+	List *parser_tes = NIL;
+	foreach_node(TargetEntry, tle, result_tlist) {
+		if (!tle->resjunk) {
+			parser_tes = lappend(parser_tes, tle);
+		}
+	}
+	bool use_parser_types = static_cast<size_t>(list_length(parser_tes)) == prepared_result_types.size();
+
+	/*
+	 * The DuckDB-derived Postgres Oids, stashed in custom_private so the
+	 * executor can detect a DuckDB result-type change between planning and
+	 * execution (the plan's Var types are now the parser types, so we can no
+	 * longer use them for that check).
+	 */
+	List *duckdb_column_oids = NIL;
+
 	for (size_t i = 0; i < prepared_result_types.size(); i++) {
-		Oid postgresColumnOid = pgduckdb::GetPostgresDuckDBType(prepared_result_types[i], throw_error);
+		Oid duckdb_column_oid = pgduckdb::GetPostgresDuckDBType(prepared_result_types[i], throw_error);
 
-		if (!OidIsValid(postgresColumnOid)) {
+		if (!OidIsValid(duckdb_column_oid)) {
 			return nullptr;
 		}
 
-		HeapTuple tp;
-		Form_pg_type typtup;
+		duckdb_column_oids = lappend_oid(duckdb_column_oids, duckdb_column_oid);
 
-		tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(postgresColumnOid));
-		if (!HeapTupleIsValid(tp)) {
-			elog(elevel, "(PGDuckDB/CreatePlan) Cache lookup failed for type %u", postgresColumnOid);
-			return nullptr;
+		/* Default to the DuckDB-derived type. */
+		Oid column_oid = duckdb_column_oid;
+		int32 column_typmod = pgduckdb::GetPostgresDuckDBTypemod(prepared_result_types[i]);
+		Oid column_collation = get_typcollation(duckdb_column_oid);
+
+		/*
+		 * Override with the parser type only when Postgres' parser says the
+		 * column is numeric but DuckDB produced a non-numeric type (i.e. a
+		 * double/float). That is the case that corrupts results in the extended
+		 * protocol, because the cached result descriptor (numeric) disagrees
+		 * with the value we emit. When DuckDB already produces a numeric the oid
+		 * matches, so we keep the DuckDB type: its typmod is harmless for the
+		 * numeric wire format, and is the bounded DECIMAL that e.g. CREATE TABLE
+		 * AS needs (Postgres' bare numeric is unbounded, which DuckDB can't
+		 * store). We deliberately require an exact NUMERICOID match (not the base
+		 * type) so domains over numeric keep the DuckDB type, since the value
+		 * converter dispatches on the declared oid and does not handle domains.
+		 */
+		if (use_parser_types && duckdb_column_oid != NUMERICOID) {
+			TargetEntry *tle = list_nth_node(TargetEntry, parser_tes, i);
+			if (exprType((Node *)tle->expr) == NUMERICOID) {
+				column_oid = NUMERICOID;
+				column_typmod = exprTypmod((Node *)tle->expr);
+				column_collation = exprCollation((Node *)tle->expr);
+			}
 		}
-
-		typtup = (Form_pg_type)GETSTRUCT(tp);
-		typtup->typtypmod = pgduckdb::GetPostgresDuckDBTypemod(prepared_result_types[i]);
 
 		/*
 		 * We hardcode varno 1 here, because our final plan will only have a
@@ -96,7 +152,7 @@ CreatePlan(Query *query, bool throw_error) {
 		 * filled it in later. If at some point we need multiple RTEs again, we
 		 * might want to start doing that again.
 		 */
-		Var *var = makeVar(1, i + 1, postgresColumnOid, typtup->typtypmod, typtup->typcollation, 0);
+		Var *var = makeVar(1, i + 1, column_oid, column_typmod, column_collation, 0);
 
 		TargetEntry *target_entry =
 		    makeTargetEntry((Expr *)var, i + 1, (char *)pstrdup(prepared_query->GetNames()[i].c_str()), false);
@@ -111,11 +167,9 @@ CreatePlan(Query *query, bool throw_error) {
 		/* But we also need an actual target list, because Postgres expects it
 		 * for things like materialization */
 		duckdb_node->scan.plan.targetlist = lappend(duckdb_node->scan.plan.targetlist, target_entry);
-
-		ReleaseSysCache(tp);
 	}
 
-	duckdb_node->custom_private = list_make1(query);
+	duckdb_node->custom_private = list_make2(query, duckdb_column_oids);
 	duckdb_node->methods = &duckdb_scan_scan_methods;
 
 	return (Plan *)duckdb_node;

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -446,7 +446,7 @@ ConvertNumeric(const duckdb::Value &ddb_value, idx_t scale, NumericVar &result) 
 }
 
 static Datum
-ConvertNumericDatum(const duckdb::Value &value) {
+ConvertNumericDatum(const duckdb::Value &value, int32 typmod) {
 	auto value_type_id = value.type().id();
 
 	// Special handle duckdb BIGNUM type.
@@ -458,14 +458,31 @@ ConvertNumericDatum(const duckdb::Value &value) {
 		return pg_numeric;
 	}
 
-	// Special handle duckdb DOUBLE TYPE.
+	// DuckDB FLOAT/DOUBLE -> Postgres numeric. This happens when the Postgres
+	// parser typed the result column as numeric but DuckDB computed it as a
+	// floating point value (e.g. ROUND(AVG(int) / c, n)). We must produce a real
+	// numeric Datum (matching Postgres' own float->numeric cast) rather than the
+	// raw float bytes, otherwise the value is reinterpreted as a numeric varlena
+	// in the extended query protocol (where the output uses the parser's numeric
+	// type), corrupting the result.
 	if (value_type_id == duckdb::LogicalTypeId::DOUBLE) {
-		return ConvertDoubleDatum(value);
+		return pgduckdb::pg::DoubleToNumeric(value.GetValue<double>(), typmod);
+	}
+	if (value_type_id == duckdb::LogicalTypeId::FLOAT) {
+		return pgduckdb::pg::FloatToNumeric(value.GetValue<float>(), typmod);
+	}
+
+	// The fast NumericVar path below only handles the decimal-family physical
+	// representations. Any other DuckDB type that ends up in a numeric column
+	// (e.g. an integer or a value from a DuckDB-only function whose Postgres
+	// signature declares numeric) is converted via its text representation,
+	// which is robust and never crashes.
+	if (value_type_id != duckdb::LogicalTypeId::DECIMAL && value_type_id != duckdb::LogicalTypeId::HUGEINT &&
+	    value_type_id != duckdb::LogicalTypeId::UBIGINT && value_type_id != duckdb::LogicalTypeId::UHUGEINT) {
+		return pgduckdb::pg::StringToNumeric(value.ToString().c_str());
 	}
 
 	NumericVar numeric_var;
-	D_ASSERT(value_type_id == duckdb::LogicalTypeId::DECIMAL || value_type_id == duckdb::LogicalTypeId::HUGEINT ||
-	         value_type_id == duckdb::LogicalTypeId::UBIGINT || value_type_id == duckdb::LogicalTypeId::UHUGEINT);
 	const bool is_decimal = value_type_id == duckdb::LogicalTypeId::DECIMAL;
 	uint8_t scale = is_decimal ? duckdb::DecimalType::GetScale(value.type()) : 0;
 
@@ -791,7 +808,8 @@ struct PostgresTypeTraits<NUMERICOID> {
 
 	static inline Datum
 	ToDatum(const duckdb::Value &val) {
-		return ConvertNumericDatum(val);
+		/* Array elements carry no per-element typmod. */
+		return ConvertNumericDatum(val, -1);
 	}
 };
 
@@ -1157,7 +1175,7 @@ ConvertDuckToPostgresValue(TupleTableSlot *slot, duckdb::Value &value, idx_t col
 		break;
 	}
 	case NUMERICOID: {
-		slot->tts_values[col] = ConvertNumericDatum(value);
+		slot->tts_values[col] = ConvertNumericDatum(value, TupleDescAttr(slot->tts_tupleDescriptor, col)->atttypmod);
 		break;
 	}
 	case UUIDOID: {

--- a/src/pgduckdb_types.cpp
+++ b/src/pgduckdb_types.cpp
@@ -468,6 +468,10 @@ ConvertNumericDatum(const duckdb::Value &value, int32 typmod) {
 	if (value_type_id == duckdb::LogicalTypeId::DOUBLE) {
 		return pgduckdb::pg::DoubleToNumeric(value.GetValue<double>(), typmod);
 	}
+	// FLOAT is handled for completeness/symmetry; it is not reachable through
+	// query push-down today (a query whose Postgres parser type is numeric never
+	// makes DuckDB emit a bare FLOAT -- a ::numeric cast becomes a DECIMAL), and
+	// the generic fallback below would convert it correctly anyway.
 	if (value_type_id == duckdb::LogicalTypeId::FLOAT) {
 		return pgduckdb::pg::FloatToNumeric(value.GetValue<float>(), typmod);
 	}

--- a/test/pycheck/prepared_test.py
+++ b/test/pycheck/prepared_test.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from decimal import Decimal
 
 import psycopg.types.json
 import pytest
@@ -174,6 +175,38 @@ def test_prepared_ctas(cur: Cursor):
     cur.sql("DROP TABLE t3")
     cur.sql(prepared_query)
     assert cur.sql("SELECT count(*) FROM t3") == 3
+
+
+def test_prepared_type_mismatch(cur: Cursor):
+    # Postgres types ROUND(AVG(bigint) / 1024.0, 2) as numeric, while DuckDB
+    # types it as double. pg_duckdb must declare (and return) the Postgres parser
+    # type, so the value is the same in the simple and the extended/cached-plan
+    # protocols instead of being reinterpreted as garbage. psycopg returns a
+    # Decimal for numeric and a float for double, so comparing against a Decimal
+    # asserts both the value AND that we report the Postgres type.
+    cur.sql("CREATE TABLE metrics(id int, vol bigint)")
+    cur.sql("INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g")
+
+    q = "SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics"
+    expected = Decimal("49.32")
+
+    # Unprepared (extended protocol).
+    result = cur.sql(q)
+    assert result == expected
+    assert isinstance(result, Decimal)
+
+    # Server-prepared statement, executed multiple times (custom then generic plan).
+    cur.sql("SET plan_cache_mode = 'force_custom_plan'")
+    assert cur.sql(q, prepare=True) == expected
+    assert cur.sql(q) == expected
+    cur.sql("SET plan_cache_mode = 'force_generic_plan'")
+    assert cur.sql(q) == expected
+
+    # Parameterized variant (parameter in the filter), numeric result column.
+    cur.sql("SET plan_cache_mode = 'auto'")
+    q2 = "SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics WHERE id > %s"
+    assert cur.sql(q2, (0,), prepare=True) == expected
+    assert cur.sql(q2, (0,)) == expected
 
 
 def test_prepared_change_type(cur: Cursor, tmp_path):

--- a/test/pycheck/prepared_test.py
+++ b/test/pycheck/prepared_test.py
@@ -185,7 +185,9 @@ def test_prepared_type_mismatch(cur: Cursor):
     # Decimal for numeric and a float for double, so comparing against a Decimal
     # asserts both the value AND that we report the Postgres type.
     cur.sql("CREATE TABLE metrics(id int, vol bigint)")
-    cur.sql("INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g")
+    cur.sql(
+        "INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g"
+    )
 
     q = "SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics"
     expected = Decimal("49.32")
@@ -207,6 +209,15 @@ def test_prepared_type_mismatch(cur: Cursor):
     q2 = "SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics WHERE id > %s"
     assert cur.sql(q2, (0,), prepare=True) == expected
     assert cur.sql(q2, (0,)) == expected
+
+    # Bare AVG(bigint): Postgres numeric, DuckDB double -> double->numeric path.
+    assert cur.sql("SELECT AVG(vol) FROM metrics", prepare=True) == Decimal("50500")
+    assert isinstance(cur.sql("SELECT AVG(vol) FROM metrics"), Decimal)
+
+    # Postgres numeric where DuckDB also yields numeric (DECIMAL): unchanged.
+    assert cur.sql("SELECT MIN(vol) + 0.5 FROM metrics", prepare=True) == Decimal(
+        "1000.5"
+    )
 
 
 def test_prepared_change_type(cur: Cursor, tmp_path):

--- a/test/regression/expected/execution_error.out
+++ b/test/regression/expected/execution_error.out
@@ -16,7 +16,7 @@ Did you mean "main.pragma_user_agent"?
 
 LINE 1: SELECT raw_query FROM duckdb.raw_query('aaaaa'::text) raw_query(raw_query)
                               ^
-LOCATION:  CreatePlan, pgduckdb_planner.cpp:66
+LOCATION:  CreatePlan, pgduckdb_planner.cpp:67
 ERROR:  XX000: (PGDuckDB/pgduckdb_raw_query_cpp) Parser Error: syntax error at or near "aaaaa"
 
 LINE 1: aaaaa

--- a/test/regression/expected/prepare_type_mismatch.out
+++ b/test/regression/expected/prepare_type_mismatch.out
@@ -55,6 +55,37 @@ EXECUTE pbug2(0);
  49.32
 (1 row)
 
+-- Bare aggregate: Postgres types AVG(bigint) as numeric, DuckDB as double. This
+-- exercises the double -> numeric coercion directly (no surrounding ROUND).
+PREPARE pavg AS SELECT AVG(vol) AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pavg';
+ result_types 
+--------------
+ {numeric}
+(1 row)
+
+EXECUTE pavg;
+   v   
+-------
+ 50500
+(1 row)
+
+-- Postgres numeric where DuckDB also produces a numeric (DECIMAL): the oids
+-- already match so we keep the DuckDB type; the value must still pass through
+-- the cached-plan path unchanged.
+PREPARE pdec AS SELECT MIN(vol) + 0.5 AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pdec';
+ result_types 
+--------------
+ {numeric}
+(1 row)
+
+EXECUTE pdec;
+    v     
+----------
+ 1000.500
+(1 row)
+
 -- Control: when Postgres and DuckDB agree on the type (double), the value is
 -- already correct and stays unchanged.
 PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;

--- a/test/regression/expected/prepare_type_mismatch.out
+++ b/test/regression/expected/prepare_type_mismatch.out
@@ -9,6 +9,11 @@
 -- that the cached-plan path returns the same correct value as the simple
 -- protocol instead of reinterpreting the bytes (which previously yielded
 -- garbage such as 0.000000000000000000000000000000).
+--
+-- NOTE: we deliberately do not query pg_prepared_statements.result_types here;
+-- that column only exists on PostgreSQL 16+. The EXECUTE results below are what
+-- demonstrate the fix, and they are identical across the simple and extended
+-- protocols and across PostgreSQL versions.
 SET duckdb.force_execution = true;
 CREATE TABLE metrics(id int, vol bigint);
 INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g;
@@ -19,16 +24,8 @@ SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
  49.32
 (1 row)
 
--- The cached plan's result type is numeric (this is what the extended protocol
--- uses for the row description / output).
-PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pbug';
- result_types 
---------------
- {numeric}
-(1 row)
-
 -- Cached-plan path: must match the simple-protocol value, not corrupt it.
+PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
 EXECUTE pbug;
    v   
 -------
@@ -58,12 +55,6 @@ EXECUTE pbug2(0);
 -- Bare aggregate: Postgres types AVG(bigint) as numeric, DuckDB as double. This
 -- exercises the double -> numeric coercion directly (no surrounding ROUND).
 PREPARE pavg AS SELECT AVG(vol) AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pavg';
- result_types 
---------------
- {numeric}
-(1 row)
-
 EXECUTE pavg;
    v   
 -------
@@ -74,12 +65,6 @@ EXECUTE pavg;
 -- already match so we keep the DuckDB type; the value must still pass through
 -- the cached-plan path unchanged.
 PREPARE pdec AS SELECT MIN(vol) + 0.5 AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pdec';
- result_types 
---------------
- {numeric}
-(1 row)
-
 EXECUTE pdec;
     v     
 ----------
@@ -89,12 +74,6 @@ EXECUTE pdec;
 -- Control: when Postgres and DuckDB agree on the type (double), the value is
 -- already correct and stays unchanged.
 PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pok';
-     result_types     
-----------------------
- {"double precision"}
-(1 row)
-
 EXECUTE pok;
       v      
 -------------

--- a/test/regression/expected/prepare_type_mismatch.out
+++ b/test/regression/expected/prepare_type_mismatch.out
@@ -1,0 +1,82 @@
+-- Regression test for result-type handling in the extended query protocol.
+--
+-- PostgreSQL's parser and DuckDB can assign different types to the same result
+-- column. For example ROUND(AVG(bigint) / 1024.0, 2) is NUMERIC according to
+-- the Postgres parser but DOUBLE according to DuckDB. The Postgres parser type
+-- is what gets frozen into the cached plan's result descriptor (and sent as the
+-- RowDescription) in the extended / cached-plan path (PREPARE/EXECUTE, JDBC,
+-- ...). pg_duckdb must therefore produce values of the parser-declared type, so
+-- that the cached-plan path returns the same correct value as the simple
+-- protocol instead of reinterpreting the bytes (which previously yielded
+-- garbage such as 0.000000000000000000000000000000).
+SET duckdb.force_execution = true;
+CREATE TABLE metrics(id int, vol bigint);
+INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g;
+-- Simple protocol: baseline correct value (Postgres parser type is numeric).
+SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
+   v   
+-------
+ 49.32
+(1 row)
+
+-- The cached plan's result type is numeric (this is what the extended protocol
+-- uses for the row description / output).
+PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pbug';
+ result_types 
+--------------
+ {numeric}
+(1 row)
+
+-- Cached-plan path: must match the simple-protocol value, not corrupt it.
+EXECUTE pbug;
+   v   
+-------
+ 49.32
+(1 row)
+
+EXECUTE pbug;
+   v   
+-------
+ 49.32
+(1 row)
+
+-- Parameterized + cached plan: parameter in the filter, numeric result column.
+PREPARE pbug2(int) AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics WHERE id > $1;
+EXECUTE pbug2(0);
+   v   
+-------
+ 49.32
+(1 row)
+
+EXECUTE pbug2(0);
+   v   
+-------
+ 49.32
+(1 row)
+
+-- Control: when Postgres and DuckDB agree on the type (double), the value is
+-- already correct and stays unchanged.
+PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pok';
+     result_types     
+----------------------
+ {"double precision"}
+(1 row)
+
+EXECUTE pok;
+      v      
+-------------
+ 49.31640625
+(1 row)
+
+-- Control: integer aggregate, both agree on the type.
+PREPARE pcount AS SELECT count(*) AS c FROM metrics;
+EXECUTE pcount;
+  c  
+-----
+ 100
+(1 row)
+
+DEALLOCATE ALL;
+DROP TABLE metrics;

--- a/test/regression/expected/type_support.out
+++ b/test/regression/expected/type_support.out
@@ -350,7 +350,7 @@ SELECT * FROM numeric_as_double;
 -----------------------
            0.234234234
                       
- 4.582345020342342e+20
+ 458234502034234000000
 (3 rows)
 
 RESET duckdb.convert_unsupported_numeric_to_double;

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -34,6 +34,7 @@ test: json_functions_duckdb
 test: materialized_view
 test: non_superuser
 test: prepare
+test: prepare_type_mismatch
 test: projection_pushdown_unsupported_type
 test: query_filter
 test: read_functions

--- a/test/regression/sql/prepare_type_mismatch.sql
+++ b/test/regression/sql/prepare_type_mismatch.sql
@@ -1,0 +1,45 @@
+-- Regression test for result-type handling in the extended query protocol.
+--
+-- PostgreSQL's parser and DuckDB can assign different types to the same result
+-- column. For example ROUND(AVG(bigint) / 1024.0, 2) is NUMERIC according to
+-- the Postgres parser but DOUBLE according to DuckDB. The Postgres parser type
+-- is what gets frozen into the cached plan's result descriptor (and sent as the
+-- RowDescription) in the extended / cached-plan path (PREPARE/EXECUTE, JDBC,
+-- ...). pg_duckdb must therefore produce values of the parser-declared type, so
+-- that the cached-plan path returns the same correct value as the simple
+-- protocol instead of reinterpreting the bytes (which previously yielded
+-- garbage such as 0.000000000000000000000000000000).
+SET duckdb.force_execution = true;
+
+CREATE TABLE metrics(id int, vol bigint);
+INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g;
+
+-- Simple protocol: baseline correct value (Postgres parser type is numeric).
+SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
+
+-- The cached plan's result type is numeric (this is what the extended protocol
+-- uses for the row description / output).
+PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pbug';
+
+-- Cached-plan path: must match the simple-protocol value, not corrupt it.
+EXECUTE pbug;
+EXECUTE pbug;
+
+-- Parameterized + cached plan: parameter in the filter, numeric result column.
+PREPARE pbug2(int) AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics WHERE id > $1;
+EXECUTE pbug2(0);
+EXECUTE pbug2(0);
+
+-- Control: when Postgres and DuckDB agree on the type (double), the value is
+-- already correct and stays unchanged.
+PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pok';
+EXECUTE pok;
+
+-- Control: integer aggregate, both agree on the type.
+PREPARE pcount AS SELECT count(*) AS c FROM metrics;
+EXECUTE pcount;
+
+DEALLOCATE ALL;
+DROP TABLE metrics;

--- a/test/regression/sql/prepare_type_mismatch.sql
+++ b/test/regression/sql/prepare_type_mismatch.sql
@@ -31,6 +31,19 @@ PREPARE pbug2(int) AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics WHERE
 EXECUTE pbug2(0);
 EXECUTE pbug2(0);
 
+-- Bare aggregate: Postgres types AVG(bigint) as numeric, DuckDB as double. This
+-- exercises the double -> numeric coercion directly (no surrounding ROUND).
+PREPARE pavg AS SELECT AVG(vol) AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pavg';
+EXECUTE pavg;
+
+-- Postgres numeric where DuckDB also produces a numeric (DECIMAL): the oids
+-- already match so we keep the DuckDB type; the value must still pass through
+-- the cached-plan path unchanged.
+PREPARE pdec AS SELECT MIN(vol) + 0.5 AS v FROM metrics;
+SELECT result_types FROM pg_prepared_statements WHERE name = 'pdec';
+EXECUTE pdec;
+
 -- Control: when Postgres and DuckDB agree on the type (double), the value is
 -- already correct and stays unchanged.
 PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;

--- a/test/regression/sql/prepare_type_mismatch.sql
+++ b/test/regression/sql/prepare_type_mismatch.sql
@@ -9,6 +9,11 @@
 -- that the cached-plan path returns the same correct value as the simple
 -- protocol instead of reinterpreting the bytes (which previously yielded
 -- garbage such as 0.000000000000000000000000000000).
+--
+-- NOTE: we deliberately do not query pg_prepared_statements.result_types here;
+-- that column only exists on PostgreSQL 16+. The EXECUTE results below are what
+-- demonstrate the fix, and they are identical across the simple and extended
+-- protocols and across PostgreSQL versions.
 SET duckdb.force_execution = true;
 
 CREATE TABLE metrics(id int, vol bigint);
@@ -17,12 +22,8 @@ INSERT INTO metrics SELECT g, (g * 1000)::bigint FROM generate_series(1, 100) g;
 -- Simple protocol: baseline correct value (Postgres parser type is numeric).
 SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
 
--- The cached plan's result type is numeric (this is what the extended protocol
--- uses for the row description / output).
-PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pbug';
-
 -- Cached-plan path: must match the simple-protocol value, not corrupt it.
+PREPARE pbug AS SELECT ROUND(AVG(vol) / 1024.0, 2) AS v FROM metrics;
 EXECUTE pbug;
 EXECUTE pbug;
 
@@ -34,20 +35,17 @@ EXECUTE pbug2(0);
 -- Bare aggregate: Postgres types AVG(bigint) as numeric, DuckDB as double. This
 -- exercises the double -> numeric coercion directly (no surrounding ROUND).
 PREPARE pavg AS SELECT AVG(vol) AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pavg';
 EXECUTE pavg;
 
 -- Postgres numeric where DuckDB also produces a numeric (DECIMAL): the oids
 -- already match so we keep the DuckDB type; the value must still pass through
 -- the cached-plan path unchanged.
 PREPARE pdec AS SELECT MIN(vol) + 0.5 AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pdec';
 EXECUTE pdec;
 
 -- Control: when Postgres and DuckDB agree on the type (double), the value is
 -- already correct and stays unchanged.
 PREPARE pok AS SELECT (AVG(vol) / 1024.0)::float8 AS v FROM metrics;
-SELECT result_types FROM pg_prepared_statements WHERE name = 'pok';
 EXECUTE pok;
 
 -- Control: integer aggregate, both agree on the type.


### PR DESCRIPTION
# Problem

When PostgreSQL's parser types a result column as numeric but DuckDB computes it as double — e.g. `ROUND(AVG(bigint_col) / 1024.0, 2)` (PG: `numeric`; DuckDB: `double`) — pg_duckdb returned corrupted results in the extended query protocol (PREPARE/EXECUTE, server-side prepared statements, JDBC).

```
SET duckdb.force_execution = true;
SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics;            -- 49.32          (simple: OK)

PREPARE p AS SELECT ROUND(AVG(vol) / 1024.0, 2) FROM metrics;
EXECUTE p;   -- 0.000000000000000000000000000000               (cached plan: CORRUPT)
```

# Root cause

PostgreSQL freezes the parser's column types into the cached plan's result descriptor (PlanCacheComputeResultDesc) and uses them for the RowDescription/output in the extended protocol — this is not reachable from planner_hook. Our CustomScan declared (and emitted) the DuckDB type (double). So the portal output type was numeric while the executor produced a double Datum; the 8 double bytes were reinterpreted as a numeric varlena → silent corruption. The simple protocol works because there the RowDescription comes from the executing plan's tuple descriptor (double), matching the data.

# Behavior change

Queries where PG's parser says `numeric` but DuckDB computes `double` (e.g. `AVG(int), ROUND(.../n, k)`) now return `numeric` in both protocols. The value equals DuckDB's double cast to numeric.